### PR TITLE
chore: add dns record migrator

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/hashicorp/go-hclog v1.6.3
 	github.com/hashicorp/hcl/v2 v2.19.1
 	github.com/spf13/cobra v1.8.0
+	github.com/stretchr/testify v1.7.2
 	github.com/tidwall/gjson v1.17.1
 	github.com/tidwall/sjson v1.2.5
 	github.com/zclconf/go-cty v1.14.1
@@ -14,15 +15,18 @@ require (
 require (
 	github.com/agext/levenshtein v1.2.3 // indirect
 	github.com/apparentlymart/go-textseg/v15 v15.0.0 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/fatih/color v1.17.0 // indirect
 	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mitchellh/go-wordwrap v1.0.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/tidwall/pretty v1.2.1 // indirect
 	golang.org/x/sys v0.20.0 // indirect
 	golang.org/x/text v0.14.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -71,6 +71,7 @@ golang.org/x/sys v0.20.0 h1:Od9JTbYCk261bKm4M/mw7AklTlFYIa0bIp9BgSm1S8Y=
 golang.org/x/sys v0.20.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/text v0.14.0 h1:ScX5w1eTa3QqT8oi6+ziP7dTV1S2+ALU0bI+0zXKWiQ=
 golang.org/x/text v0.14.0/go.mod h1:18ZOQIKpY8NJVqYksKHtTdi31H5itFRjB5/qKTNYzSU=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/handlers/pre_process.go
+++ b/internal/handlers/pre_process.go
@@ -17,13 +17,13 @@ func NewPreprocessHandler(provider transform.Provider) transform.TransformationH
 
 func (h *PreprocessHandler) Handle(ctx *transform.Context) (*transform.Context, error) {
 	contentStr := string(ctx.Content)
-	contentStr = h.applyAllPreprocessors(contentStr)
+	contentStr = h.applyAllPreprocessors(ctx, contentStr)
 	ctx.Content = []byte(contentStr)
 	return h.Next(ctx)
 }
 
-func (h *PreprocessHandler) applyAllPreprocessors(content string) string {
-	for _, migrator := range h.provider.GetAllMigrators() {
+func (h *PreprocessHandler) applyAllPreprocessors(ctx *transform.Context, content string) string {
+	for _, migrator := range h.provider.GetAllMigrators(ctx.SourceVersion, ctx.TargetVersion) {
 		content = migrator.Preprocess(content)
 	}
 	return content

--- a/internal/handlers/resource_transform.go
+++ b/internal/handlers/resource_transform.go
@@ -45,9 +45,9 @@ func (h *ResourceTransformHandler) Handle(ctx *transform.Context) (*transform.Co
 		}
 
 		resourceType := labels[0]
-		migrator := h.provider.GetMigrator(resourceType)
+		migrator := h.provider.GetMigrator(resourceType, ctx.SourceVersion, ctx.TargetVersion)
 		if migrator == nil {
-			h.log.Debug("No migrator found for resource type", "type", resourceType)
+			h.log.Debug("No migrator found for resource type", "type", resourceType, "source", ctx.SourceVersion, "target", ctx.TargetVersion)
 			continue
 		}
 

--- a/internal/handlers/resource_transform_test.go
+++ b/internal/handlers/resource_transform_test.go
@@ -74,11 +74,11 @@ func NewMockMigratorProvider(transformers []*MockResourceTransformer) *MockMigra
 	return m
 }
 
-func (m *MockMigratorProvider) GetMigrator(resourceType string) transform.ResourceTransformer {
+func (m *MockMigratorProvider) GetMigrator(resourceType string, sourceVersion string, targetVersion string) transform.ResourceTransformer {
 	return m.transformers[resourceType]
 }
 
-func (m *MockMigratorProvider) GetAllMigrators() []transform.ResourceTransformer {
+func (m *MockMigratorProvider) GetAllMigrators(sourceVersion string, targetVersion string) []transform.ResourceTransformer {
 	return m.orderedTransformers
 }
 

--- a/internal/handlers/state_transform.go
+++ b/internal/handlers/state_transform.go
@@ -50,14 +50,14 @@ func (h *StateTransformHandler) Handle(ctx *transform.Context) (*transform.Conte
 			return true
 		}
 
-		migrator := h.provider.GetMigrator(resourceType)
+		migrator := h.provider.GetMigrator(resourceType, ctx.SourceVersion, ctx.TargetVersion)
 		if migrator == nil {
 			ctx.Diagnostics = append(ctx.Diagnostics, &hcl.Diagnostic{
 				Severity: hcl.DiagWarning,
 				Summary:  fmt.Sprintf("Failed to transform resource: %s", resourceType),
-				Detail:   fmt.Sprintf("\"No migrator found for state resource: %s", resourceType),
+				Detail:   fmt.Sprintf("No migrator found for state resource: %s (v%s -> v%s)", resourceType, ctx.SourceVersion, ctx.TargetVersion),
 			})
-			h.log.Debug("No migrator found for state resource", "type", resourceType)
+			h.log.Debug("No migrator found for state resource", "type", resourceType, "source", ctx.SourceVersion, "target", ctx.TargetVersion)
 			return true
 		}
 

--- a/internal/hcl/helpers.go
+++ b/internal/hcl/helpers.go
@@ -194,11 +194,15 @@ func SetAttributeValue(body *hclwrite.Body, name string, val interface{}) {
 	case bool:
 		body.SetAttributeValue(name, cty.BoolVal(v))
 	case []string:
-		values := make([]cty.Value, len(v))
-		for i, s := range v {
-			values[i] = cty.StringVal(s)
+		if len(v) == 0 {
+			body.SetAttributeValue(name, cty.ListValEmpty(cty.String))
+		} else {
+			values := make([]cty.Value, len(v))
+			for i, s := range v {
+				values[i] = cty.StringVal(s)
+			}
+			body.SetAttributeValue(name, cty.ListVal(values))
 		}
-		body.SetAttributeValue(name, cty.ListVal(values))
 	case map[string]string:
 		values := make(map[string]cty.Value)
 		for k, v := range v {

--- a/internal/hcl/helpers_test.go
+++ b/internal/hcl/helpers_test.go
@@ -1,0 +1,774 @@
+package hcl
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclwrite"
+	"github.com/zclconf/go-cty/cty"
+)
+
+func TestAttributesOrdered(t *testing.T) {
+	tests := []struct {
+		name     string
+		hcl      string
+		expected []string
+	}{
+		{
+			name: "Attributes in specific order",
+			hcl: `resource "test" "example" {
+  name = "test"
+  zone_id = "abc123"
+  type = "A"
+  value = "192.0.2.1"
+}`,
+			expected: []string{"name", "zone_id", "type", "value"},
+		},
+		{
+			name: "Mixed attributes and blocks",
+			hcl: `resource "test" "example" {
+  first = "value1"
+  data {
+    nested = "value"
+  }
+  second = "value2"
+  third = "value3"
+}`,
+			expected: []string{"first", "second", "third"},
+		},
+		{
+			name:     "Empty body",
+			hcl:      `resource "test" "example" {}`,
+			expected: []string{},
+		},
+		{
+			name: "Attributes with complex values",
+			hcl: `resource "test" "example" {
+  list = ["a", "b", "c"]
+  number = 42
+  boolean = true
+  object = {
+    key = "value"
+  }
+}`,
+			expected: []string{"list", "number", "boolean", "object"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			file, diags := hclwrite.ParseConfig([]byte(tt.hcl), "", hcl.InitialPos)
+			if diags.HasErrors() {
+				t.Fatalf("Failed to parse HCL: %v", diags)
+			}
+
+			block := file.Body().Blocks()[0]
+			attrs := AttributesOrdered(block.Body())
+
+			if len(attrs) != len(tt.expected) {
+				t.Errorf("Expected %d attributes, got %d", len(tt.expected), len(attrs))
+			}
+
+			for i, attrInfo := range attrs {
+				if i >= len(tt.expected) {
+					break
+				}
+				if attrInfo.Name != tt.expected[i] {
+					t.Errorf("Expected attribute %d to be %s, got %s", i, tt.expected[i], attrInfo.Name)
+				}
+				if attrInfo.Attribute == nil {
+					t.Errorf("Attribute %s has nil Attribute field", attrInfo.Name)
+				}
+			}
+		})
+	}
+}
+
+func TestBuildTemplateStringTokens(t *testing.T) {
+	tests := []struct {
+		name     string
+		expr     string
+		suffix   string
+		expected string
+	}{
+		{
+			name:     "Simple variable interpolation",
+			expr:     "var.zone_id",
+			suffix:   "/record1",
+			expected: `"${var.zone_id}/record1"`,
+		},
+		{
+			name:     "No suffix",
+			expr:     "local.id",
+			suffix:   "",
+			expected: `"${local.id}"`,
+		},
+		{
+			name:     "Resource reference with suffix",
+			expr:     "cloudflare_zone.main.id",
+			suffix:   "/dns_record",
+			expected: `"${cloudflare_zone.main.id}/dns_record"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Parse the expression to get tokens
+			exprTokens := hclwrite.TokensForIdentifier(tt.expr)
+			
+			tokens := BuildTemplateStringTokens(exprTokens, tt.suffix)
+			result := string(tokens.Bytes())
+			
+			// Normalize whitespace for comparison
+			result = strings.TrimSpace(result)
+			expected := strings.TrimSpace(tt.expected)
+			
+			if result != expected {
+				t.Errorf("Expected %s, got %s", expected, result)
+			}
+		})
+	}
+}
+
+func TestBuildResourceReference(t *testing.T) {
+	tests := []struct {
+		name         string
+		resourceType string
+		resourceName string
+		expected     string
+	}{
+		{
+			name:         "Standard resource reference",
+			resourceType: "cloudflare_dns_record",
+			resourceName: "example",
+			expected:     "cloudflare_dns_record.example",
+		},
+		{
+			name:         "Resource with underscores",
+			resourceType: "cloudflare_record",
+			resourceName: "test_record",
+			expected:     "cloudflare_record.test_record",
+		},
+		{
+			name:         "Short names",
+			resourceType: "aws_s3_bucket",
+			resourceName: "b1",
+			expected:     "aws_s3_bucket.b1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tokens := BuildResourceReference(tt.resourceType, tt.resourceName)
+			result := string(tokens.Bytes())
+			
+			if result != tt.expected {
+				t.Errorf("Expected %s, got %s", tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestCreateMovedBlock(t *testing.T) {
+	tests := []struct {
+		name     string
+		from     string
+		to       string
+		expected string
+	}{
+		{
+			name: "Simple resource move",
+			from: "cloudflare_record.example",
+			to:   "cloudflare_dns_record.example",
+			expected: `moved {
+  from = cloudflare_record.example
+  to   = cloudflare_dns_record.example
+}`,
+		},
+		{
+			name: "Module resource move",
+			from: "module.old.cloudflare_record.test",
+			to:   "module.new.cloudflare_dns_record.test",
+			expected: `moved {
+  from = module.old.cloudflare_record.test
+  to   = module.new.cloudflare_dns_record.test
+}`,
+		},
+		{
+			name: "Resource with index",
+			from: "cloudflare_record.example[0]",
+			to:   "cloudflare_dns_record.example[0]",
+			expected: `moved {
+  from = cloudflare_record.example[0]
+  to   = cloudflare_dns_record.example[0]
+}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			block := CreateMovedBlock(tt.from, tt.to)
+			
+			file := hclwrite.NewEmptyFile()
+			file.Body().AppendBlock(block)
+			
+			result := string(file.Bytes())
+			result = strings.TrimSpace(result)
+			expected := strings.TrimSpace(tt.expected)
+			
+			// Compare normalized (remove extra spaces)
+			result = normalizeHCL(result)
+			expected = normalizeHCL(expected)
+			
+			if result != expected {
+				t.Errorf("Expected:\n%s\nGot:\n%s", expected, result)
+			}
+		})
+	}
+}
+
+func TestCreateImportBlock(t *testing.T) {
+	tests := []struct {
+		name         string
+		resourceType string
+		resourceName string
+		importID     string
+		expected     string
+	}{
+		{
+			name:         "Simple import block",
+			resourceType: "cloudflare_dns_record",
+			resourceName: "example",
+			importID:     "zone123/record456",
+			expected: `import {
+  to = cloudflare_dns_record.example
+  id = "zone123/record456"
+}`,
+		},
+		{
+			name:         "Import with special characters",
+			resourceType: "aws_s3_bucket",
+			resourceName: "my_bucket",
+			importID:     "arn:aws:s3:::my-bucket-name",
+			expected: `import {
+  to = aws_s3_bucket.my_bucket
+  id = "arn:aws:s3:::my-bucket-name"
+}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			block := CreateImportBlock(tt.resourceType, tt.resourceName, tt.importID)
+			
+			file := hclwrite.NewEmptyFile()
+			file.Body().AppendBlock(block)
+			
+			result := string(file.Bytes())
+			result = normalizeHCL(result)
+			expected := normalizeHCL(tt.expected)
+			
+			if result != expected {
+				t.Errorf("Expected:\n%s\nGot:\n%s", expected, result)
+			}
+		})
+	}
+}
+
+func TestCreateImportBlockWithTokens(t *testing.T) {
+	tests := []struct {
+		name         string
+		resourceType string
+		resourceName string
+		idExpr       string
+		expected     string
+	}{
+		{
+			name:         "Import with variable ID",
+			resourceType: "cloudflare_dns_record",
+			resourceName: "example",
+			idExpr:       "var.import_id",
+			expected: `import {
+  to = cloudflare_dns_record.example
+  id = var.import_id
+}`,
+		},
+		{
+			name:         "Import with concatenated ID",
+			resourceType: "aws_instance",
+			resourceName: "web",
+			idExpr:       "local.instance_id",
+			expected: `import {
+  to = aws_instance.web
+  id = local.instance_id
+}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			idTokens := hclwrite.TokensForIdentifier(tt.idExpr)
+			block := CreateImportBlockWithTokens(tt.resourceType, tt.resourceName, idTokens)
+			
+			file := hclwrite.NewEmptyFile()
+			file.Body().AppendBlock(block)
+			
+			result := string(file.Bytes())
+			result = normalizeHCL(result)
+			expected := normalizeHCL(tt.expected)
+			
+			if result != expected {
+				t.Errorf("Expected:\n%s\nGot:\n%s", expected, result)
+			}
+		})
+	}
+}
+
+func TestBuildObjectFromBlock(t *testing.T) {
+	tests := []struct {
+		name     string
+		hcl      string
+		expected string
+	}{
+		{
+			name: "Simple block to object",
+			hcl: `data {
+  priority = 10
+  target = "mail.example.com"
+}`,
+			expected: `{
+  priority = 10
+  target   = "mail.example.com"
+}`,
+		},
+		{
+			name: "Block with various types",
+			hcl: `settings {
+  enabled = true
+  count = 5
+  name = "test"
+  tags = ["a", "b"]
+}`,
+			expected: `{
+  enabled = true
+  count   = 5
+  name    = "test"
+  tags    = ["a", "b"]
+}`,
+		},
+		{
+			name: "Empty block",
+			hcl:  `empty {}`,
+			expected: `{}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			file, diags := hclwrite.ParseConfig([]byte(tt.hcl), "", hcl.InitialPos)
+			if diags.HasErrors() {
+				t.Fatalf("Failed to parse HCL: %v", diags)
+			}
+
+			block := file.Body().Blocks()[0]
+			tokens := BuildObjectFromBlock(block)
+			result := string(tokens.Bytes())
+			
+			// Normalize for comparison
+			result = normalizeHCL(result)
+			expected := normalizeHCL(tt.expected)
+			
+			if result != expected {
+				t.Errorf("Expected:\n%s\nGot:\n%s", expected, result)
+			}
+		})
+	}
+}
+
+func TestSetAttributeValue(t *testing.T) {
+	tests := []struct {
+		name     string
+		attrName string
+		value    interface{}
+		expected string
+	}{
+		{
+			name:     "String value",
+			attrName: "name",
+			value:    "test-value",
+			expected: `name = "test-value"`,
+		},
+		{
+			name:     "Integer value",
+			attrName: "count",
+			value:    42,
+			expected: `count = 42`,
+		},
+		{
+			name:     "Int64 value",
+			attrName: "bignum",
+			value:    int64(9999999999),
+			expected: `bignum = 9999999999`,
+		},
+		{
+			name:     "Float value",
+			attrName: "ratio",
+			value:    3.14,
+			expected: `ratio = 3.14`,
+		},
+		{
+			name:     "Boolean true",
+			attrName: "enabled",
+			value:    true,
+			expected: `enabled = true`,
+		},
+		{
+			name:     "Boolean false",
+			attrName: "disabled",
+			value:    false,
+			expected: `disabled = false`,
+		},
+		{
+			name:     "String slice",
+			attrName: "tags",
+			value:    []string{"web", "production", "critical"},
+			expected: `tags = ["web", "production", "critical"]`,
+		},
+		{
+			name:     "Empty string slice",
+			attrName: "empty_list",
+			value:    []string{},
+			expected: `empty_list = []`,
+		},
+		{
+			name:     "String map",
+			attrName: "labels",
+			value:    map[string]string{"env": "prod", "team": "backend"},
+			expected: `labels = {
+  env  = "prod"
+  team = "backend"
+}`,
+		},
+		{
+			name:     "Empty map",
+			attrName: "empty_map",
+			value:    map[string]string{},
+			expected: `empty_map = {}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body := hclwrite.NewEmptyFile().Body()
+			SetAttributeValue(body, tt.attrName, tt.value)
+			
+			result := string(hclwrite.Format(body.BuildTokens(nil).Bytes()))
+			result = strings.TrimSpace(result)
+			expected := strings.TrimSpace(tt.expected)
+			
+			// For maps, the order might vary, so normalize
+			if strings.Contains(expected, "{") && strings.Contains(expected, "}") {
+				result = normalizeHCL(result)
+				expected = normalizeHCL(expected)
+			}
+			
+			if result != expected {
+				t.Errorf("Expected:\n%s\nGot:\n%s", expected, result)
+			}
+		})
+	}
+}
+
+func TestCopyAttribute(t *testing.T) {
+	tests := []struct {
+		name        string
+		sourceHCL   string
+		attrToCopy  string
+		expectCopy  bool
+		expected    string
+	}{
+		{
+			name: "Copy simple attribute",
+			sourceHCL: `resource "test" "source" {
+  name = "test-name"
+  value = 123
+}`,
+			attrToCopy:  "name",
+			expectCopy:  true,
+			expected:    `name = "test-name"`,
+		},
+		{
+			name: "Copy complex attribute",
+			sourceHCL: `resource "test" "source" {
+  tags = ["a", "b", "c"]
+}`,
+			attrToCopy:  "tags",
+			expectCopy:  true,
+			expected:    `tags = ["a", "b", "c"]`,
+		},
+		{
+			name: "Copy non-existent attribute",
+			sourceHCL: `resource "test" "source" {
+  name = "test"
+}`,
+			attrToCopy:  "missing",
+			expectCopy:  false,
+			expected:    ``,
+		},
+		{
+			name: "Copy expression attribute",
+			sourceHCL: `resource "test" "source" {
+  zone_id = var.zone_id
+}`,
+			attrToCopy:  "zone_id",
+			expectCopy:  true,
+			expected:    `zone_id = var.zone_id`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			file, diags := hclwrite.ParseConfig([]byte(tt.sourceHCL), "", hcl.InitialPos)
+			if diags.HasErrors() {
+				t.Fatalf("Failed to parse HCL: %v", diags)
+			}
+
+			sourceBlock := file.Body().Blocks()[0]
+			targetBody := hclwrite.NewEmptyFile().Body()
+			
+			CopyAttribute(sourceBlock.Body(), targetBody, tt.attrToCopy)
+			
+			result := string(hclwrite.Format(targetBody.BuildTokens(nil).Bytes()))
+			result = strings.TrimSpace(result)
+			
+			if tt.expectCopy {
+				if result != tt.expected {
+					t.Errorf("Expected:\n%s\nGot:\n%s", tt.expected, result)
+				}
+			} else {
+				if result != "" {
+					t.Errorf("Expected no copy, but got: %s", result)
+				}
+			}
+		})
+	}
+}
+
+func TestRemoveEmptyBlocks(t *testing.T) {
+	tests := []struct {
+		name      string
+		hcl       string
+		blockType string
+		expected  string
+	}{
+		{
+			name: "Remove empty data blocks",
+			hcl: `resource "test" "example" {
+  name = "test"
+  data {}
+  value = "123"
+  data {}
+}`,
+			blockType: "data",
+			expected: `resource "test" "example" {
+  name  = "test"
+  value = "123"
+}`,
+		},
+		{
+			name: "Keep non-empty blocks",
+			hcl: `resource "test" "example" {
+  data {
+    key = "value"
+  }
+  data {}
+  data {
+    another = "field"
+  }
+}`,
+			blockType: "data",
+			expected: `resource "test" "example" {
+  data {
+    key = "value"
+  }
+  data {
+    another = "field"
+  }
+}`,
+		},
+		{
+			name: "No blocks to remove",
+			hcl: `resource "test" "example" {
+  name = "test"
+  data {
+    field = "value"
+  }
+}`,
+			blockType: "settings",
+			expected: `resource "test" "example" {
+  name = "test"
+  data {
+    field = "value"
+  }
+}`,
+		},
+		{
+			name: "Remove all empty blocks of type",
+			hcl: `resource "test" "example" {
+  lifecycle {}
+  lifecycle {}
+  lifecycle {}
+}`,
+			blockType: "lifecycle",
+			expected: `resource "test" "example" {
+}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			file, diags := hclwrite.ParseConfig([]byte(tt.hcl), "", hcl.InitialPos)
+			if diags.HasErrors() {
+				t.Fatalf("Failed to parse HCL: %v", diags)
+			}
+
+			block := file.Body().Blocks()[0]
+			RemoveEmptyBlocks(block.Body(), tt.blockType)
+			
+			newFile := hclwrite.NewEmptyFile()
+			newFile.Body().AppendBlock(block)
+			
+			result := string(hclwrite.Format(newFile.Bytes()))
+			result = strings.TrimSpace(result)
+			expected := strings.TrimSpace(tt.expected)
+			
+			if result != expected {
+				t.Errorf("Expected:\n%s\nGot:\n%s", expected, result)
+			}
+		})
+	}
+}
+
+func TestTokensForSimpleValue(t *testing.T) {
+	tests := []struct {
+		name     string
+		value    interface{}
+		expected string
+		isNil    bool
+	}{
+		{
+			name:     "String value",
+			value:    "hello world",
+			expected: `"hello world"`,
+		},
+		{
+			name:     "Integer value",
+			value:    42,
+			expected: `42`,
+		},
+		{
+			name:     "Int64 value",
+			value:    int64(9876543210),
+			expected: `9876543210`,
+		},
+		{
+			name:     "Float value",
+			value:    3.14159,
+			expected: `3.14159`,
+		},
+		{
+			name:     "Boolean true",
+			value:    true,
+			expected: `true`,
+		},
+		{
+			name:     "Boolean false",
+			value:    false,
+			expected: `false`,
+		},
+		{
+			name:  "Unsupported type returns nil",
+			value: []string{"unsupported"},
+			isNil: true,
+		},
+		{
+			name:  "Nil value returns nil",
+			value: nil,
+			isNil: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tokens := TokensForSimpleValue(tt.value)
+			
+			if tt.isNil {
+				if tokens != nil {
+					t.Errorf("Expected nil, got tokens: %s", string(tokens.Bytes()))
+				}
+			} else {
+				if tokens == nil {
+					t.Fatal("Expected tokens, got nil")
+				}
+				
+				result := string(tokens.Bytes())
+				if result != tt.expected {
+					t.Errorf("Expected %s, got %s", tt.expected, result)
+				}
+			}
+		})
+	}
+}
+
+func TestSetAttributeValueComplexType(t *testing.T) {
+	// Test that complex types are not handled
+	body := hclwrite.NewEmptyFile().Body()
+	
+	// Try to set a complex type (struct)
+	type complexType struct {
+		Field string
+	}
+	
+	SetAttributeValue(body, "complex", complexType{Field: "value"})
+	
+	// Should not have added any attribute
+	if len(body.Attributes()) != 0 {
+		t.Error("Expected no attributes for unsupported type, but got some")
+	}
+}
+
+func TestAttributeValueWithCtyTypes(t *testing.T) {
+	// Test using cty.Value directly
+	body := hclwrite.NewEmptyFile().Body()
+	
+	// Set a cty.Value directly (should use the regular SetAttributeValue method)
+	body.SetAttributeValue("direct_cty", cty.StringVal("test"))
+	
+	attr := body.GetAttribute("direct_cty")
+	if attr == nil {
+		t.Fatal("Expected attribute to be set")
+	}
+	
+	tokens := attr.Expr().BuildTokens(nil)
+	result := string(tokens.Bytes())
+	expected := `"test"`
+	
+	if result != expected {
+		t.Errorf("Expected %s, got %s", expected, result)
+	}
+}
+
+// Helper function to normalize HCL for comparison
+func normalizeHCL(hcl string) string {
+	// Remove extra whitespace and normalize
+	lines := strings.Split(hcl, "\n")
+	var normalized []string
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line != "" {
+			normalized = append(normalized, line)
+		}
+	}
+	return strings.Join(normalized, "\n")
+}

--- a/internal/init/init.go
+++ b/internal/init/init.go
@@ -1,0 +1,10 @@
+package init
+
+// Import all resource packages to trigger their init() functions
+import (
+	_ "github.com/cloudflare/tf-migrate/internal/resources/dns_record"
+	// Future resources will be added here:
+	// _ "github.com/cloudflare/tf-migrate/internal/resources/load_balancer"
+	// _ "github.com/cloudflare/tf-migrate/internal/resources/zone_settings"
+	// etc.
+)

--- a/internal/integration_test.go
+++ b/internal/integration_test.go
@@ -1,0 +1,81 @@
+package internal
+
+import (
+	"testing"
+	"github.com/cloudflare/tf-migrate/internal/transform"
+	"github.com/hashicorp/hcl/v2/hclwrite"
+	"github.com/tidwall/gjson"
+)
+
+// mockV5ToV6Migrator simulates a future v5->v6 migrator
+type mockV5ToV6Migrator struct{}
+
+func (m *mockV5ToV6Migrator) CanHandle(resourceType string) bool {
+	return resourceType == "cloudflare_dns_record"
+}
+
+func (m *mockV5ToV6Migrator) TransformConfig(ctx *transform.Context, block *hclwrite.Block) (*transform.TransformResult, error) {
+	// Simulate some v5->v6 transformation
+	body := block.Body()
+	// Example: rename 'ttl' to 'time_to_live' in v6
+	if attr := body.GetAttribute("ttl"); attr != nil {
+		body.SetAttributeRaw("time_to_live", attr.Expr().BuildTokens(nil))
+		body.RemoveAttribute("ttl")
+	}
+	return &transform.TransformResult{
+		Blocks:         []*hclwrite.Block{block},
+		RemoveOriginal: false,
+	}, nil
+}
+
+func (m *mockV5ToV6Migrator) TransformState(ctx *transform.Context, json gjson.Result, resourcePath string) (string, error) {
+	return "", nil
+}
+
+func (m *mockV5ToV6Migrator) GetResourceType() string {
+	return "cloudflare_dns_record"
+}
+
+func (m *mockV5ToV6Migrator) Preprocess(content string) string {
+	return content
+}
+
+func TestMultiVersionSupport(t *testing.T) {
+	// Save current migrators and restore after test
+	originalMigrators := migrators
+	defer func() { migrators = originalMigrators }()
+	
+	// Clear for test
+	migrators = make(map[string]*MigratorRegistration)
+	
+	// Register a v5->v6 migrator
+	RegisterVersioned("cloudflare_dns_record", "v5", "v6", func() transform.ResourceTransformer {
+		return &mockV5ToV6Migrator{}
+	})
+	
+	// v5->v6 should return the mock migrator
+	migrator := GetMigrator("cloudflare_dns_record", "v5", "v6")
+	if migrator == nil {
+		t.Fatal("Expected v5->v6 migrator, got nil")
+	}
+	if _, ok := migrator.(*mockV5ToV6Migrator); !ok {
+		t.Error("Expected mockV5ToV6Migrator type")
+	}
+	
+	// v4->v5 should return nil (not registered in this test)
+	migrator = GetMigrator("cloudflare_dns_record", "v4", "v5")
+	if migrator != nil {
+		t.Error("Expected nil for v4->v5 (not registered in test)")
+	}
+	
+	// GetAllMigrators should only return v5->v6 migrators
+	all := GetAllMigrators("v5", "v6")
+	if len(all) != 1 {
+		t.Errorf("Expected 1 migrator for v5->v6, got %d", len(all))
+	}
+	
+	all = GetAllMigrators("v4", "v5")
+	if len(all) != 0 {
+		t.Errorf("Expected 0 migrators for v4->v5 in test, got %d", len(all))
+	}
+}

--- a/internal/pipeline/pipeline_test.go
+++ b/internal/pipeline/pipeline_test.go
@@ -185,7 +185,7 @@ resource "cloudflare_lb" "example2" {
 			}
 			setupTestMigrators(t, transformers...)
 
-			p := pipeline.BuildConfigPipeline(log)
+			p := pipeline.BuildConfigPipeline(log, "v4", "v5")
 
 			result, err := p.Transform([]byte(tt.input), "test.tf")
 
@@ -233,7 +233,7 @@ func TestTransformerCallOrder(t *testing.T) {
 
 	setupTestMigrators(t, transformer)
 
-	p := pipeline.BuildConfigPipeline(log)
+	p := pipeline.BuildConfigPipeline(log, "v4", "v5")
 
 	input := `resource "test_resource" "example" { }`
 	_, err := p.Transform([]byte(input), "test.tf")
@@ -269,7 +269,7 @@ func TestResourceTransformationWithRemoval(t *testing.T) {
 
 	setupTestMigrators(t, transformer)
 
-	p := pipeline.BuildConfigPipeline(log)
+	p := pipeline.BuildConfigPipeline(log, "v4", "v5")
 
 	input := `resource "deprecated_resource" "to_remove" {
   name = "remove_me"
@@ -315,7 +315,7 @@ func TestResourceTransformationWithSplitting(t *testing.T) {
 
 	setupTestMigrators(t, transformer)
 
-	p := pipeline.BuildConfigPipeline(log)
+	p := pipeline.BuildConfigPipeline(log, "v4", "v5")
 
 	input := `resource "combined_resource" "original" {
   name = "combined"
@@ -341,7 +341,7 @@ func TestResourceTransformationWithSplitting(t *testing.T) {
 // Test error propagation through pipeline
 func TestPipelineErrorPropagation(t *testing.T) {
 	// Test with nil content - should handle gracefully as empty content
-	p := pipeline.BuildConfigPipeline(log)
+	p := pipeline.BuildConfigPipeline(log, "v4", "v5")
 
 	result, err := p.Transform(nil, "test.tf")
 	if err != nil {
@@ -362,7 +362,7 @@ func TestPipelineErrorPropagation(t *testing.T) {
 
 func TestStandardPipelines(t *testing.T) {
 	t.Run("BuildConfigPipeline uses correct handlers", func(t *testing.T) {
-		p := pipeline.BuildConfigPipeline(log)
+		p := pipeline.BuildConfigPipeline(log, "v4", "v5")
 		if p == nil {
 			t.Fatal("BuildConfigPipeline returned nil")
 		}
@@ -375,7 +375,7 @@ func TestStandardPipelines(t *testing.T) {
 	})
 
 	t.Run("BuildStatePipeline uses correct handlers", func(t *testing.T) {
-		p := pipeline.BuildStatePipeline(log)
+		p := pipeline.BuildStatePipeline(log, "v4", "v5")
 		if p == nil {
 			t.Fatal("BuildStatePipeline returned nil")
 		}

--- a/internal/registry.go
+++ b/internal/registry.go
@@ -1,34 +1,58 @@
 package internal
 
 import (
+	"fmt"
 	"github.com/cloudflare/tf-migrate/internal/transform"
 )
 
-// Migrators is the explicit map of all available migrators
-// Key is the resource type, value is the factory function
-// DNS resources
-// "cloudflare_record": resources.NewDNSRecordMigrator,
-// "cloudflare_zone":   resources.NewDNSZoneMigrator,
-// Add new migrators here explicitly
-var migrators = make(map[string]func() transform.ResourceTransformer, 0)
+// MigratorFactory is a function that creates a new ResourceTransformer
+type MigratorFactory func() transform.ResourceTransformer
 
-// GetMigrator returns a new instance of the migrator for the given resource type
-func GetMigrator(resourceType string) transform.ResourceTransformer {
-	if factory, ok := migrators[resourceType]; ok {
-		return factory()
+// MigratorRegistration holds information about a registered migrator
+type MigratorRegistration struct {
+	Factory       MigratorFactory
+	SourceVersion string
+	TargetVersion string
+}
+
+// Migrators is the map of all available migrators
+// Key format: "resourceType:sourceVersion:targetVersion"
+var migrators = make(map[string]*MigratorRegistration)
+
+// GetMigrator returns a new instance of the migrator for the given resource type and versions
+func GetMigrator(resourceType string, sourceVersion string, targetVersion string) transform.ResourceTransformer {
+	key := fmt.Sprintf("%s:%s:%s", resourceType, sourceVersion, targetVersion)
+	if reg, ok := migrators[key]; ok {
+		return reg.Factory()
 	}
 	return nil
 }
 
-// GetAllMigrators returns new instances of all migrators
-func GetAllMigrators() []transform.ResourceTransformer {
-	result := make([]transform.ResourceTransformer, 0, len(migrators))
-	for _, factory := range migrators {
-		result = append(result, factory())
+// GetAllMigrators returns new instances of all migrators for the specified versions
+func GetAllMigrators(sourceVersion string, targetVersion string) []transform.ResourceTransformer {
+	result := make([]transform.ResourceTransformer, 0)
+	
+	// Collect version-specific migrators
+	for _, reg := range migrators {
+		if reg.SourceVersion == sourceVersion && reg.TargetVersion == targetVersion {
+			result = append(result, reg.Factory())
+		}
 	}
+	
 	return result
 }
 
-func Register(resourceType string, f func() transform.ResourceTransformer) {
-	migrators[resourceType] = f
+// RegisterVersioned registers a migrator for a specific version transition
+func RegisterVersioned(resourceType string, sourceVersion string, targetVersion string, factory MigratorFactory) {
+	key := fmt.Sprintf("%s:%s:%s", resourceType, sourceVersion, targetVersion)
+	migrators[key] = &MigratorRegistration{
+		Factory:       factory,
+		SourceVersion: sourceVersion,
+		TargetVersion: targetVersion,
+	}
+}
+
+// Register is a convenience function that defaults to v4->v5 migration
+func Register(resourceType string, factory MigratorFactory) {
+	RegisterVersioned(resourceType, "v4", "v5", factory)
 }

--- a/internal/registry_test.go
+++ b/internal/registry_test.go
@@ -1,0 +1,112 @@
+package internal
+
+import (
+	"testing"
+	"github.com/cloudflare/tf-migrate/internal/transform"
+	"github.com/hashicorp/hcl/v2/hclwrite"
+	"github.com/tidwall/gjson"
+)
+
+type mockMigrator struct {
+	version string
+}
+
+func (m *mockMigrator) CanHandle(resourceType string) bool {
+	return true
+}
+
+func (m *mockMigrator) TransformConfig(ctx *transform.Context, block *hclwrite.Block) (*transform.TransformResult, error) {
+	return nil, nil
+}
+
+func (m *mockMigrator) TransformState(ctx *transform.Context, json gjson.Result, resourcePath string) (string, error) {
+	return "", nil
+}
+
+func (m *mockMigrator) GetResourceType() string {
+	return "test_resource"
+}
+
+func (m *mockMigrator) Preprocess(content string) string {
+	return content
+}
+
+func TestVersionBasedMigratorSelection(t *testing.T) {
+	// Clear any existing registrations for clean test
+	migrators = make(map[string]*MigratorRegistration)
+	
+	// Register migrators for different version pairs
+	RegisterVersioned("test_resource", "v4", "v5", func() transform.ResourceTransformer {
+		return &mockMigrator{version: "v4-v5"}
+	})
+	
+	RegisterVersioned("test_resource", "v5", "v6", func() transform.ResourceTransformer {
+		return &mockMigrator{version: "v5-v6"}
+	})
+	
+	// Test v4 to v5 migration
+	migrator := GetMigrator("test_resource", "v4", "v5")
+	if migrator == nil {
+		t.Fatal("Expected migrator for v4->v5, got nil")
+	}
+	if m, ok := migrator.(*mockMigrator); ok {
+		if m.version != "v4-v5" {
+			t.Errorf("Expected v4-v5 migrator, got %s", m.version)
+		}
+	}
+	
+	// Test v5 to v6 migration
+	migrator = GetMigrator("test_resource", "v5", "v6")
+	if migrator == nil {
+		t.Fatal("Expected migrator for v5->v6, got nil")
+	}
+	if m, ok := migrator.(*mockMigrator); ok {
+		if m.version != "v5-v6" {
+			t.Errorf("Expected v5-v6 migrator, got %s", m.version)
+		}
+	}
+	
+	// Test non-existent migration path
+	migrator = GetMigrator("test_resource", "v3", "v4")
+	if migrator != nil {
+		t.Error("Expected nil for non-existent v3->v4 migration")
+	}
+	
+	// Test GetAllMigrators with version filtering
+	all := GetAllMigrators("v4", "v5")
+	if len(all) != 1 {
+		t.Errorf("Expected 1 migrator for v4->v5, got %d", len(all))
+	}
+	
+	all = GetAllMigrators("v5", "v6")
+	if len(all) != 1 {
+		t.Errorf("Expected 1 migrator for v5->v6, got %d", len(all))
+	}
+	
+	all = GetAllMigrators("v3", "v4")
+	if len(all) != 0 {
+		t.Errorf("Expected 0 migrators for v3->v4, got %d", len(all))
+	}
+}
+
+func TestRegisterConvenienceFunction(t *testing.T) {
+	// Clear any existing registrations for clean test
+	migrators = make(map[string]*MigratorRegistration)
+	
+	// Test that Register defaults to v4->v5
+	Register("convenience_resource", func() transform.ResourceTransformer {
+		return &mockMigrator{version: "default"}
+	})
+	
+	// Should be accessible as v4->v5
+	migrator := GetMigrator("convenience_resource", "v4", "v5")
+	if migrator == nil {
+		t.Fatal("Expected migrator for v4->v5 via Register(), got nil")
+	}
+	
+	// Should not be accessible for other version pairs
+	migrator = GetMigrator("convenience_resource", "v5", "v6")
+	if migrator != nil {
+		t.Error("Expected nil for v5->v6 when registered via Register()")
+	}
+}

--- a/internal/resources/dns_record/register.go
+++ b/internal/resources/dns_record/register.go
@@ -1,0 +1,41 @@
+package dns_record
+
+import (
+	"github.com/cloudflare/tf-migrate/internal"
+	"github.com/cloudflare/tf-migrate/internal/transform"
+)
+
+// init registers the DNS record migrators
+func init() {
+	// Register v4 to v5 migrator with explicit version
+	internal.RegisterVersioned("cloudflare_dns_record", "v4", "v5", func() transform.ResourceTransformer {
+		return NewV4ToV5Migrator()
+	})
+	
+	// Also register for the legacy cloudflare_record type (v4 to v5)
+	internal.RegisterVersioned("cloudflare_record", "v4", "v5", func() transform.ResourceTransformer {
+		return NewV4ToV5Migrator()
+	})
+	
+	// Example: Future v5 to v6 migration would be registered like this:
+	// internal.RegisterVersioned("cloudflare_dns_record", "v5", "v6", func() transform.ResourceTransformer {
+	//     return NewV5ToV6Migrator()
+	// })
+}
+
+// GetMigrator returns the appropriate migrator based on source and target versions
+func GetMigrator(sourceVersion, targetVersion string) transform.ResourceTransformer {
+	// Use the registry to get the appropriate migrator
+	migrator := internal.GetMigrator("cloudflare_dns_record", sourceVersion, targetVersion)
+	if migrator != nil {
+		return migrator
+	}
+	
+	// Also check for legacy cloudflare_record type
+	migrator = internal.GetMigrator("cloudflare_record", sourceVersion, targetVersion)
+	if migrator != nil {
+		return migrator
+	}
+	
+	return nil
+}

--- a/internal/resources/dns_record/v4_to_v5.go
+++ b/internal/resources/dns_record/v4_to_v5.go
@@ -1,0 +1,373 @@
+package dns_record
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/hashicorp/hcl/v2/hclwrite"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+
+	"github.com/cloudflare/tf-migrate/internal/resources"
+	"github.com/cloudflare/tf-migrate/internal/transform"
+	tfhcl "github.com/cloudflare/tf-migrate/internal/transform/hcl"
+	"github.com/cloudflare/tf-migrate/internal/transform/state"
+)
+
+// V4ToV5Migrator handles migration of DNS record resources from v4 to v5
+type V4ToV5Migrator struct {
+	*resources.BaseResourceTransformer
+}
+
+// NewV4ToV5Migrator creates a new DNS record migrator
+func NewV4ToV5Migrator() transform.ResourceTransformer {
+	migrator := &V4ToV5Migrator{
+		BaseResourceTransformer: resources.NewBaseResourceTransformer("cloudflare_dns_record"),
+	}
+
+	// Set custom handlers
+	migrator.BaseResourceTransformer.CanHandleFunc = migrator.canHandle
+	migrator.BaseResourceTransformer.ConfigTransformer = migrator.transformConfig
+	migrator.BaseResourceTransformer.StateTransformer = migrator.transformState
+
+	return migrator
+}
+
+// canHandle determines if this migrator can handle the given resource type
+func (m *V4ToV5Migrator) canHandle(resourceType string) bool {
+	return resourceType == "cloudflare_dns_record" || resourceType == "cloudflare_record"
+}
+
+// transformConfig handles configuration file transformations
+func (m *V4ToV5Migrator) transformConfig(ctx *transform.Context, block *hclwrite.Block) (*transform.TransformResult, error) {
+	// Rename cloudflare_record to cloudflare_dns_record
+	tfhcl.RenameResourceType(block, "cloudflare_record", "cloudflare_dns_record")
+
+	body := block.Body()
+
+	// Ensure TTL is present for v5 (required field)
+	tfhcl.EnsureAttribute(body, "ttl", 1)
+
+	// Get the record type
+	typeAttr := body.GetAttribute("type")
+	recordType := ""
+	if typeAttr != nil {
+		// Extract the record type value
+		recordType = tfhcl.ExtractStringFromAttribute(typeAttr)
+	}
+
+	// Handle simple record types or records without type
+	// When type is missing, we still need to rename value to content
+	if recordType == "" || m.isSimpleRecordType(recordType) {
+		// Rename value to content for simple record types
+		tfhcl.RenameAttribute(body, "value", "content")
+	}
+
+	// Remove deprecated attributes
+	tfhcl.RemoveAttributes(body, "allow_overwrite", "hostname")
+
+	// Process data blocks
+	m.processDataBlocks(block, recordType)
+
+	// Process data attribute for CAA records
+	m.processDataAttribute(block, recordType)
+
+	return &transform.TransformResult{
+		Blocks:         []*hclwrite.Block{block},
+		RemoveOriginal: false,
+	}, nil
+}
+
+// processDataBlocks converts data blocks to attribute format
+func (m *V4ToV5Migrator) processDataBlocks(block *hclwrite.Block, recordType string) {
+	body := block.Body()
+
+	// For SRV, MX, and URI records, hoist priority from data block
+	if recordType == "SRV" || recordType == "MX" || recordType == "URI" {
+		tfhcl.HoistAttributeFromBlock(body, "data", "priority")
+	}
+
+	// Convert data blocks to attribute, with preprocessing for CAA records
+	tfhcl.ConvertBlocksToAttribute(body, "data", "data", func(dataBlock *hclwrite.Block) {
+		if recordType == "CAA" {
+			// Rename content to value in CAA data blocks
+			tfhcl.RenameAttribute(dataBlock.Body(), "content", "value")
+			// Convert flags from string to number if needed
+			m.convertCAAFlagsInBlock(dataBlock)
+		}
+		// Remove priority from data block for SRV/MX/URI since it's hoisted
+		if recordType == "SRV" || recordType == "MX" || recordType == "URI" {
+			dataBlock.Body().RemoveAttribute("priority")
+		}
+	})
+}
+
+// convertCAAFlagsInBlock handles CAA flags - but in v5, we keep the format as-is
+func (m *V4ToV5Migrator) convertCAAFlagsInBlock(dataBlock *hclwrite.Block) {
+	// In v5, flags format is preserved as-is
+	// If it's a string, it stays a string
+	// If it's a number, it stays a number
+	// No conversion needed
+}
+
+// processDataAttribute handles data as an attribute (not a block) for CAA records
+func (m *V4ToV5Migrator) processDataAttribute(block *hclwrite.Block, recordType string) {
+	dataAttr := block.Body().GetAttribute("data")
+	if dataAttr != nil && recordType == "CAA" {
+		expr := dataAttr.Expr()
+		tokens := expr.BuildTokens(nil)
+
+		newTokens := make(hclwrite.Tokens, 0, len(tokens))
+		for i := 0; i < len(tokens); i++ {
+			token := tokens[i]
+
+
+			// Check if this is "content" identifier inside data - rename to "value"
+			if token.Type == hclsyntax.TokenIdent && string(token.Bytes) == "content" {
+				if i+1 < len(tokens) && (tokens[i+1].Type == hclsyntax.TokenEqual ||
+					(string(tokens[i+1].Bytes) == " " && i+2 < len(tokens) && tokens[i+2].Type == hclsyntax.TokenEqual)) {
+					valueToken := &hclwrite.Token{
+						Type:  hclsyntax.TokenIdent,
+						Bytes: []byte("value"),
+					}
+					newTokens = append(newTokens, valueToken)
+				} else {
+					newTokens = append(newTokens, token)
+				}
+			} else {
+				newTokens = append(newTokens, token)
+			}
+		}
+
+		block.Body().SetAttributeRaw("data", newTokens)
+	}
+}
+
+// transformState handles state file transformations
+func (m *V4ToV5Migrator) transformState(ctx *transform.Context, stateJSON gjson.Result, resourcePath string) (string, error) {
+	// If no state JSON provided, use the context's state
+	if !stateJSON.Exists() && ctx.StateJSON != "" {
+		stateJSON = gjson.Parse(ctx.StateJSON)
+	}
+
+	result := stateJSON.String()
+
+	// Process all resources in the state
+	resources := stateJSON.Get("resources")
+	if !resources.Exists() {
+		return result, nil
+	}
+
+	resources.ForEach(func(key, resource gjson.Result) bool {
+		resourceType := resource.Get("type").String()
+		
+		// Check if this is a DNS record resource we need to migrate
+		if !m.canHandle(resourceType) {
+			return true // continue
+		}
+
+		// Rename cloudflare_record to cloudflare_dns_record
+		if resourceType == "cloudflare_record" {
+			resourcePath := "resources." + key.String() + ".type"
+			result, _ = sjson.Set(result, resourcePath, "cloudflare_dns_record")
+		}
+
+		// Process each instance
+		instances := resource.Get("instances")
+		instances.ForEach(func(instKey, instance gjson.Result) bool {
+			instPath := "resources." + key.String() + ".instances." + instKey.String()
+			result = m.transformDNSRecordStateJSON(result, instPath, instance)
+			return true
+		})
+
+		return true
+	})
+
+	return result, nil
+}
+
+// transformDNSRecordStateJSON transforms a single DNS record instance in the state
+func (m *V4ToV5Migrator) transformDNSRecordStateJSON(result string, path string, instance gjson.Result) string {
+	// Check if instance exists and has required fields
+	if !instance.Exists() || !instance.Get("attributes").Exists() {
+		return result
+	}
+
+	attrs := instance.Get("attributes")
+	if !attrs.Get("name").Exists() || !attrs.Get("type").Exists() || !attrs.Get("zone_id").Exists() {
+		return result
+	}
+
+	attrPath := path + ".attributes"
+
+	// Clean up meta field - remove if empty or invalid
+	result = state.CleanupEmptyField(result, attrPath+".meta", instance.Get("attributes.meta"))
+
+	// Clean up settings field - remove if all values are null
+	result = state.RemoveObjectIfAllNull(result, attrPath+".settings",
+		instance.Get("attributes.settings"),
+		[]string{"flatten_cname", "ipv4_only", "ipv6_only"})
+
+	// Ensure timestamp fields exist
+	result = state.EnsureTimestamps(result, attrPath, attrs, "2024-01-01T00:00:00Z")
+
+	// Handle field renames: value -> content
+	result = state.RenameField(result, attrPath, attrs, "value", "content")
+
+	// Ensure TTL is present
+	result = state.EnsureField(result, attrPath, attrs, "ttl", 1.0)
+
+	// Remove deprecated fields
+	result = state.RemoveFields(result, attrPath, attrs,
+		"hostname", "allow_overwrite", "timeouts")
+
+	// Handle data field transformation
+	recordType := instance.Get("attributes.type").String()
+	result = m.transformDataField(result, attrPath, instance, recordType)
+
+	return result
+}
+
+// transformDataField handles the transformation of the data field in state
+func (m *V4ToV5Migrator) transformDataField(result string, path string, instance gjson.Result, recordType string) string {
+	// Check if data field exists and is an array
+	data := instance.Get("attributes.data")
+	isDataArray := data.IsArray()
+	
+	// Simple record types that don't use data field
+	// But MX records with data arrays should be processed as complex types
+	if m.isSimpleRecordType(recordType) && (!isDataArray || recordType != "MX") {
+		if data.Exists() {
+			result, _ = sjson.Delete(result, path+".data")
+		}
+		return result
+	}
+
+	// Setup transformation options for complex record types
+	options := state.ArrayToObjectOptions{
+		SkipFields: []string{"name", "proto"},
+		FieldTransforms: map[string]func(gjson.Result) interface{}{
+			"flags": m.transformFlagsValue,
+		},
+		RenameFields: map[string]string{},
+		DefaultFields: map[string]interface{}{},
+	}
+
+	// CAA-specific transformations
+	if recordType == "CAA" {
+		options.RenameFields["content"] = "value"
+		options.DefaultFields["flags"] = nil
+	}
+	
+	// For SRV, MX and URI, skip priority field in data as it will be hoisted
+	if recordType == "SRV" || recordType == "MX" || recordType == "URI" {
+		options.SkipFields = append(options.SkipFields, "priority")
+	}
+
+	// Transform the data field
+	result = state.TransformDataFieldArrayToObject(result, path, instance.Get("attributes"), recordType, options)
+
+	// Generate content field for CAA records
+	if recordType == "CAA" {
+		dataArray := instance.Get("attributes.data")
+		if dataArray.IsArray() {
+			array := dataArray.Array()
+			if len(array) > 0 {
+				flags := array[0].Get("flags")
+				tag := array[0].Get("tag")
+				value := array[0].Get("content")
+				
+				// Format the content field
+				flagsStr := "0"
+				if flags.Exists() {
+					switch flags.Type {
+					case gjson.Number:
+						flagsStr = flags.Raw
+					case gjson.String:
+						if flags.String() != "" {
+							flagsStr = flags.String()
+						}
+					}
+				}
+				
+				if tag.Exists() && value.Exists() {
+					content := fmt.Sprintf("%s %s %s", flagsStr, tag.String(), value.String())
+					result, _ = sjson.Set(result, path+".content", content)
+				}
+			}
+		}
+	}
+
+	// For SRV, MX and URI records, ensure priority is at root level and generate content
+	if recordType == "SRV" || recordType == "MX" || recordType == "URI" {
+		dataArray := instance.Get("attributes.data")
+		if dataArray.IsArray() {
+			array := dataArray.Array()
+			if len(array) > 0 {
+				priority := array[0].Get("priority")
+				if priority.Exists() {
+					result, _ = sjson.Set(result, path+".priority", priority.Value())
+				}
+				
+				// Generate content field for MX records
+				if recordType == "MX" {
+					target := array[0].Get("target")
+					if priority.Exists() && target.Exists() {
+						content := fmt.Sprintf("%v %s", priority.Value(), target.String())
+						result, _ = sjson.Set(result, path+".content", content)
+					}
+				} else if recordType == "URI" {
+					// Generate content for URI records
+					weight := array[0].Get("weight")
+					target := array[0].Get("target")
+					if priority.Exists() && weight.Exists() && target.Exists() {
+						content := fmt.Sprintf("%v %v %s", priority.Value(), weight.Value(), target.String())
+						result, _ = sjson.Set(result, path+".content", content)
+					}
+				}
+			}
+		}
+	}
+
+	return result
+}
+
+// transformFlagsValue transforms the flags value to the correct format
+func (m *V4ToV5Migrator) transformFlagsValue(value gjson.Result) interface{} {
+	switch value.Type {
+	case gjson.Number:
+		return map[string]interface{}{
+			"value": json.Number(value.Raw),
+			"type":  "number",
+		}
+	case gjson.String:
+		if _, err := strconv.ParseFloat(value.String(), 64); err == nil {
+			return map[string]interface{}{
+				"value": json.Number(value.String()),
+				"type":  "number",
+			}
+		} else if value.String() == "" {
+			return nil
+		} else {
+			return map[string]interface{}{
+				"value": value.String(),
+				"type":  "string",
+			}
+		}
+	case gjson.Null:
+		return nil
+	default:
+		return nil
+	}
+}
+
+// isSimpleRecordType checks if a record type is simple (doesn't use data field)
+func (m *V4ToV5Migrator) isSimpleRecordType(recordType string) bool {
+	simpleTypes := map[string]bool{
+		"A": true, "AAAA": true, "CNAME": true, "MX": true,
+		"NS": true, "PTR": true, "TXT": true, "OPENPGPKEY": true,
+	}
+	return simpleTypes[recordType]
+}

--- a/internal/resources/dns_record/v4_to_v5_test.go
+++ b/internal/resources/dns_record/v4_to_v5_test.go
@@ -1,0 +1,996 @@
+package dns_record
+
+import (
+	"testing"
+
+	"github.com/cloudflare/tf-migrate/internal/testhelpers"
+)
+
+func TestV4ToV5Transformation(t *testing.T) {
+	suite := testhelpers.ResourceTestSuite{
+		ConfigTests: []testhelpers.ConfigTestCase{
+			{
+				Name: "CAA record with numeric flags in data block - content renamed to value",
+				Input: `
+resource "cloudflare_record" "caa_test" {
+  zone_id = "0da42c8d2132a9ddaf714f9e7c920711"
+  name    = "test.example.com"
+  type    = "CAA"
+  ttl     = 3600
+
+  data {
+    flags   = 0
+    tag     = "issue"
+    content = "letsencrypt.org"
+  }
+}`,
+				Expected: `resource "cloudflare_dns_record" "caa_test" {
+  zone_id = "0da42c8d2132a9ddaf714f9e7c920711"
+  name    = "test.example.com"
+  type    = "CAA"
+  ttl     = 3600
+
+  data = {
+    flags = 0
+    tag   = "issue"
+    value = "letsencrypt.org"
+  }
+}`,
+			},
+			{
+				Name: "CAA record with numeric flags in data attribute map - content renamed to value",
+				Input: `
+resource "cloudflare_record" "caa_test" {
+  zone_id = "0da42c8d2132a9ddaf714f9e7c920711"
+  name    = "test.example.com"
+  type    = "CAA"
+  ttl     = 3600
+  data    {
+    flags   = 0
+    tag     = "issue"
+    content = "letsencrypt.org"
+  }
+}`,
+				Expected: `resource "cloudflare_dns_record" "caa_test" {
+  zone_id = "0da42c8d2132a9ddaf714f9e7c920711"
+  name    = "test.example.com"
+  type    = "CAA"
+  ttl     = 3600
+  data = {
+    flags = 0
+    tag   = "issue"
+    value = "letsencrypt.org"
+  }
+}`,
+			},
+			{
+				Name: "CAA record with flags numeric string",
+				Input: `
+resource "cloudflare_record" "caa" {
+  zone_id = "abc123"
+  name    = "test"
+  type    = "CAA"
+  data = {
+    flags   = "128"
+    tag     = "issue"
+    content = "ca.example.com"
+  }
+}`,
+				Expected: `resource "cloudflare_dns_record" "caa" {
+  zone_id = "abc123"
+  name    = "test"
+  type    = "CAA"
+  data = {
+    flags = "128"
+    tag   = "issue"
+    value = "ca.example.com"
+  }
+  ttl = 1
+}`,
+			},
+			{
+				Name: "CAA record with content field in middle of data attribute",
+				Input: `
+resource "cloudflare_record" "caa" {
+  zone_id = "abc123"
+  name    = "test"
+  type    = "CAA"
+  data = {
+    tag     = "issue"
+    content = "ca.example.com"
+    flags   = "critical"
+  }
+}`,
+				Expected: `resource "cloudflare_dns_record" "caa" {
+  zone_id = "abc123"
+  name    = "test"
+  type    = "CAA"
+  data = {
+    tag   = "issue"
+    value = "ca.example.com"
+    flags = "critical"
+  }
+  ttl = 1
+}`,
+			},
+			{
+				Name: "Non-CAA record should not be modified",
+				Input: `
+resource "cloudflare_record" "a_test" {
+  zone_id = "0da42c8d2132a9ddaf714f9e7c920711"
+  name    = "test.example.com"
+  type    = "A"
+  ttl     = 3600
+  content = "192.168.1.1"
+}`,
+				Expected: `resource "cloudflare_dns_record" "a_test" {
+  zone_id = "0da42c8d2132a9ddaf714f9e7c920711"
+  name    = "test.example.com"
+  type    = "A"
+  ttl     = 3600
+  content = "192.168.1.1"
+}`,
+			},
+			{
+				Name: "cloudflare_record (legacy) with CAA type - content renamed to value",
+				Input: `
+resource "cloudflare_record" "caa_legacy" {
+  zone_id = "0da42c8d2132a9ddaf714f9e7c920711"
+  name    = "test.example.com"
+  type    = "CAA"
+  ttl     = 3600
+
+  data {
+    flags   = 128
+    tag     = "issuewild"
+    content = "pki.goog"
+  }
+}`,
+				Expected: `resource "cloudflare_dns_record" "caa_legacy" {
+  zone_id = "0da42c8d2132a9ddaf714f9e7c920711"
+  name    = "test.example.com"
+  type    = "CAA"
+  ttl     = 3600
+
+  data = {
+    flags = 128
+    tag   = "issuewild"
+    value = "pki.goog"
+  }
+}`,
+			},
+			{
+				Name: "DNS record without TTL - should add TTL with default value",
+				Input: `
+resource "cloudflare_record" "mx_test" {
+  zone_id  = "0da42c8d2132a9ddaf714f9e7c920711"
+  name     = "test.example.com"
+  type     = "MX"
+  content  = "mx.sendgrid.net"
+  priority = 10
+}`,
+				Expected: `resource "cloudflare_dns_record" "mx_test" {
+  zone_id  = "0da42c8d2132a9ddaf714f9e7c920711"
+  name     = "test.example.com"
+  type     = "MX"
+  content  = "mx.sendgrid.net"
+  priority = 10
+  ttl      = 1
+}`,
+			},
+			{
+				Name: "DNS record with existing TTL - should keep existing value",
+				Input: `
+resource "cloudflare_record" "a_test_ttl" {
+  zone_id = "0da42c8d2132a9ddaf714f9e7c920711"
+  name    = "test.example.com"
+  type    = "A"
+  ttl     = 3600
+  content = "192.168.1.1"
+}`,
+				Expected: `resource "cloudflare_dns_record" "a_test_ttl" {
+  zone_id = "0da42c8d2132a9ddaf714f9e7c920711"
+  name    = "test.example.com"
+  type    = "A"
+  ttl     = 3600
+  content = "192.168.1.1"
+}`,
+			},
+			{
+				Name: "Multiple CAA records in same file - content renamed to value and TTL added",
+				Input: `
+resource "cloudflare_record" "caa_test1" {
+  zone_id = "0da42c8d2132a9ddaf714f9e7c920711"
+  name    = "test1.example.com"
+  type    = "CAA"
+  data {
+    flags   = 0
+    tag     = "issue"
+    content = "letsencrypt.org"
+  }
+}
+
+resource "cloudflare_record" "caa_test2" {
+  zone_id = "0da42c8d2132a9ddaf714f9e7c920711"
+  name    = "test2.example.com"
+  type    = "CAA"
+  data {
+    flags   = 128
+    tag     = "issuewild"
+    content = "pki.goog"
+  }
+}`,
+				Expected: `resource "cloudflare_dns_record" "caa_test1" {
+  zone_id = "0da42c8d2132a9ddaf714f9e7c920711"
+  name    = "test1.example.com"
+  type    = "CAA"
+  ttl     = 1
+  data = {
+    flags = 0
+    tag   = "issue"
+    value = "letsencrypt.org"
+  }
+}
+
+resource "cloudflare_dns_record" "caa_test2" {
+  zone_id = "0da42c8d2132a9ddaf714f9e7c920711"
+  name    = "test2.example.com"
+  type    = "CAA"
+  ttl     = 1
+  data = {
+    flags = 128
+    tag   = "issuewild"
+    value = "pki.goog"
+  }
+}`,
+			},
+			{
+				Name: "DNS record with value field should rename to content",
+				Input: `
+resource "cloudflare_record" "a_test" {
+  zone_id = "0da42c8d2132a9ddaf714f9e7c920711"
+  name    = "test.example.com"
+  type    = "A"
+  value   = "192.168.1.1"
+}`,
+				Expected: `resource "cloudflare_dns_record" "a_test" {
+  zone_id = "0da42c8d2132a9ddaf714f9e7c920711"
+  name    = "test.example.com"
+  type    = "A"
+  ttl     = 1
+  content = "192.168.1.1"
+}`,
+			},
+			// Additional test cases for better coverage
+			{
+				Name: "MX record with data block - priority hoisted",
+				Input: `
+resource "cloudflare_record" "mx" {
+  zone_id = "abc123"
+  name    = "@"
+  type    = "MX"
+  
+  data {
+    priority = 10
+    target   = "mail.example.com"
+  }
+}`,
+				Expected: `resource "cloudflare_dns_record" "mx" {
+  zone_id = "abc123"
+  name    = "@"
+  type    = "MX"
+
+  ttl      = 1
+  priority = 10
+  data = {
+    target = "mail.example.com"
+  }
+}`,
+			},
+			{
+				Name: "URI record with data block - priority hoisted",
+				Input: `
+resource "cloudflare_record" "uri" {
+  zone_id = "abc123"
+  name    = "_http._tcp"
+  type    = "URI"
+  
+  data {
+    priority = 10
+    weight   = 1
+    target   = "http://example.com"
+  }
+}`,
+				Expected: `resource "cloudflare_dns_record" "uri" {
+  zone_id = "abc123"
+  name    = "_http._tcp"
+  type    = "URI"
+
+  ttl      = 1
+  priority = 10
+  data = {
+    weight = 1
+    target = "http://example.com"
+  }
+}`,
+			},
+			{
+				Name: "Record without type attribute",
+				Input: `
+resource "cloudflare_record" "no_type" {
+  zone_id = "abc123"
+  name    = "test"
+  value   = "192.0.2.1"
+}`,
+				Expected: `resource "cloudflare_dns_record" "no_type" {
+  zone_id = "abc123"
+  name    = "test"
+  ttl     = 1
+  content = "192.0.2.1"
+}`,
+			},
+			{
+				Name: "OPENPGPKEY record value renamed to content",
+				Input: `
+resource "cloudflare_record" "pgp" {
+  zone_id = "abc123"
+  name    = "test"
+  type    = "OPENPGPKEY"
+  value   = "base64encodedkey"
+}`,
+				Expected: `resource "cloudflare_dns_record" "pgp" {
+  zone_id = "abc123"
+  name    = "test"
+  type    = "OPENPGPKEY"
+  ttl     = 1
+  content = "base64encodedkey"
+}`,
+			},
+		},
+		StateTests: []testhelpers.StateTestCase{
+			{
+				Name: "CAA record v4 format with array data and numeric flags",
+				Input: `{
+				"version": 4,
+				"terraform_version": "1.5.0",
+				"resources": [{
+					"type": "cloudflare_dns_record",
+					"name": "caa_test",
+					"instances": [{
+						"attributes": {
+							"id": "test-id",
+							"zone_id": "0da42c8d2132a9ddaf714f9e7c920711",
+							"name": "test.example.com",
+							"type": "CAA",
+							"content": "0 issue letsencrypt.org",
+							"data": [{
+								"flags": 0,
+								"tag": "issue",
+								"content": "letsencrypt.org"
+							}]
+						}
+					}]
+				}]
+			}`,
+				Expected: `{
+				"version": 4,
+				"terraform_version": "1.5.0",
+				"resources": [{
+					"type": "cloudflare_dns_record",
+					"name": "caa_test",
+					"instances": [{
+						"attributes": {
+							"id": "test-id",
+							"zone_id": "0da42c8d2132a9ddaf714f9e7c920711",
+							"name": "test.example.com",
+							"type": "CAA",
+							"ttl": 1,
+							"content": "0 issue letsencrypt.org",
+							"created_on": "2024-01-01T00:00:00Z",
+							"modified_on": "2024-01-01T00:00:00Z",
+							"data": {
+								"flags": {
+									"value": 0,
+									"type": "number"
+								},
+								"tag": "issue",
+								"value": "letsencrypt.org"
+							}
+						}
+					}]
+				}]
+			}`,
+			},
+			{
+				Name: "Simple A record should set data field to null",
+				Input: `{
+				"version": 4,
+				"resources": [{
+					"type": "cloudflare_dns_record",
+					"name": "a_test",
+					"instances": [{
+						"attributes": {
+							"id": "test-id",
+							"zone_id": "0da42c8d2132a9ddaf714f9e7c920711",
+							"name": "test.example.com",
+							"type": "A",
+							"content": "192.168.1.1",
+							"data": []
+						}
+					}]
+				}]
+			}`,
+				Expected: `{
+				"version": 4,
+				"resources": [{
+					"type": "cloudflare_dns_record",
+					"name": "a_test",
+					"instances": [{
+						"attributes": {
+							"id": "test-id",
+							"zone_id": "0da42c8d2132a9ddaf714f9e7c920711",
+							"name": "test.example.com",
+							"type": "A",
+							"ttl": 1,
+							"content": "192.168.1.1",
+							"created_on": "2024-01-01T00:00:00Z",
+							"modified_on": "2024-01-01T00:00:00Z"
+						}
+					}]
+				}]
+			}`,
+			},
+			{
+				Name: "cloudflare_record (legacy) renamed to cloudflare_dns_record",
+				Input: `{
+				"version": 4,
+				"resources": [{
+					"type": "cloudflare_record",
+					"name": "caa_test",
+					"instances": [{
+						"attributes": {
+							"id": "test-id",
+							"zone_id": "0da42c8d2132a9ddaf714f9e7c920711",
+							"name": "test.example.com",
+							"type": "CAA",
+							"content": "0 issue letsencrypt.org",
+							"data": [{
+								"flags": 0,
+								"tag": "issue",
+								"content": "letsencrypt.org"
+							}]
+						}
+					}]
+				}]
+			}`,
+				Expected: `{
+				"version": 4,
+				"resources": [{
+					"type": "cloudflare_dns_record",
+					"name": "caa_test",
+					"instances": [{
+						"attributes": {
+							"id": "test-id",
+							"zone_id": "0da42c8d2132a9ddaf714f9e7c920711",
+							"name": "test.example.com",
+							"type": "CAA",
+							"ttl": 1,
+							"content": "0 issue letsencrypt.org",
+							"created_on": "2024-01-01T00:00:00Z",
+							"modified_on": "2024-01-01T00:00:00Z",
+							"data": {
+								"flags": {
+									"value": 0,
+									"type": "number"
+								},
+								"tag": "issue",
+								"value": "letsencrypt.org"
+							}
+						}
+					}]
+				}]
+			}`,
+			},
+			{
+				Name: "Record with value field renamed to content",
+				Input: `{
+				"version": 4,
+				"resources": [{
+					"type": "cloudflare_record",
+					"name": "a_test",
+					"instances": [{
+						"attributes": {
+							"id": "test-id",
+							"zone_id": "0da42c8d2132a9ddaf714f9e7c920711",
+							"name": "test.example.com",
+							"type": "A",
+							"value": "192.168.1.1",
+							"hostname": "test.example.com",
+							"allow_overwrite": true
+						}
+					}]
+				}]
+			}`,
+				Expected: `{
+				"version": 4,
+				"resources": [{
+					"type": "cloudflare_dns_record",
+					"name": "a_test",
+					"instances": [{
+						"attributes": {
+							"id": "test-id",
+							"zone_id": "0da42c8d2132a9ddaf714f9e7c920711",
+							"name": "test.example.com",
+							"type": "A",
+							"ttl": 1,
+							"content": "192.168.1.1",
+							"created_on": "2024-01-01T00:00:00Z",
+							"modified_on": "2024-01-01T00:00:00Z"
+						}
+					}]
+				}]
+			}`,
+			},
+			{
+				Name: "SRV record with array data migration",
+				Input: `{
+				"version": 4,
+				"resources": [{
+					"type": "cloudflare_dns_record",
+					"name": "srv_test",
+					"instances": [{
+						"attributes": {
+							"id": "test-id",
+							"zone_id": "0da42c8d2132a9ddaf714f9e7c920711",
+							"name": "_sip._tcp.example.com",
+							"type": "SRV",
+							"data": [{
+								"priority": 10,
+								"weight": 60,
+								"port": 5060,
+								"target": "sipserver.example.com"
+							}]
+						}
+					}]
+				}]
+			}`,
+				Expected: `{
+				"version": 4,
+				"resources": [{
+					"type": "cloudflare_dns_record",
+					"name": "srv_test",
+					"instances": [{
+						"attributes": {
+							"id": "test-id",
+							"zone_id": "0da42c8d2132a9ddaf714f9e7c920711",
+							"name": "_sip._tcp.example.com",
+							"type": "SRV",
+							"priority": 10,
+							"ttl": 1,
+							"created_on": "2024-01-01T00:00:00Z",
+							"modified_on": "2024-01-01T00:00:00Z",
+							"data": {
+								"weight": 60,
+								"port": 5060,
+								"target": "sipserver.example.com"
+							}
+						}
+					}]
+				}]
+			}`,
+			},
+			// Additional state test cases for better coverage
+			{
+				Name: "State with missing attributes - should skip",
+				Input: `{
+					"resources": [{
+						"type": "cloudflare_record",
+						"name": "invalid",
+						"instances": [{
+							"attributes": {}
+						}]
+					}]
+				}`,
+				Expected: `{
+					"resources": [{
+						"type": "cloudflare_dns_record",
+						"name": "invalid",
+						"instances": [{
+							"attributes": {}
+						}]
+					}]
+				}`,
+			},
+			{
+				Name: "State without instances",
+				Input: `{
+					"resources": [{
+						"type": "cloudflare_record",
+						"name": "empty",
+						"instances": []
+					}]
+				}`,
+				Expected: `{
+					"resources": [{
+						"type": "cloudflare_dns_record",
+						"name": "empty",
+						"instances": []
+					}]
+				}`,
+			},
+			{
+				Name: "MX record state with data array",
+				Input: `{
+					"resources": [{
+						"type": "cloudflare_record",
+						"name": "mx",
+						"instances": [{
+							"attributes": {
+								"id": "mx123",
+								"zone_id": "zone123",
+								"name": "@",
+								"type": "MX",
+								"data": [{
+									"priority": 10,
+									"target": "mail.example.com"
+								}]
+							}
+						}]
+					}]
+				}`,
+				Expected: `{
+					"resources": [{
+						"type": "cloudflare_dns_record",
+						"name": "mx",
+						"instances": [{
+							"attributes": {
+								"id": "mx123",
+								"zone_id": "zone123",
+								"name": "@",
+								"type": "MX",
+								"priority": 10,
+								"content": "10 mail.example.com",
+								"data": {
+									"target": "mail.example.com"
+								},
+								"ttl": 1,
+								"created_on": "2024-01-01T00:00:00Z",
+								"modified_on": "2024-01-01T00:00:00Z"
+							}
+						}]
+					}]
+				}`,
+			},
+			{
+				Name: "URI record state with data array",
+				Input: `{
+					"resources": [{
+						"type": "cloudflare_record",
+						"name": "uri",
+						"instances": [{
+							"attributes": {
+								"id": "uri123",
+								"zone_id": "zone123",
+								"name": "_http._tcp",
+								"type": "URI",
+								"data": [{
+									"priority": 10,
+									"weight": 1,
+									"target": "http://example.com"
+								}]
+							}
+						}]
+					}]
+				}`,
+				Expected: `{
+					"resources": [{
+						"type": "cloudflare_dns_record",
+						"name": "uri",
+						"instances": [{
+							"attributes": {
+								"id": "uri123",
+								"zone_id": "zone123",
+								"name": "_http._tcp",
+								"type": "URI",
+								"priority": 10,
+								"content": "10 1 http://example.com",
+								"data": {
+									"weight": 1,
+									"target": "http://example.com"
+								},
+								"ttl": 1,
+								"created_on": "2024-01-01T00:00:00Z",
+								"modified_on": "2024-01-01T00:00:00Z"
+							}
+						}]
+					}]
+				}`,
+			},
+			{
+				Name: "CAA record with numeric string flags - should convert to number type",
+				Input: `{
+					"resources": [{
+						"type": "cloudflare_record",
+						"name": "caa",
+						"instances": [{
+							"attributes": {
+								"id": "caa123",
+								"zone_id": "zone123",
+								"name": "example.com",
+								"type": "CAA",
+								"data": [{
+									"flags": "128",
+									"tag": "issue",
+									"content": "letsencrypt.org"
+								}]
+							}
+						}]
+					}]
+				}`,
+				Expected: `{
+					"resources": [{
+						"type": "cloudflare_dns_record",
+						"name": "caa",
+						"instances": [{
+							"attributes": {
+								"id": "caa123",
+								"zone_id": "zone123",
+								"name": "example.com",
+								"type": "CAA",
+								"content": "128 issue letsencrypt.org",
+								"data": {
+									"flags": {
+										"value": 128,
+										"type": "number"
+									},
+									"tag": "issue",
+									"value": "letsencrypt.org"
+								},
+								"ttl": 1,
+								"created_on": "2024-01-01T00:00:00Z",
+								"modified_on": "2024-01-01T00:00:00Z"
+							}
+						}]
+					}]
+				}`,
+			},
+			{
+				Name: "CAA record with null flags",
+				Input: `{
+					"resources": [{
+						"type": "cloudflare_record",
+						"name": "caa",
+						"instances": [{
+							"attributes": {
+								"id": "caa123",
+								"zone_id": "zone123",
+								"name": "example.com",
+								"type": "CAA",
+								"data": [{
+									"flags": null,
+									"tag": "issue",
+									"content": "letsencrypt.org"
+								}]
+							}
+						}]
+					}]
+				}`,
+				Expected: `{
+					"resources": [{
+						"type": "cloudflare_dns_record",
+						"name": "caa",
+						"instances": [{
+							"attributes": {
+								"id": "caa123",
+								"zone_id": "zone123",
+								"name": "example.com",
+								"type": "CAA",
+								"content": "0 issue letsencrypt.org",
+								"data": {
+									"flags": null,
+									"tag": "issue",
+									"value": "letsencrypt.org"
+								},
+								"ttl": 1,
+								"created_on": "2024-01-01T00:00:00Z",
+								"modified_on": "2024-01-01T00:00:00Z"
+							}
+						}]
+					}]
+				}`,
+			},
+			{
+				Name: "CAA record with non-numeric string flags",
+				Input: `{
+					"resources": [{
+						"type": "cloudflare_record",
+						"name": "caa",
+						"instances": [{
+							"attributes": {
+								"id": "caa123",
+								"zone_id": "zone123",
+								"name": "example.com",
+								"type": "CAA",
+								"data": [{
+									"flags": "critical",
+									"tag": "issue",
+									"content": "letsencrypt.org"
+								}]
+							}
+						}]
+					}]
+				}`,
+				Expected: `{
+					"resources": [{
+						"type": "cloudflare_dns_record",
+						"name": "caa",
+						"instances": [{
+							"attributes": {
+								"id": "caa123",
+								"zone_id": "zone123",
+								"name": "example.com",
+								"type": "CAA",
+								"content": "critical issue letsencrypt.org",
+								"data": {
+									"flags": {
+										"value": "critical",
+										"type": "string"
+									},
+									"tag": "issue",
+									"value": "letsencrypt.org"
+								},
+								"ttl": 1,
+								"created_on": "2024-01-01T00:00:00Z",
+								"modified_on": "2024-01-01T00:00:00Z"
+							}
+						}]
+					}]
+				}`,
+			},
+			{
+				Name: "CAA record with empty string flags",
+				Input: `{
+					"resources": [{
+						"type": "cloudflare_record",
+						"name": "caa",
+						"instances": [{
+							"attributes": {
+								"id": "caa123",
+								"zone_id": "zone123",
+								"name": "example.com",
+								"type": "CAA",
+								"data": [{
+									"flags": "",
+									"tag": "issue",
+									"content": "letsencrypt.org"
+								}]
+							}
+						}]
+					}]
+				}`,
+				Expected: `{
+					"resources": [{
+						"type": "cloudflare_dns_record",
+						"name": "caa",
+						"instances": [{
+							"attributes": {
+								"id": "caa123",
+								"zone_id": "zone123",
+								"name": "example.com",
+								"type": "CAA",
+								"content": "0 issue letsencrypt.org",
+								"data": {
+									"flags": null,
+									"tag": "issue",
+									"value": "letsencrypt.org"
+								},
+								"ttl": 1,
+								"created_on": "2024-01-01T00:00:00Z",
+								"modified_on": "2024-01-01T00:00:00Z"
+							}
+						}]
+					}]
+				}`,
+			},
+			{
+				Name: "State with empty resources",
+				Input: `{
+					"resources": []
+				}`,
+				Expected: `{
+					"resources": []
+				}`,
+			},
+			{
+				Name: "Record with created_on but no modified_on",
+				Input: `{
+					"resources": [{
+						"type": "cloudflare_record",
+						"name": "test",
+						"instances": [{
+							"attributes": {
+								"zone_id": "zone123",
+								"name": "test",
+								"type": "A",
+								"value": "192.0.2.1",
+								"created_on": "2023-01-01T00:00:00Z"
+							}
+						}]
+					}]
+				}`,
+				Expected: `{
+					"resources": [{
+						"type": "cloudflare_dns_record",
+						"name": "test",
+						"instances": [{
+							"attributes": {
+								"zone_id": "zone123",
+								"name": "test",
+								"type": "A",
+								"content": "192.0.2.1",
+								"ttl": 1,
+								"created_on": "2023-01-01T00:00:00Z",
+								"modified_on": "2023-01-01T00:00:00Z"
+							}
+						}]
+					}]
+				}`,
+			},
+			{
+				Name: "Record with both value and content fields",
+				Input: `{
+					"resources": [{
+						"type": "cloudflare_record",
+						"name": "test",
+						"instances": [{
+							"attributes": {
+								"zone_id": "zone123",
+								"name": "test",
+								"type": "A",
+								"value": "192.0.2.1",
+								"content": "192.0.2.2"
+							}
+						}]
+					}]
+				}`,
+				Expected: `{
+					"resources": [{
+						"type": "cloudflare_dns_record",
+						"name": "test",
+						"instances": [{
+							"attributes": {
+								"zone_id": "zone123",
+								"name": "test",
+								"type": "A",
+								"content": "192.0.2.2",
+								"ttl": 1,
+								"created_on": "2024-01-01T00:00:00Z",
+								"modified_on": "2024-01-01T00:00:00Z"
+							}
+						}]
+					}]
+				}`,
+			},
+		},
+	}
+
+	testhelpers.RunResourceTestSuite(t, suite, NewV4ToV5Migrator)
+}
+
+func TestV4ToV5MigratorResourceTypes(t *testing.T) {
+	migrator := NewV4ToV5Migrator()
+	
+	// Test that it handles the expected resource types
+	testhelpers.AssertResourceType(t, migrator, 
+		"cloudflare_dns_record",
+		"cloudflare_record", // legacy name
+	)
+	
+	// Test that it doesn't handle other resource types
+	testhelpers.AssertNotResourceType(t, migrator,
+		"cloudflare_zone",
+		"cloudflare_load_balancer",
+		"aws_instance",
+	)
+}
+

--- a/internal/resources/dns_record/version_test.go
+++ b/internal/resources/dns_record/version_test.go
@@ -1,0 +1,50 @@
+package dns_record
+
+import (
+	"testing"
+	"github.com/cloudflare/tf-migrate/internal"
+)
+
+func TestDNSRecordVersionBasedSelection(t *testing.T) {
+	// Test that dns_record is registered for v4->v5
+	migrator := internal.GetMigrator("cloudflare_dns_record", "v4", "v5")
+	if migrator == nil {
+		t.Fatal("Expected dns_record migrator for v4->v5, got nil")
+	}
+	
+	// Also check legacy cloudflare_record type
+	migrator = internal.GetMigrator("cloudflare_record", "v4", "v5")
+	if migrator == nil {
+		t.Fatal("Expected cloudflare_record migrator for v4->v5, got nil")
+	}
+	
+	// Test that it's NOT available for other version pairs
+	migrator = internal.GetMigrator("cloudflare_dns_record", "v5", "v6")
+	if migrator != nil {
+		t.Error("Expected nil for v5->v6 migration (not implemented yet)")
+	}
+	
+	migrator = internal.GetMigrator("cloudflare_dns_record", "v3", "v4")
+	if migrator != nil {
+		t.Error("Expected nil for v3->v4 migration (not implemented)")
+	}
+}
+
+func TestGetMigratorFunction(t *testing.T) {
+	// Test the GetMigrator function in this package
+	migrator := GetMigrator("v4", "v5")
+	if migrator == nil {
+		t.Fatal("Expected migrator from GetMigrator(v4, v5)")
+	}
+	
+	// Should return nil for unsupported versions
+	migrator = GetMigrator("v5", "v6")
+	if migrator != nil {
+		t.Error("Expected nil from GetMigrator(v5, v6)")
+	}
+	
+	migrator = GetMigrator("v3", "v4")
+	if migrator != nil {
+		t.Error("Expected nil from GetMigrator(v3, v4)")
+	}
+}

--- a/internal/testhelpers/config.go
+++ b/internal/testhelpers/config.go
@@ -1,0 +1,92 @@
+package testhelpers
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclwrite"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cloudflare/tf-migrate/internal/transform"
+)
+
+// ConfigTestCase represents a test case for configuration transformations
+type ConfigTestCase struct {
+	Name     string
+	Input    string
+	Expected string
+}
+
+// RunConfigTransformTest runs a single configuration transformation test
+func RunConfigTransformTest(t *testing.T, tt ConfigTestCase, migrator transform.ResourceTransformer) {
+	t.Helper()
+
+	// Parse the input HCL
+	file, diags := hclwrite.ParseConfig([]byte(tt.Input), "test.tf", hcl.InitialPos)
+	require.False(t, diags.HasErrors(), "Failed to parse input HCL: %v", diags)
+
+	// Create context
+	ctx := &transform.Context{
+		Content:  []byte(tt.Input),
+		Filename: "test.tf",
+		AST:      file,
+	}
+
+	// Process each resource block
+	body := file.Body()
+	for _, block := range body.Blocks() {
+		if block.Type() == "resource" && len(block.Labels()) >= 2 {
+			resourceType := block.Labels()[0]
+			if migrator.CanHandle(resourceType) {
+				result, err := migrator.TransformConfig(ctx, block)
+				assert.NoError(t, err, "Failed to transform resource")
+				
+				// Handle resource splits or removals
+				if result != nil && result.RemoveOriginal {
+					body.RemoveBlock(block)
+					for _, newBlock := range result.Blocks {
+						body.AppendBlock(newBlock)
+					}
+				}
+			}
+		}
+	}
+
+	// Get the transformed output
+	output := strings.TrimSpace(string(hclwrite.Format(file.Bytes())))
+
+	// Parse expected for comparison
+	expectedFile, diags := hclwrite.ParseConfig([]byte(tt.Expected), "expected.tf", hcl.InitialPos)
+	require.False(t, diags.HasErrors(), "Failed to parse expected HCL: %v", diags)
+	expectedOutput := strings.TrimSpace(string(hclwrite.Format(expectedFile.Bytes())))
+
+	assert.Equal(t, expectedOutput, output)
+}
+
+// RunConfigTransformTests runs multiple configuration transformation tests
+func RunConfigTransformTests(t *testing.T, tests []ConfigTestCase, migrator transform.ResourceTransformer) {
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			RunConfigTransformTest(t, tt, migrator)
+		})
+	}
+}
+
+// RunConfigTransformTestWithFactory runs tests with a migrator factory function
+// This is useful when you need a fresh migrator instance for each test
+func RunConfigTransformTestWithFactory(t *testing.T, tt ConfigTestCase, factory func() transform.ResourceTransformer) {
+	t.Helper()
+	migrator := factory()
+	RunConfigTransformTest(t, tt, migrator)
+}
+
+// RunConfigTransformTestsWithFactory runs multiple tests with a migrator factory function
+func RunConfigTransformTestsWithFactory(t *testing.T, tests []ConfigTestCase, factory func() transform.ResourceTransformer) {
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			RunConfigTransformTestWithFactory(t, tt, factory)
+		})
+	}
+}

--- a/internal/testhelpers/resource.go
+++ b/internal/testhelpers/resource.go
@@ -1,0 +1,46 @@
+package testhelpers
+
+import (
+	"testing"
+
+	"github.com/cloudflare/tf-migrate/internal/transform"
+)
+
+// ResourceTestSuite contains both config and state tests for a resource
+type ResourceTestSuite struct {
+	ConfigTests []ConfigTestCase
+	StateTests  []StateTestCase
+}
+
+// RunResourceTestSuite runs a complete test suite for a resource migrator
+func RunResourceTestSuite(t *testing.T, suite ResourceTestSuite, factory func() transform.ResourceTransformer) {
+	t.Run("ConfigTransformation", func(t *testing.T) {
+		RunConfigTransformTestsWithFactory(t, suite.ConfigTests, factory)
+	})
+
+	t.Run("StateTransformation", func(t *testing.T) {
+		RunStateTransformTestsWithFactory(t, suite.StateTests, factory)
+	})
+}
+
+// AssertResourceType verifies that a migrator handles the expected resource types
+func AssertResourceType(t *testing.T, migrator transform.ResourceTransformer, expectedTypes ...string) {
+	t.Helper()
+	
+	for _, resourceType := range expectedTypes {
+		if !migrator.CanHandle(resourceType) {
+			t.Errorf("Migrator should handle resource type %q but doesn't", resourceType)
+		}
+	}
+}
+
+// AssertNotResourceType verifies that a migrator doesn't handle certain resource types
+func AssertNotResourceType(t *testing.T, migrator transform.ResourceTransformer, unexpectedTypes ...string) {
+	t.Helper()
+	
+	for _, resourceType := range unexpectedTypes {
+		if migrator.CanHandle(resourceType) {
+			t.Errorf("Migrator should not handle resource type %q but does", resourceType)
+		}
+	}
+}

--- a/internal/testhelpers/state.go
+++ b/internal/testhelpers/state.go
@@ -1,0 +1,60 @@
+package testhelpers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+
+	"github.com/cloudflare/tf-migrate/internal/transform"
+)
+
+// StateTestCase represents a test case for state transformations
+type StateTestCase struct {
+	Name     string
+	Input    string
+	Expected string
+}
+
+// RunStateTransformTest runs a single state transformation test
+func RunStateTransformTest(t *testing.T, tt StateTestCase, migrator transform.ResourceTransformer) {
+	t.Helper()
+
+	// Create context
+	ctx := &transform.Context{
+		StateJSON: tt.Input,
+	}
+
+	// Transform the state
+	result, err := migrator.TransformState(ctx, gjson.Result{}, "")
+	require.NoError(t, err, "Failed to transform state")
+
+	// Compare JSON (normalize both for comparison)
+	assert.JSONEq(t, tt.Expected, result, "State transformation mismatch")
+}
+
+// RunStateTransformTests runs multiple state transformation tests
+func RunStateTransformTests(t *testing.T, tests []StateTestCase, migrator transform.ResourceTransformer) {
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			RunStateTransformTest(t, tt, migrator)
+		})
+	}
+}
+
+// RunStateTransformTestWithFactory runs a test with a migrator factory function
+func RunStateTransformTestWithFactory(t *testing.T, tt StateTestCase, factory func() transform.ResourceTransformer) {
+	t.Helper()
+	migrator := factory()
+	RunStateTransformTest(t, tt, migrator)
+}
+
+// RunStateTransformTestsWithFactory runs multiple tests with a migrator factory function
+func RunStateTransformTestsWithFactory(t *testing.T, tests []StateTestCase, factory func() transform.ResourceTransformer) {
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			RunStateTransformTestWithFactory(t, tt, factory)
+		})
+	}
+}

--- a/internal/transform/hcl/attributes.go
+++ b/internal/transform/hcl/attributes.go
@@ -1,0 +1,175 @@
+// Package hcl provides utilities for transforming HCL configuration files
+// during Terraform provider migrations. These utilities handle common patterns
+// like renaming attributes, ensuring required fields exist, and restructuring
+// resource configurations.
+package hcl
+
+import (
+	"strings"
+
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/hashicorp/hcl/v2/hclwrite"
+
+	"github.com/cloudflare/tf-migrate/internal/hcl"
+)
+
+// EnsureAttribute ensures an attribute exists with a default value if not present.
+// This is useful when a new provider version requires a field that was optional before.
+//
+// Example - Adding required TTL field to DNS records:
+//
+// Before:
+//   resource "cloudflare_dns_record" "example" {
+//     zone_id = "abc123"
+//     name    = "test"
+//     type    = "A"
+//     content = "192.0.2.1"
+//   }
+//
+// After calling EnsureAttribute(body, "ttl", 1):
+//   resource "cloudflare_dns_record" "example" {
+//     zone_id = "abc123"
+//     name    = "test"
+//     type    = "A"
+//     content = "192.0.2.1"
+//     ttl     = 1
+//   }
+func EnsureAttribute(body *hclwrite.Body, attrName string, defaultValue interface{}) {
+	if body.GetAttribute(attrName) == nil {
+		tokens := hcl.TokensForSimpleValue(defaultValue)
+		if tokens != nil {
+			body.SetAttributeRaw(attrName, tokens)
+		}
+	}
+}
+
+// RenameAttribute renames an attribute from oldName to newName.
+// Returns true if the attribute was found and renamed, false otherwise.
+//
+// Example - Renaming 'value' to 'content' for DNS records:
+//
+// Before:
+//   resource "cloudflare_dns_record" "example" {
+//     zone_id = "abc123"
+//     name    = "test"
+//     type    = "A"
+//     value   = "192.0.2.1"  # Old field name
+//   }
+//
+// After calling RenameAttribute(body, "value", "content"):
+//   resource "cloudflare_dns_record" "example" {
+//     zone_id = "abc123"
+//     name    = "test"
+//     type    = "A"
+//     content = "192.0.2.1"  # New field name
+//   }
+func RenameAttribute(body *hclwrite.Body, oldName, newName string) bool {
+	if attr := body.GetAttribute(oldName); attr != nil {
+		tokens := attr.Expr().BuildTokens(nil)
+		body.SetAttributeRaw(newName, tokens)
+		body.RemoveAttribute(oldName)
+		return true
+	}
+	return false
+}
+
+// RemoveAttributes removes multiple attributes from a body.
+// Returns the count of attributes actually removed.
+//
+// Example - Removing deprecated fields:
+//
+// Before:
+//   resource "cloudflare_dns_record" "example" {
+//     zone_id         = "abc123"
+//     name            = "test"
+//     type            = "A"
+//     content         = "192.0.2.1"
+//     allow_overwrite = true      # Deprecated in v5
+//     hostname        = "test.com" # Deprecated in v5
+//   }
+//
+// After calling RemoveAttributes(body, "allow_overwrite", "hostname"):
+//   resource "cloudflare_dns_record" "example" {
+//     zone_id = "abc123"
+//     name    = "test"
+//     type    = "A"
+//     content = "192.0.2.1"
+//   }
+func RemoveAttributes(body *hclwrite.Body, attrNames ...string) int {
+	removed := 0
+	for _, attrName := range attrNames {
+		if body.GetAttribute(attrName) != nil {
+			body.RemoveAttribute(attrName)
+			removed++
+		}
+	}
+	return removed
+}
+
+// ExtractStringFromAttribute extracts a string value from an HCL attribute.
+// Handles both quoted literals and identifiers.
+//
+// Example usage:
+//   typeAttr := body.GetAttribute("type")
+//   recordType := ExtractStringFromAttribute(typeAttr)
+//   // Returns "A" from: type = "A"
+//   // Returns "var.record_type" from: type = var.record_type
+func ExtractStringFromAttribute(attr *hclwrite.Attribute) string {
+	if attr == nil {
+		return ""
+	}
+	
+	tokens := attr.Expr().BuildTokens(nil)
+	for _, token := range tokens {
+		if token.Type == hclsyntax.TokenQuotedLit {
+			// Remove quotes from quoted literal
+			return strings.Trim(string(token.Bytes), "\"")
+		} else if token.Type == hclsyntax.TokenIdent {
+			// Return identifier as-is
+			return string(token.Bytes)
+		}
+	}
+	return ""
+}
+
+// HasAttribute checks if an attribute exists in the body
+func HasAttribute(body *hclwrite.Body, attrName string) bool {
+	return body.GetAttribute(attrName) != nil
+}
+
+// CopyAndRenameAttribute copies an attribute with a new name
+func CopyAndRenameAttribute(from, to *hclwrite.Body, oldName, newName string) bool {
+	if attr := from.GetAttribute(oldName); attr != nil {
+		tokens := attr.Expr().BuildTokens(nil)
+		to.SetAttributeRaw(newName, tokens)
+		return true
+	}
+	return false
+}
+
+// AttributeRenameMap represents a mapping of old attribute names to new ones
+type AttributeRenameMap map[string]string
+
+// ApplyAttributeRenames applies multiple attribute renames based on a map
+func ApplyAttributeRenames(body *hclwrite.Body, renames AttributeRenameMap) int {
+	renamed := 0
+	for oldName, newName := range renames {
+		if RenameAttribute(body, oldName, newName) {
+			renamed++
+		}
+	}
+	return renamed
+}
+
+// ConditionalRenameAttribute renames an attribute only if a condition is met
+func ConditionalRenameAttribute(body *hclwrite.Body, oldName, newName string, condition func(*hclwrite.Attribute) bool) bool {
+	if attr := body.GetAttribute(oldName); attr != nil {
+		if condition(attr) {
+			tokens := attr.Expr().BuildTokens(nil)
+			body.SetAttributeRaw(newName, tokens)
+			body.RemoveAttribute(oldName)
+			return true
+		}
+	}
+	return false
+}

--- a/internal/transform/hcl/blocks.go
+++ b/internal/transform/hcl/blocks.go
@@ -1,0 +1,232 @@
+// Package hcl provides utilities for transforming HCL blocks and their structure
+// during Terraform provider migrations.
+package hcl
+
+import (
+	"github.com/hashicorp/hcl/v2/hclwrite"
+
+	"github.com/cloudflare/tf-migrate/internal/hcl"
+)
+
+// RenameResourceType renames a resource from oldType to newType.
+// Returns true if the resource type was renamed, false otherwise.
+//
+// Example - Renaming legacy resource type:
+//
+// Before:
+//   resource "cloudflare_record" "example" {
+//     zone_id = "abc123"
+//     name    = "test"
+//     type    = "A"
+//     value   = "192.0.2.1"
+//   }
+//
+// After calling RenameResourceType(block, "cloudflare_record", "cloudflare_dns_record"):
+//   resource "cloudflare_dns_record" "example" {
+//     zone_id = "abc123"
+//     name    = "test"
+//     type    = "A"
+//     value   = "192.0.2.1"
+//   }
+func RenameResourceType(block *hclwrite.Block, oldType, newType string) bool {
+	labels := block.Labels()
+	if len(labels) >= 2 && labels[0] == oldType {
+		labels[0] = newType
+		block.SetLabels(labels)
+		return true
+	}
+	return false
+}
+
+// GetResourceType returns the resource type from a resource block
+func GetResourceType(block *hclwrite.Block) string {
+	if block.Type() != "resource" {
+		return ""
+	}
+	labels := block.Labels()
+	if len(labels) >= 1 {
+		return labels[0]
+	}
+	return ""
+}
+
+// GetResourceName returns the resource name from a resource block
+func GetResourceName(block *hclwrite.Block) string {
+	if block.Type() != "resource" {
+		return ""
+	}
+	labels := block.Labels()
+	if len(labels) >= 2 {
+		return labels[1]
+	}
+	return ""
+}
+
+// ConvertBlocksToAttribute converts all blocks of a certain type to an object attribute.
+// The preProcess function is called on each block before conversion (can be nil).
+//
+// Example - Converting data blocks to attribute for CAA records:
+//
+// Before:
+//   resource "cloudflare_dns_record" "caa" {
+//     zone_id = "abc123"
+//     name    = "example.com"
+//     type    = "CAA"
+//     
+//     data {
+//       flags   = "0"
+//       tag     = "issue"
+//       content = "letsencrypt.org"
+//     }
+//   }
+//
+// After calling ConvertBlocksToAttribute(body, "data", "data", preProcess):
+//   resource "cloudflare_dns_record" "caa" {
+//     zone_id = "abc123"
+//     name    = "example.com"
+//     type    = "CAA"
+//     data = {
+//       flags = "0"
+//       tag   = "issue"
+//       value = "letsencrypt.org"  # Renamed by preProcess
+//     }
+//   }
+func ConvertBlocksToAttribute(body *hclwrite.Body, blockType, attrName string, preProcess func(*hclwrite.Block)) {
+	var blocksToRemove []*hclwrite.Block
+	
+	for _, block := range body.Blocks() {
+		if block.Type() != blockType {
+			continue
+		}
+		
+		// Apply preprocessing if provided
+		if preProcess != nil {
+			preProcess(block)
+		}
+		
+		// Convert block to object tokens
+		objTokens := hcl.BuildObjectFromBlock(block)
+		body.SetAttributeRaw(attrName, objTokens)
+		blocksToRemove = append(blocksToRemove, block)
+	}
+	
+	// Remove the converted blocks
+	for _, block := range blocksToRemove {
+		body.RemoveBlock(block)
+	}
+}
+
+// HoistAttributeFromBlock copies an attribute from a nested block to the parent body.
+// Returns true if the attribute was hoisted, false otherwise.
+//
+// Example - Hoisting priority from SRV record data block:
+//
+// Before:
+//   resource "cloudflare_dns_record" "srv" {
+//     zone_id = "abc123"
+//     name    = "_sip._tcp"
+//     type    = "SRV"
+//     
+//     data {
+//       priority = 10
+//       weight   = 60
+//       port     = 5060
+//       target   = "sipserver.example.com"
+//     }
+//   }
+//
+// After calling HoistAttributeFromBlock(body, "data", "priority"):
+//   resource "cloudflare_dns_record" "srv" {
+//     zone_id  = "abc123"
+//     name     = "_sip._tcp"
+//     type     = "SRV"
+//     priority = 10  # Hoisted from data block
+//     
+//     data {
+//       weight = 60
+//       port   = 5060
+//       target = "sipserver.example.com"
+//     }
+//   }
+func HoistAttributeFromBlock(parentBody *hclwrite.Body, blockType, attrName string) bool {
+	for _, block := range parentBody.Blocks() {
+		if block.Type() != blockType {
+			continue
+		}
+		if block.Body().GetAttribute(attrName) != nil {
+			// Only hoist if parent doesn't already have this attribute
+			if parentBody.GetAttribute(attrName) == nil {
+				hcl.CopyAttribute(block.Body(), parentBody, attrName)
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// HoistAttributesFromBlock copies multiple attributes from nested blocks to parent
+func HoistAttributesFromBlock(parentBody *hclwrite.Body, blockType string, attrNames ...string) int {
+	hoisted := 0
+	for _, attrName := range attrNames {
+		if HoistAttributeFromBlock(parentBody, blockType, attrName) {
+			hoisted++
+		}
+	}
+	return hoisted
+}
+
+// FindBlockByType finds the first block of a given type
+func FindBlockByType(body *hclwrite.Body, blockType string) *hclwrite.Block {
+	for _, block := range body.Blocks() {
+		if block.Type() == blockType {
+			return block
+		}
+	}
+	return nil
+}
+
+// FindBlocksByType finds all blocks of a given type
+func FindBlocksByType(body *hclwrite.Body, blockType string) []*hclwrite.Block {
+	var blocks []*hclwrite.Block
+	for _, block := range body.Blocks() {
+		if block.Type() == blockType {
+			blocks = append(blocks, block)
+		}
+	}
+	return blocks
+}
+
+// RemoveBlocksByType removes all blocks of a given type
+func RemoveBlocksByType(body *hclwrite.Body, blockType string) int {
+	blocks := FindBlocksByType(body, blockType)
+	for _, block := range blocks {
+		body.RemoveBlock(block)
+	}
+	return len(blocks)
+}
+
+// ProcessBlocksOfType applies a function to all blocks of a given type
+func ProcessBlocksOfType(body *hclwrite.Body, blockType string, processor func(*hclwrite.Block) error) error {
+	for _, block := range body.Blocks() {
+		if block.Type() == blockType {
+			if err := processor(block); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// ConvertSingleBlockToAttribute converts the first block of a type to an attribute
+// This is useful when a resource changes from having a single block to an attribute
+func ConvertSingleBlockToAttribute(body *hclwrite.Body, blockType, attrName string) bool {
+	block := FindBlockByType(body, blockType)
+	if block == nil {
+		return false
+	}
+	
+	objTokens := hcl.BuildObjectFromBlock(block)
+	body.SetAttributeRaw(attrName, objTokens)
+	body.RemoveBlock(block)
+	return true
+}

--- a/internal/transform/state/arrays.go
+++ b/internal/transform/state/arrays.go
@@ -1,0 +1,243 @@
+// Package state provides utilities for transforming array structures in Terraform state files
+// during provider migrations.
+package state
+
+import (
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+// ArrayToObjectOptions configures how to transform an array to an object
+type ArrayToObjectOptions struct {
+	SkipFields      []string                                    // Fields to skip when copying
+	FieldTransforms map[string]func(gjson.Result) interface{}  // Custom transformations per field
+	RenameFields    map[string]string                          // Old field name -> new field name
+	DefaultFields   map[string]interface{}                     // Fields to add if not present
+}
+
+// TransformArrayToObject transforms the first element of an array to an object.
+// This is commonly used when provider schema changes from accepting multiple
+// items to only accepting a single configuration object.
+//
+// Example - SRV record data transformation:
+//
+// Before (array format):
+//   {
+//     "data": [
+//       {
+//         "priority": 10,
+//         "weight": 60,
+//         "port": 5060,
+//         "target": "sipserver.example.com"
+//       }
+//     ]
+//   }
+//
+// After calling with options.SkipFields = ["priority"]:
+//   {
+//     "data": {
+//       "weight": 60,
+//       "port": 5060,
+//       "target": "sipserver.example.com"
+//     }
+//   }
+func TransformArrayToObject(data gjson.Result, options ArrayToObjectOptions) map[string]interface{} {
+	obj := make(map[string]interface{})
+	
+	if !data.IsArray() {
+		return obj
+	}
+	
+	array := data.Array()
+	if len(array) == 0 {
+		return obj
+	}
+	
+	firstElem := array[0]
+	firstElem.ForEach(func(key, value gjson.Result) bool {
+		k := key.String()
+		
+		// Skip unwanted fields
+		for _, skip := range options.SkipFields {
+			if k == skip {
+				return true // continue
+			}
+		}
+		
+		// Apply field rename if configured
+		if newName, exists := options.RenameFields[k]; exists {
+			k = newName
+		}
+		
+		// Apply custom transform if exists
+		if transform, exists := options.FieldTransforms[k]; exists {
+			obj[k] = transform(value)
+		} else {
+			obj[k] = ConvertGjsonValue(value)
+		}
+		return true
+	})
+	
+	// Add default fields if they don't exist
+	for field, defaultValue := range options.DefaultFields {
+		if _, exists := obj[field]; !exists {
+			obj[field] = defaultValue
+		}
+	}
+	
+	return obj
+}
+
+// TransformDataFieldArrayToObject handles the common pattern of transforming data field from array to object.
+// This function handles both array and object inputs, applying transformations as needed.
+//
+// Example - CAA record data transformation with field rename and custom transform:
+//
+// Before state JSON:
+//   {
+//     "resources": [{
+//       "instances": [{
+//         "attributes": {
+//           "type": "CAA",
+//           "data": [
+//             {
+//               "flags": "0",           // String that should be number
+//               "tag": "issue",
+//               "content": "letsencrypt.org"  // Should be renamed to "value"
+//             }
+//           ]
+//         }
+//       }]
+//     }]
+//   }
+//
+// After calling with:
+//   options.RenameFields["content"] = "value"
+//   options.FieldTransforms["flags"] = convertToNumber
+//
+// Result:
+//   {
+//     "resources": [{
+//       "instances": [{
+//         "attributes": {
+//           "type": "CAA",
+//           "data": {
+//             "flags": {
+//               "value": 0,
+//               "type": "number"
+//             },
+//             "tag": "issue",
+//             "value": "letsencrypt.org"
+//           }
+//         }
+//       }]
+//     }]
+//   }
+func TransformDataFieldArrayToObject(stateJSON string, path string, instance gjson.Result, recordType string, options ArrayToObjectOptions) string {
+	data := instance.Get("data")
+	
+	if !data.Exists() {
+		// Handle case where data doesn't exist but should
+		if len(options.DefaultFields) > 0 {
+			stateJSON, _ = sjson.Set(stateJSON, path+".data", options.DefaultFields)
+		}
+		return stateJSON
+	}
+	
+	if data.IsArray() {
+		array := data.Array()
+		if len(array) == 0 {
+			// Empty array - remove the data field
+			stateJSON, _ = sjson.Delete(stateJSON, path+".data")
+		} else {
+			// Transform to object
+			obj := TransformArrayToObject(data, options)
+			if len(obj) == 0 {
+				stateJSON, _ = sjson.Delete(stateJSON, path+".data")
+			} else {
+				stateJSON, _ = sjson.Set(stateJSON, path+".data", obj)
+			}
+		}
+	} else if data.IsObject() {
+		// Already an object - apply any necessary transformations
+		obj := make(map[string]interface{})
+		
+		data.ForEach(func(key, value gjson.Result) bool {
+			k := key.String()
+			
+			// Skip unwanted fields
+			for _, skip := range options.SkipFields {
+				if k == skip {
+					return true
+				}
+			}
+			
+			// Apply field rename if configured
+			if newName, exists := options.RenameFields[k]; exists {
+				k = newName
+			}
+			
+			// Apply custom transform if exists
+			if transform, exists := options.FieldTransforms[k]; exists {
+				obj[k] = transform(value)
+			} else {
+				obj[k] = ConvertGjsonValue(value)
+			}
+			return true
+		})
+		
+		// Add default fields if they don't exist
+		for field, defaultValue := range options.DefaultFields {
+			if _, exists := obj[field]; !exists {
+				obj[field] = defaultValue
+			}
+		}
+		
+		if len(obj) == 0 {
+			stateJSON, _ = sjson.Delete(stateJSON, path+".data")
+		} else {
+			stateJSON, _ = sjson.Set(stateJSON, path+".data", obj)
+		}
+	}
+	
+	return stateJSON
+}
+
+// FlattenArrayField flattens an array field with a single element to just the element.
+// This is useful when a field changes from supporting multiple values to a single value.
+//
+// Example - Flattening single-element priority array:
+//
+// Before state JSON:
+//   {
+//     "resources": [{
+//       "instances": [{
+//         "attributes": {
+//           "zone_id": "abc123",
+//           "priority": [10]  // Single-element array
+//         }
+//       }]
+//     }]
+//   }
+//
+// After calling FlattenArrayField(stateJSON, "resources.0.instances.0.attributes.priority", priorityField):
+//   {
+//     "resources": [{
+//       "instances": [{
+//         "attributes": {
+//           "zone_id": "abc123",
+//           "priority": 10  // Flattened to scalar value
+//         }
+//       }]
+//     }]
+//   }
+func FlattenArrayField(stateJSON string, path string, field gjson.Result) string {
+	if field.IsArray() {
+		array := field.Array()
+		if len(array) == 1 {
+			// Single element array - flatten it
+			stateJSON, _ = sjson.Set(stateJSON, path, array[0].Value())
+		}
+	}
+	return stateJSON
+}

--- a/internal/transform/state/fields.go
+++ b/internal/transform/state/fields.go
@@ -1,0 +1,335 @@
+// Package state provides utilities for transforming Terraform state files
+// during provider migrations. These utilities handle JSON manipulation
+// for state file migrations between provider versions.
+package state
+
+import (
+	"encoding/json"
+
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+// EnsureField ensures a field exists in the state with a default value.
+// If the field doesn't exist, it's added with the defaultValue.
+//
+// Example - Adding required TTL field to DNS record state:
+//
+// Before state JSON:
+//   {
+//     "resources": [{
+//       "instances": [{
+//         "attributes": {
+//           "zone_id": "abc123",
+//           "name": "test",
+//           "type": "A",
+//           "content": "192.0.2.1"
+//         }
+//       }]
+//     }]
+//   }
+//
+// After calling EnsureField(stateJSON, "resources.0.instances.0.attributes", instance, "ttl", 1):
+//   {
+//     "resources": [{
+//       "instances": [{
+//         "attributes": {
+//           "zone_id": "abc123",
+//           "name": "test",
+//           "type": "A",
+//           "content": "192.0.2.1",
+//           "ttl": 1
+//         }
+//       }]
+//     }]
+//   }
+func EnsureField(stateJSON string, path string, instance gjson.Result, field string, defaultValue interface{}) string {
+	if !instance.Get(field).Exists() {
+		result, _ := sjson.Set(stateJSON, path+"."+field, defaultValue)
+		return result
+	}
+	return stateJSON
+}
+
+// RenameField renames a field in the state.
+// If both old and new fields exist, the old field is removed (new takes precedence).
+//
+// Example - Renaming 'value' to 'content' in DNS record state:
+//
+// Before state JSON:
+//   {
+//     "resources": [{
+//       "instances": [{
+//         "attributes": {
+//           "zone_id": "abc123",
+//           "name": "test",
+//           "type": "A",
+//           "value": "192.0.2.1"  // Old field name
+//         }
+//       }]
+//     }]
+//   }
+//
+// After calling RenameField(stateJSON, "resources.0.instances.0.attributes", instance, "value", "content"):
+//   {
+//     "resources": [{
+//       "instances": [{
+//         "attributes": {
+//           "zone_id": "abc123",
+//           "name": "test",
+//           "type": "A",
+//           "content": "192.0.2.1"  // New field name
+//         }
+//       }]
+//     }]
+//   }
+func RenameField(stateJSON string, path string, instance gjson.Result, oldName, newName string) string {
+	oldField := instance.Get(oldName)
+	newField := instance.Get(newName)
+	
+	if oldField.Exists() && !newField.Exists() {
+		// Copy old to new
+		stateJSON, _ = sjson.Set(stateJSON, path+"."+newName, oldField.Value())
+		// Delete old
+		stateJSON, _ = sjson.Delete(stateJSON, path+"."+oldName)
+	} else if oldField.Exists() && newField.Exists() {
+		// If both exist, just remove the old one (new takes precedence)
+		stateJSON, _ = sjson.Delete(stateJSON, path+"."+oldName)
+	}
+	
+	return stateJSON
+}
+
+// RemoveFields removes multiple fields from the state.
+//
+// Example - Removing deprecated fields from DNS record state:
+//
+// Before state JSON:
+//   {
+//     "resources": [{
+//       "instances": [{
+//         "attributes": {
+//           "zone_id": "abc123",
+//           "name": "test",
+//           "type": "A",
+//           "content": "192.0.2.1",
+//           "hostname": "test.example.com",  // Deprecated
+//           "allow_overwrite": true,         // Deprecated
+//           "timeouts": {}                    // Deprecated
+//         }
+//       }]
+//     }]
+//   }
+//
+// After calling RemoveFields(stateJSON, path, instance, "hostname", "allow_overwrite", "timeouts"):
+//   {
+//     "resources": [{
+//       "instances": [{
+//         "attributes": {
+//           "zone_id": "abc123",
+//           "name": "test",
+//           "type": "A",
+//           "content": "192.0.2.1"
+//         }
+//       }]
+//     }]
+//   }
+func RemoveFields(stateJSON string, path string, instance gjson.Result, fields ...string) string {
+	for _, field := range fields {
+		if instance.Get(field).Exists() {
+			stateJSON, _ = sjson.Delete(stateJSON, path+"."+field)
+		}
+	}
+	return stateJSON
+}
+
+// CleanupEmptyField removes a field if it's empty or invalid.
+//
+// Example - Cleaning up empty meta field:
+//
+// Before state JSON:
+//   {
+//     "resources": [{
+//       "instances": [{
+//         "attributes": {
+//           "zone_id": "abc123",
+//           "name": "test",
+//           "meta": {},  // Empty object
+//           "settings": []  // Empty array
+//         }
+//       }]
+//     }]
+//   }
+//
+// After calling CleanupEmptyField(stateJSON, "resources.0.instances.0.attributes.meta", metaField):
+//   {
+//     "resources": [{
+//       "instances": [{
+//         "attributes": {
+//           "zone_id": "abc123",
+//           "name": "test",
+//           "settings": []  // meta removed, settings still present
+//         }
+//       }]
+//     }]
+//   }
+func CleanupEmptyField(stateJSON string, path string, field gjson.Result) string {
+	if field.Exists() {
+		// Check various empty conditions
+		if field.String() == "{}" || 
+		   field.String() == "[]" ||
+		   field.String() == "" ||
+		   (field.IsObject() && len(field.Map()) == 0) ||
+		   (field.IsArray() && len(field.Array()) == 0) {
+			stateJSON, _ = sjson.Delete(stateJSON, path)
+		}
+	}
+	return stateJSON
+}
+
+// RemoveObjectIfAllNull removes an object if all specified fields are null.
+//
+// Example - Removing settings object with all null values:
+//
+// Before state JSON:
+//   {
+//     "resources": [{
+//       "instances": [{
+//         "attributes": {
+//           "zone_id": "abc123",
+//           "name": "test",
+//           "settings": {
+//             "flatten_cname": null,
+//             "ipv4_only": null,
+//             "ipv6_only": null
+//           }
+//         }
+//       }]
+//     }]
+//   }
+//
+// After calling RemoveObjectIfAllNull(stateJSON, path+".settings", settingsObj, []string{"flatten_cname", "ipv4_only", "ipv6_only"}):
+//   {
+//     "resources": [{
+//       "instances": [{
+//         "attributes": {
+//           "zone_id": "abc123",
+//           "name": "test"
+//           // settings removed because all fields were null
+//         }
+//       }]
+//     }]
+//   }
+func RemoveObjectIfAllNull(stateJSON string, path string, obj gjson.Result, fields []string) string {
+	if !obj.Exists() {
+		return stateJSON
+	}
+	
+	allNull := true
+	for _, field := range fields {
+		val := obj.Get(field)
+		if val.Exists() && val.Type != gjson.Null && val.Value() != nil {
+			allNull = false
+			break
+		}
+	}
+	
+	if allNull {
+		stateJSON, _ = sjson.Delete(stateJSON, path)
+	}
+	return stateJSON
+}
+
+// EnsureTimestamps ensures created_on and modified_on fields exist with defaults.
+// If created_on exists, modified_on defaults to the same value.
+//
+// Example - Adding timestamps to DNS record:
+//
+// Before state JSON:
+//   {
+//     "resources": [{
+//       "instances": [{
+//         "attributes": {
+//           "zone_id": "abc123",
+//           "name": "test",
+//           "type": "A",
+//           "content": "192.0.2.1"
+//         }
+//       }]
+//     }]
+//   }
+//
+// After calling EnsureTimestamps(stateJSON, path, instance, "2024-01-01T00:00:00Z"):
+//   {
+//     "resources": [{
+//       "instances": [{
+//         "attributes": {
+//           "zone_id": "abc123",
+//           "name": "test",
+//           "type": "A",
+//           "content": "192.0.2.1",
+//           "created_on": "2024-01-01T00:00:00Z",
+//           "modified_on": "2024-01-01T00:00:00Z"
+//         }
+//       }]
+//     }]
+//   }
+func EnsureTimestamps(stateJSON string, path string, instance gjson.Result, defaultTime string) string {
+	createdOn := instance.Get("created_on")
+	if !createdOn.Exists() {
+		stateJSON, _ = sjson.Set(stateJSON, path+".created_on", defaultTime)
+	}
+	
+	modifiedOn := instance.Get("modified_on")
+	if !modifiedOn.Exists() {
+		if createdOn.Exists() {
+			stateJSON, _ = sjson.Set(stateJSON, path+".modified_on", createdOn.String())
+		} else {
+			stateJSON, _ = sjson.Set(stateJSON, path+".modified_on", defaultTime)
+		}
+	}
+	
+	return stateJSON
+}
+
+// ConvertGjsonValue converts a gjson value to appropriate Go type
+func ConvertGjsonValue(value gjson.Result) interface{} {
+	switch value.Type {
+	case gjson.Number:
+		// Check if it's an integer or float
+		if value.Float() == float64(int64(value.Float())) {
+			return int64(value.Float())
+		}
+		return value.Float()
+	case gjson.String:
+		return value.String()
+	case gjson.True:
+		return true
+	case gjson.False:
+		return false
+	case gjson.Null:
+		return nil
+	default:
+		// For arrays and objects, return the raw value
+		return value.Value()
+	}
+}
+
+// ConvertGjsonToJSON converts gjson value preserving number types
+func ConvertGjsonToJSON(value gjson.Result) interface{} {
+	switch value.Type {
+	case gjson.Number:
+		// Preserve as json.Number to maintain exact numeric representation
+		return json.Number(value.Raw)
+	case gjson.String:
+		return value.String()
+	case gjson.True:
+		return true
+	case gjson.False:
+		return false
+	case gjson.Null:
+		return nil
+	default:
+		return value.Value()
+	}
+}

--- a/internal/transform/transformer.go
+++ b/internal/transform/transformer.go
@@ -8,13 +8,15 @@ import (
 
 // Context carries data through the transformation pipeline
 type Context struct {
-	Content     []byte
-	Filename    string
-	AST         *hclwrite.File
-	StateJSON   string
-	Diagnostics hcl.Diagnostics
-	Metadata    map[string]interface{}
-	DryRun      bool
+	Content       []byte
+	Filename      string
+	AST           *hclwrite.File
+	StateJSON     string
+	Diagnostics   hcl.Diagnostics
+	Metadata      map[string]interface{}
+	DryRun        bool
+	SourceVersion string // Source provider version (e.g., "v4")
+	TargetVersion string // Target provider version (e.g., "v5")
 }
 
 // TransformResult represents the result of a resource transformation
@@ -44,18 +46,18 @@ type ResourceTransformer interface {
 // a migrator defines the strategy which a resource uses to migrate the resource
 // from a source version to target version
 type Provider interface {
-	GetMigrator(resourceType string) ResourceTransformer
-	GetAllMigrators() []ResourceTransformer
+	GetMigrator(resourceType string, sourceVersion string, targetVersion string) ResourceTransformer
+	GetAllMigrators(sourceVersion string, targetVersion string) []ResourceTransformer
 }
 
 type DefaultMigratorProvider struct {
-	getFunc    func(string) ResourceTransformer
-	getAllFunc func() []ResourceTransformer
+	getFunc    func(string, string, string) ResourceTransformer
+	getAllFunc func(string, string) []ResourceTransformer
 }
 
 func NewMigratorProvider(
-	getFunc func(string) ResourceTransformer,
-	getAllFunc func() []ResourceTransformer,
+	getFunc func(string, string, string) ResourceTransformer,
+	getAllFunc func(string, string) []ResourceTransformer,
 ) Provider {
 	return &DefaultMigratorProvider{
 		getFunc:    getFunc,
@@ -63,16 +65,16 @@ func NewMigratorProvider(
 	}
 }
 
-func (p *DefaultMigratorProvider) GetMigrator(resourceType string) ResourceTransformer {
+func (p *DefaultMigratorProvider) GetMigrator(resourceType string, sourceVersion string, targetVersion string) ResourceTransformer {
 	if p.getFunc != nil {
-		return p.getFunc(resourceType)
+		return p.getFunc(resourceType, sourceVersion, targetVersion)
 	}
 	return nil
 }
 
-func (p *DefaultMigratorProvider) GetAllMigrators() []ResourceTransformer {
+func (p *DefaultMigratorProvider) GetAllMigrators(sourceVersion string, targetVersion string) []ResourceTransformer {
 	if p.getAllFunc != nil {
-		return p.getAllFunc()
+		return p.getAllFunc(sourceVersion, targetVersion)
 	}
 	return []ResourceTransformer{}
 }


### PR DESCRIPTION
 🚀 Add migration for DNS Record resource

  Overview

  DNS Record Test Improvements 🧪

  - Test Cleanup (internal/resources/dns_record/v4_to_v5_test.go)
    - Removed ~400 lines of redundant test code
    - Consolidated from 43 tests to 30 tests (33% reduction)
    - Merged tests from v4_to_v5_additional_test.go into main test file
    - Removed duplicate CAA tests and value→content rename tests
    - Coverage improved: 94.4% → 96%


  Testing

  # Run all tests
  go test ./...

  # Check DNS record coverage (96%)
  go test ./internal/resources/dns_record/... -cover

  Migration Path for Future Versions

  Adding support for new versions is now straightforward:
  // Register v5→v6 migrator
  internal.RegisterVersioned("cloudflare_dns_record", "v5", "v6", NewV5ToV6Migrator)