### PR TITLE
fix: fix dns_record due to failing provider tests

### DIFF
--- a/integration/v4_to_v5/testdata/dns_record/expected/dns_record.tf
+++ b/integration/v4_to_v5/testdata/dns_record/expected/dns_record.tf
@@ -51,9 +51,10 @@ resource "cloudflare_dns_record" "example_srv" {
   ttl      = 1
   priority = 5
   data = {
-    weight = 10
-    port   = 5060
-    target = "sip.example.com"
+    priority = 5
+    weight   = 10
+    port     = 5060
+    target   = "sip.example.com"
   }
 }
 

--- a/integration/v4_to_v5/testdata/dns_record/expected/terraform.tfstate
+++ b/integration/v4_to_v5/testdata/dns_record/expected/terraform.tfstate
@@ -111,6 +111,7 @@
             "created_on": "2024-01-01T00:00:00Z",
             "data": {
               "port": 5060,
+              "priority": 5,
               "target": "sip.example.com",
               "weight": 10
             },

--- a/internal/resources/dns_record/v4_to_v5.go
+++ b/internal/resources/dns_record/v4_to_v5.go
@@ -5,23 +5,31 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/cloudflare/tf-migrate/internal"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/hashicorp/hcl/v2/hclwrite"
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
 
+	"github.com/cloudflare/tf-migrate/internal"
+
 	"github.com/cloudflare/tf-migrate/internal/transform"
 	tfhcl "github.com/cloudflare/tf-migrate/internal/transform/hcl"
 	"github.com/cloudflare/tf-migrate/internal/transform/state"
+	"github.com/cloudflare/tf-migrate/internal/transform/structural"
 )
 
 // V4ToV5Migrator handles migration of DNS record resources from v4 to v5
 type V4ToV5Migrator struct {
+	typeUpdater *structural.ResourceTypeUpdater
 }
 
 func NewV4ToV5Migrator() transform.ResourceTransformer {
-	migrator := &V4ToV5Migrator{}
+	migrator := &V4ToV5Migrator{
+		typeUpdater: &structural.ResourceTypeUpdater{
+			OldType: "cloudflare_record",
+			NewType: "cloudflare_dns_record",
+		},
+	}
 	internal.RegisterMigrator("cloudflare_record", "v4", "v5", migrator)
 	return migrator
 }
@@ -82,7 +90,8 @@ func (m *V4ToV5Migrator) TransformConfig(ctx *transform.Context, block *hclwrite
 func (m *V4ToV5Migrator) processDataBlocks(block *hclwrite.Block, recordType string) {
 	body := block.Body()
 
-	// For SRV, MX, and URI records, hoist priority from data block
+	// For SRV, MX, and URI records, hoist priority from data block to root
+	// Note: SRV will keep priority in BOTH places (root and data)
 	if recordType == "SRV" || recordType == "MX" || recordType == "URI" {
 		tfhcl.HoistAttributeFromBlock(body, "data", "priority")
 	}
@@ -94,10 +103,12 @@ func (m *V4ToV5Migrator) processDataBlocks(block *hclwrite.Block, recordType str
 			tfhcl.RenameAttribute(dataBlock.Body(), "content", "value")
 			// In v5, flags format is preserved as-is (string stays string, number stays number)
 		}
-		// Remove priority from data block for SRV/MX/URI since it's hoisted
-		if recordType == "SRV" || recordType == "MX" || recordType == "URI" {
+		// Remove priority from data block for MX/URI since it's hoisted to root only
+		// SRV keeps priority in BOTH the data block AND root
+		if recordType == "MX" || recordType == "URI" {
 			dataBlock.Body().RemoveAttribute("priority")
 		}
+		// Note: For SRV, we do NOT remove priority from data block
 	})
 }
 
@@ -159,6 +170,9 @@ func (m *V4ToV5Migrator) TransformState(ctx *transform.Context, stateJSON gjson.
 
 	// Transform the single instance
 	result = m.transformSingleDNSInstance(result, stateJSON)
+	
+	// Ensure schema_version is set to 0 for v5
+	result, _ = sjson.Set(result, "schema_version", 0)
 
 	return result, nil
 }
@@ -198,10 +212,17 @@ func (m *V4ToV5Migrator) transformFullState(result string, stateJSON gjson.Resul
 				instJSON := instance.String()
 				// Transform it
 				transformedInst := m.transformSingleDNSInstance(instJSON, instance)
-				// Parse the transformed instance
-				transformedInstParsed := gjson.Parse(transformedInst)
+				
+				// Ensure schema_version is set to 0 for v5
+				transformedInst, _ = sjson.Set(transformedInst, "schema_version", 0)
+				
 				// Update the result with the transformed instance
-				result, _ = sjson.SetRaw(result, instPath, transformedInstParsed.Raw)
+				// Using the raw JSON string directly to preserve all fields including schema_version
+				result, _ = sjson.SetRaw(result, instPath, transformedInst)
+			} else {
+				// Even if attributes don't exist or are incomplete, update schema_version
+				schemaPath := instPath + ".schema_version"
+				result, _ = sjson.Set(result, schemaPath, 0)
 			}
 			return true
 		})
@@ -228,19 +249,31 @@ func (m *V4ToV5Migrator) transformSingleDNSInstance(result string, instance gjso
 	result = state.EnsureTimestamps(result, "attributes", attrs, "2024-01-01T00:00:00Z")
 
 	// Handle field renames: value -> content
-	// If both exist, keep content and remove value
-	// If only value exists, rename it to content
+	// But only for record types that use content (not data)
 	recordType := instance.Get("attributes.type").String()
 	valueField := attrs.Get("value")
 	contentField := attrs.Get("content")
+	
+	// Records that use data field don't have content
+	usesDataField := recordType == "SRV" || recordType == "CAA" || 
+		recordType == "CERT" || recordType == "DNSKEY" || recordType == "DS" ||
+		recordType == "LOC" || recordType == "NAPTR" || recordType == "SMIMEA" ||
+		recordType == "SSHFP" || recordType == "SVCB" || recordType == "HTTPS" ||
+		recordType == "TLSA" || recordType == "URI"
 
-	if valueField.Exists() && !contentField.Exists() {
-		// Only value exists - rename it to content
-		result, _ = sjson.Set(result, "attributes.content", valueField.Value())
+	if !usesDataField {
+		if valueField.Exists() && !contentField.Exists() {
+			// Only value exists - rename it to content
+			result, _ = sjson.Set(result, "attributes.content", valueField.Value())
+			result, _ = sjson.Delete(result, "attributes.value")
+		} else if valueField.Exists() && contentField.Exists() {
+			// Both exist - keep content, remove value
+			result, _ = sjson.Delete(result, "attributes.value")
+		}
+	} else {
+		// For records that use data field, remove both value and content if they exist
 		result, _ = sjson.Delete(result, "attributes.value")
-	} else if valueField.Exists() && contentField.Exists() {
-		// Both exist - keep content, remove value
-		result, _ = sjson.Delete(result, "attributes.value")
+		result, _ = sjson.Delete(result, "attributes.content")
 	}
 
 	// Ensure TTL is present
@@ -256,7 +289,7 @@ func (m *V4ToV5Migrator) transformSingleDNSInstance(result string, instance gjso
 	// Convert priority field to float64 if it exists at root level
 	rootPriority := instance.Get("attributes.priority")
 	if rootPriority.Exists() && rootPriority.Type == gjson.Number {
-		result, _ = sjson.Set(result, "attributes.priority", rootPriority.Float())
+		result, _ = sjson.Set(result, "attributes.priority", state.ConvertToFloat64(rootPriority))
 	}
 
 	return result
@@ -316,8 +349,9 @@ func (m *V4ToV5Migrator) transformDataFieldForInstance(result string, instance g
 		options.DefaultFields["flags"] = nil
 	}
 
-	// For SRV, MX and URI, skip priority field in data as it will be hoisted
-	if recordType == "SRV" || recordType == "MX" || recordType == "URI" {
+	// For MX and URI, skip priority field in data as it will be hoisted
+	// SRV keeps priority in the data field
+	if recordType == "MX" || recordType == "URI" {
 		options.SkipFields = append(options.SkipFields, "priority")
 	}
 
@@ -355,32 +389,50 @@ func (m *V4ToV5Migrator) transformDataFieldForInstance(result string, instance g
 		}
 	}
 
-	// For SRV, MX and URI records, ensure priority is at root level and generate content
+	// For SRV, MX and URI records, ensure priority is at root level
 	if recordType == "SRV" || recordType == "MX" || recordType == "URI" {
-		dataArray := instance.Get("attributes.data")
-		if dataArray.IsArray() {
-			array := dataArray.Array()
-			if len(array) > 0 {
-				priority := array[0].Get("priority")
-				if priority.Exists() {
-					// Convert priority to float64 for v5 compatibility
-					result, _ = sjson.Set(result, "attributes.priority", priority.Float())
-				}
-
-				// Generate content field for MX records
-				if recordType == "MX" {
-					target := array[0].Get("target")
-					if priority.Exists() && target.Exists() {
-						content := fmt.Sprintf("%v %s", priority.Value(), target.String())
-						result, _ = sjson.Set(result, "attributes.content", content)
+		// Check original instance for priority (before transformation)
+		originalPriority := instance.Get("attributes.priority")
+		
+		if originalPriority.Exists() {
+			// Preserve the original priority at root level
+			result, _ = sjson.Set(result, "attributes.priority", originalPriority.Float())
+		} else {
+			// If not at root in original, check data array
+			dataArray := instance.Get("attributes.data")
+			if dataArray.IsArray() {
+				array := dataArray.Array()
+				if len(array) > 0 {
+					priority := array[0].Get("priority")
+					if priority.Exists() {
+						// Set priority at root level for v5 compatibility
+						result, _ = sjson.Set(result, "attributes.priority", priority.Float())
 					}
-				} else if recordType == "URI" {
-					// Generate content for URI records
-					weight := array[0].Get("weight")
-					target := array[0].Get("target")
-					if priority.Exists() && weight.Exists() && target.Exists() {
-						content := fmt.Sprintf("%v %v %s", priority.Value(), weight.Value(), target.String())
-						result, _ = sjson.Set(result, "attributes.content", content)
+				}
+			}
+		}
+		
+		// Generate content field for MX and URI records (not SRV)
+		if recordType == "MX" || recordType == "URI" {
+			dataArray := instance.Get("attributes.data")
+			if dataArray.IsArray() {
+				array := dataArray.Array()
+				if len(array) > 0 {
+					priority := array[0].Get("priority")
+					
+					if recordType == "MX" {
+						target := array[0].Get("target")
+						if priority.Exists() && target.Exists() {
+							content := fmt.Sprintf("%v %s", priority.Value(), target.String())
+							result, _ = sjson.Set(result, "attributes.content", content)
+						}
+					} else if recordType == "URI" {
+						weight := array[0].Get("weight")
+						target := array[0].Get("target")
+						if priority.Exists() && weight.Exists() && target.Exists() {
+							content := fmt.Sprintf("%v %v %s", priority.Value(), weight.Value(), target.String())
+							result, _ = sjson.Set(result, "attributes.content", content)
+						}
 					}
 				}
 			}

--- a/internal/resources/dns_record/v4_to_v5_test.go
+++ b/internal/resources/dns_record/v4_to_v5_test.go
@@ -377,7 +377,8 @@ resource "cloudflare_record" "pgp" {
 								"tag": "issue",
 								"content": "letsencrypt.org"
 							}]
-						}
+						},
+						"schema_version": 0
 					}]
 				}]
 			}`,
@@ -405,7 +406,8 @@ resource "cloudflare_record" "pgp" {
 								"tag": "issue",
 								"value": "letsencrypt.org"
 							}
-						}
+						},
+						"schema_version": 0
 					}]
 				}]
 			}`,
@@ -425,7 +427,8 @@ resource "cloudflare_record" "pgp" {
 							"type": "A",
 							"content": "192.168.1.1",
 							"data": []
-						}
+						},
+						"schema_version": 0
 					}]
 				}]
 			}`,
@@ -444,7 +447,53 @@ resource "cloudflare_record" "pgp" {
 							"content": "192.168.1.1",
 							"created_on": "2024-01-01T00:00:00Z",
 							"modified_on": "2024-01-01T00:00:00Z"
-						}
+						},
+						"schema_version": 0
+					}]
+				}]
+			}`,
+			},
+			{
+				Name: "Schema version should be updated from v4 (3) to v5 (0)",
+				Input: `{
+				"version": 4,
+				"terraform_version": "1.5.0",
+				"resources": [{
+					"type": "cloudflare_record",
+					"name": "test",
+					"instances": [{
+						"schema_version": 3,
+						"attributes": {
+							"id": "test-id",
+							"zone_id": "test-zone",
+							"name": "test",
+							"type": "A",
+							"value": "192.168.1.1",
+							"ttl": 300
+						},
+						"schema_version": 0
+					}]
+				}]
+			}`,
+				Expected: `{
+				"version": 4,
+				"terraform_version": "1.5.0",
+				"resources": [{
+					"type": "cloudflare_dns_record",
+					"name": "test",
+					"instances": [{
+						"schema_version": 0,
+						"attributes": {
+							"id": "test-id",
+							"zone_id": "test-zone",
+							"name": "test",
+							"type": "A",
+							"content": "192.168.1.1",
+							"ttl": 300,
+							"created_on": "2024-01-01T00:00:00Z",
+							"modified_on": "2024-01-01T00:00:00Z"
+						},
+						"schema_version": 0
 					}]
 				}]
 			}`,
@@ -468,7 +517,8 @@ resource "cloudflare_record" "pgp" {
 								"tag": "issue",
 								"content": "letsencrypt.org"
 							}]
-						}
+						},
+						"schema_version": 0
 					}]
 				}]
 			}`,
@@ -495,7 +545,8 @@ resource "cloudflare_record" "pgp" {
 								"tag": "issue",
 								"value": "letsencrypt.org"
 							}
-						}
+						},
+						"schema_version": 0
 					}]
 				}]
 			}`,
@@ -516,7 +567,8 @@ resource "cloudflare_record" "pgp" {
 							"value": "192.168.1.1",
 							"hostname": "test.example.com",
 							"allow_overwrite": true
-						}
+						},
+						"schema_version": 0
 					}]
 				}]
 			}`,
@@ -535,7 +587,8 @@ resource "cloudflare_record" "pgp" {
 							"content": "192.168.1.1",
 							"created_on": "2024-01-01T00:00:00Z",
 							"modified_on": "2024-01-01T00:00:00Z"
-						}
+						},
+						"schema_version": 0
 					}]
 				}]
 			}`,
@@ -559,7 +612,8 @@ resource "cloudflare_record" "pgp" {
 								"port": 5060,
 								"target": "sipserver.example.com"
 							}]
-						}
+						},
+						"schema_version": 0
 					}]
 				}]
 			}`,
@@ -579,11 +633,13 @@ resource "cloudflare_record" "pgp" {
 							"created_on": "2024-01-01T00:00:00Z",
 							"modified_on": "2024-01-01T00:00:00Z",
 							"data": {
+								"priority": 10,
 								"weight": 60,
 								"port": 5060,
 								"target": "sipserver.example.com"
 							}
-						}
+						},
+						"schema_version": 0
 					}]
 				}]
 			}`,
@@ -605,7 +661,8 @@ resource "cloudflare_record" "pgp" {
 						"type": "cloudflare_dns_record",
 						"name": "invalid",
 						"instances": [{
-							"attributes": {}
+							"attributes": {},
+							"schema_version": 0
 						}]
 					}]
 				}`,
@@ -665,7 +722,8 @@ resource "cloudflare_record" "pgp" {
 								"ttl": 1,
 								"created_on": "2024-01-01T00:00:00Z",
 								"modified_on": "2024-01-01T00:00:00Z"
-							}
+							},
+							"schema_version": 0
 						}]
 					}]
 				}`,
@@ -710,7 +768,8 @@ resource "cloudflare_record" "pgp" {
 								"ttl": 1,
 								"created_on": "2024-01-01T00:00:00Z",
 								"modified_on": "2024-01-01T00:00:00Z"
-							}
+							},
+							"schema_version": 0
 						}]
 					}]
 				}`,
@@ -758,7 +817,8 @@ resource "cloudflare_record" "pgp" {
 								"ttl": 1,
 								"created_on": "2024-01-01T00:00:00Z",
 								"modified_on": "2024-01-01T00:00:00Z"
-							}
+							},
+							"schema_version": 0
 						}]
 					}]
 				}`,
@@ -803,7 +863,8 @@ resource "cloudflare_record" "pgp" {
 								"ttl": 1,
 								"created_on": "2024-01-01T00:00:00Z",
 								"modified_on": "2024-01-01T00:00:00Z"
-							}
+							},
+							"schema_version": 0
 						}]
 					}]
 				}`,
@@ -851,7 +912,8 @@ resource "cloudflare_record" "pgp" {
 								"ttl": 1,
 								"created_on": "2024-01-01T00:00:00Z",
 								"modified_on": "2024-01-01T00:00:00Z"
-							}
+							},
+							"schema_version": 0
 						}]
 					}]
 				}`,
@@ -896,7 +958,8 @@ resource "cloudflare_record" "pgp" {
 								"ttl": 1,
 								"created_on": "2024-01-01T00:00:00Z",
 								"modified_on": "2024-01-01T00:00:00Z"
-							}
+							},
+							"schema_version": 0
 						}]
 					}]
 				}`,
@@ -940,7 +1003,8 @@ resource "cloudflare_record" "pgp" {
 								"ttl": 1,
 								"created_on": "2023-01-01T00:00:00Z",
 								"modified_on": "2023-01-01T00:00:00Z"
-							}
+							},
+							"schema_version": 0
 						}]
 					}]
 				}`,
@@ -975,7 +1039,8 @@ resource "cloudflare_record" "pgp" {
 								"ttl": 1,
 								"created_on": "2024-01-01T00:00:00Z",
 								"modified_on": "2024-01-01T00:00:00Z"
-							}
+							},
+							"schema_version": 0
 						}]
 					}]
 				}`,
@@ -1011,7 +1076,8 @@ resource "cloudflare_record" "pgp" {
 								"ttl": 1,
 								"created_on": "2024-01-01T00:00:00Z",
 								"modified_on": "2024-01-01T00:00:00Z"
-							}
+							},
+							"schema_version": 0
 						}]
 					}]
 				}`,
@@ -1048,6 +1114,7 @@ resource "cloudflare_record" "pgp" {
 								"type": "SRV",
 								"priority": 10,
 								"data": {
+									"priority": 10,
 									"weight": 60,
 									"port": 5060,
 									"target": "sipserver.example.com"
@@ -1055,7 +1122,8 @@ resource "cloudflare_record" "pgp" {
 								"ttl": 1,
 								"created_on": "2024-01-01T00:00:00Z",
 								"modified_on": "2024-01-01T00:00:00Z"
-							}
+							},
+							"schema_version": 0
 						}]
 					}]
 				}`,
@@ -1099,7 +1167,8 @@ resource "cloudflare_record" "pgp" {
 								"ttl": 1,
 								"created_on": "2024-01-01T00:00:00Z",
 								"modified_on": "2024-01-01T00:00:00Z"
-							}
+							},
+							"schema_version": 0
 						}]
 					}]
 				}`,

--- a/internal/transform/state/type_converters.go
+++ b/internal/transform/state/type_converters.go
@@ -1,0 +1,36 @@
+package state
+
+import (
+	"strconv"
+
+	"github.com/tidwall/gjson"
+)
+
+// ConvertToFloat64 converts a value to float64, handling various input types.
+// Returns nil for null/invalid values.
+//
+// Before → After transformations:
+//
+//	42 (json.Number)     → 42.0 (float64)
+//	"123" (string)       → 123.0 (float64)
+//	"hello" (string)     → "hello" (unchanged, not numeric)
+//	null                 → nil
+//
+// Essential for v4→v5 migrations where TypeInt becomes Float64Attribute.
+func ConvertToFloat64(value gjson.Result) interface{} {
+	switch value.Type {
+	case gjson.Number:
+		return value.Float()
+	case gjson.String:
+		// Try to parse string as number
+		if f, err := strconv.ParseFloat(value.String(), 64); err == nil {
+			return f
+		}
+		// Return as-is if not a number
+		return value.String()
+	case gjson.Null:
+		return nil
+	default:
+		return value.Value()
+	}
+}

--- a/internal/transform/state/type_converters_test.go
+++ b/internal/transform/state/type_converters_test.go
@@ -1,0 +1,52 @@
+package state
+
+import (
+	"testing"
+
+	"github.com/tidwall/gjson"
+)
+
+func TestConvertToFloat64(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected interface{}
+	}{
+		{
+			name:     "integer number",
+			input:    `42`,
+			expected: 42.0,
+		},
+		{
+			name:     "float number",
+			input:    `42.5`,
+			expected: 42.5,
+		},
+		{
+			name:     "string number",
+			input:    `"123"`,
+			expected: 123.0,
+		},
+		{
+			name:     "non-numeric string",
+			input:    `"hello"`,
+			expected: "hello",
+		},
+		{
+			name:     "null value",
+			input:    `null`,
+			expected: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			value := gjson.Parse(tt.input)
+			result := ConvertToFloat64(value)
+			
+			if result != tt.expected {
+				t.Errorf("ConvertToFloat64() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}

--- a/internal/transform/structural/state_transforms.go
+++ b/internal/transform/structural/state_transforms.go
@@ -1,0 +1,21 @@
+package structural
+
+import (
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+// ResourceTypeUpdater updates resource types in state
+type ResourceTypeUpdater struct {
+	OldType string
+	NewType string
+}
+
+// UpdateResourceType changes the resource type in state
+func (u *ResourceTypeUpdater) UpdateResourceType(stateJSON string) (string, error) {
+	resourceType := gjson.Get(stateJSON, "type").String()
+	if resourceType == u.OldType {
+		return sjson.Set(stateJSON, "type", u.NewType)
+	}
+	return stateJSON, nil
+}

--- a/internal/transform/structural/state_transforms_test.go
+++ b/internal/transform/structural/state_transforms_test.go
@@ -1,0 +1,50 @@
+package structural
+
+import (
+	"testing"
+	"github.com/tidwall/gjson"
+)
+
+func TestResourceTypeUpdater(t *testing.T) {
+	updater := ResourceTypeUpdater{
+		OldType: "cloudflare_teams_list",
+		NewType: "cloudflare_zero_trust_list",
+	}
+	
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name: "Update matching type",
+			input: `{
+				"type": "cloudflare_teams_list",
+				"name": "test"
+			}`,
+			expected: "cloudflare_zero_trust_list",
+		},
+		{
+			name: "Skip non-matching type",
+			input: `{
+				"type": "cloudflare_other",
+				"name": "test"
+			}`,
+			expected: "cloudflare_other",
+		},
+	}
+	
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := updater.UpdateResourceType(tt.input)
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+			
+			resultType := gjson.Get(result, "type").String()
+			if resultType != tt.expected {
+				t.Errorf("Expected type %s, got %s", tt.expected, resultType)
+			}
+		})
+	}
+}


### PR DESCRIPTION
I aligned dns record resource migration after integrating with migration tests in the tf provider: https://github.com/cloudflare/terraform-provider-cloudflare/pull/6396 

Also added reusable transformations. Some of them are not used by dns record, but will be used by upcoming zero trust list resource.