### PR TITLE
feat: v4 to v5 migration for zero trust access service token

### DIFF
--- a/integration/v4_to_v5/integration_test.go
+++ b/integration/v4_to_v5/integration_test.go
@@ -43,14 +43,19 @@ func TestV4ToV5Migration(t *testing.T) {
 			Resource:    "account_member",
 		},
 		{
+			Name:        "APIToken",
+			Description: "Migrate cloudflare_api_token policy blocks to policies list",
+			Resource:    "api_token",
+		},
+		{
 			Name:        "DNSRecord",
 			Description: "Migrate cloudflare_record to cloudflare_dns_record",
 			Resource:    "dns_record",
 		},
 		{
-			Name:        "APIToken",
-			Description: "Migrate cloudflare_api_token policy blocks to policies list",
-			Resource:    "api_token",
+			Name:        "ZeroTrustAccessServiceToken",
+			Description: "Migrate zero_trust_access_service_token to zero_trust_access_service_token v5",
+			Resource:    "zero_trust_access_service_token",
 		},
 		{
 			Name:        "ZeroTrustList",

--- a/integration/v4_to_v5/testdata/zero_trust_access_service_token/expected/terraform.tfstate
+++ b/integration/v4_to_v5/testdata/zero_trust_access_service_token/expected/terraform.tfstate
@@ -1,0 +1,108 @@
+{
+  "version": 4,
+  "terraform_version": "1.15.0",
+  "serial": 7,
+  "lineage": "711dca58-1045-8360-2b93-c9a8646b64cc",
+  "outputs": {},
+  "resources": [
+    {
+      "mode": "managed",
+      "type": "cloudflare_zero_trust_access_service_token",
+      "name": "basic_token_legacy",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "client_id": "123456.access",
+            "client_secret": "123456",
+            "client_secret_version": 2.0,
+            "duration": "8760h",
+            "expires_at": "2026-10-31T16:42:49Z",
+            "id": "a3689b90-4fd8-4655-8444-faa0446287ed",
+            "name": "basic_token_legacy",
+            "previous_client_secret_expires_at": "2024-12-31T23:59:59Z",
+            "zone_id": null
+          },
+          "sensitive_attributes": [
+            [
+              {
+                "type": "get_attr",
+                "value": "client_secret"
+              }
+            ]
+          ],
+          "identity_schema_version": 0,
+          "private": "bnVsbA=="
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_zero_trust_access_service_token",
+      "name": "basic_token",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "client_id": "123456.access",
+            "client_secret": "123456",
+            "client_secret_version": 2.0,
+            "duration": "8760h",
+            "expires_at": "2026-10-31T16:42:49Z",
+            "id": "89500dab-f7ac-4a1d-9157-b43a78429292",
+            "name": "basic_token",
+            "previous_client_secret_expires_at": "2024-12-31T23:59:59Z",
+            "zone_id": null
+          },
+          "sensitive_attributes": [
+            [
+              {
+                "type": "get_attr",
+                "value": "client_secret"
+              }
+            ]
+          ],
+          "identity_schema_version": 0,
+          "private": "bnVsbA=="
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_zero_trust_access_service_token",
+      "name": "basic_token_no_client_secret_version",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "client_id": "123456.access",
+            "client_secret_version": 1.0,
+            "duration": "8760h",
+            "expires_at": "2026-10-31T16:42:49Z",
+            "id": "89500dab-f7ac-4a1d-9157-b43a78429292",
+            "name": "basic_token",
+            "previous_client_secret_expires_at": "2024-12-31T23:59:59Z",
+            "zone_id": null
+          },
+          "sensitive_attributes": [
+            [
+              {
+                "type": "get_attr",
+                "value": "client_secret"
+              }
+            ]
+          ],
+          "identity_schema_version": 0,
+          "private": "bnVsbA=="
+        }
+      ]
+    }
+  ],
+  "check_results": null
+}

--- a/integration/v4_to_v5/testdata/zero_trust_access_service_token/expected/zero_trust_access_service_token.tf
+++ b/integration/v4_to_v5/testdata/zero_trust_access_service_token/expected/zero_trust_access_service_token.tf
@@ -1,0 +1,18 @@
+# Test Case 1: Basic access service token with all fields
+resource "cloudflare_zero_trust_access_service_token" "basic_token" {
+  account_id                        = "f037e56e89293a057740de681ac9abbe"
+  name                              = "basic_token"
+  duration                          = "8760h"
+  client_secret_version             = 2
+  previous_client_secret_expires_at = "2024-12-31T23:59:59Z"
+}
+
+# Test Case 2: Legacy access service token name
+resource "cloudflare_zero_trust_access_service_token" "basic_token_legacy" {
+  account_id                        = "f037e56e89293a057740de681ac9abbe"
+  name                              = "basic_token_legacy"
+  duration                          = "8760h"
+  client_secret_version             = 2
+  previous_client_secret_expires_at = "2024-12-31T23:59:59Z"
+}
+

--- a/integration/v4_to_v5/testdata/zero_trust_access_service_token/input/terraform.tfstate
+++ b/integration/v4_to_v5/testdata/zero_trust_access_service_token/input/terraform.tfstate
@@ -1,0 +1,109 @@
+{
+  "version": 4,
+  "terraform_version": "1.15.0",
+  "serial": 7,
+  "lineage": "711dca58-1045-8360-2b93-c9a8646b64cc",
+  "outputs": {},
+  "resources": [
+    {
+      "mode": "managed",
+      "type": "cloudflare_access_service_token",
+      "name": "basic_token_legacy",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "client_id": "123456.access",
+            "client_secret": "123456",
+            "client_secret_version": 2,
+            "duration": "8760h",
+            "expires_at": "2026-10-31T16:42:49Z",
+            "id": "a3689b90-4fd8-4655-8444-faa0446287ed",
+            "min_days_for_renewal": 30,
+            "name": "basic_token_legacy",
+            "previous_client_secret_expires_at": "2024-12-31T23:59:59Z",
+            "zone_id": null
+          },
+          "sensitive_attributes": [
+            [
+              {
+                "type": "get_attr",
+                "value": "client_secret"
+              }
+            ]
+          ],
+          "identity_schema_version": 0,
+          "private": "bnVsbA=="
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_zero_trust_access_service_token",
+      "name": "basic_token",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "client_id": "123456.access",
+            "client_secret": "123456",
+            "client_secret_version": 2,
+            "duration": "8760h",
+            "expires_at": "2026-10-31T16:42:49Z",
+            "id": "89500dab-f7ac-4a1d-9157-b43a78429292",
+            "min_days_for_renewal": 30,
+            "name": "basic_token",
+            "previous_client_secret_expires_at": "2024-12-31T23:59:59Z",
+            "zone_id": null
+          },
+          "sensitive_attributes": [
+            [
+              {
+                "type": "get_attr",
+                "value": "client_secret"
+              }
+            ]
+          ],
+          "identity_schema_version": 0,
+          "private": "bnVsbA=="
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_zero_trust_access_service_token",
+      "name": "basic_token_no_client_secret_version",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "client_id": "123456.access",
+            "duration": "8760h",
+            "expires_at": "2026-10-31T16:42:49Z",
+            "id": "89500dab-f7ac-4a1d-9157-b43a78429292",
+            "name": "basic_token",
+            "previous_client_secret_expires_at": "2024-12-31T23:59:59Z",
+            "zone_id": null
+          },
+          "sensitive_attributes": [
+            [
+              {
+                "type": "get_attr",
+                "value": "client_secret"
+              }
+            ]
+          ],
+          "identity_schema_version": 0,
+          "private": "bnVsbA=="
+        }
+      ]
+    }
+  ],
+  "check_results": null
+}

--- a/integration/v4_to_v5/testdata/zero_trust_access_service_token/input/zero_trust_access_service_token.tf
+++ b/integration/v4_to_v5/testdata/zero_trust_access_service_token/input/zero_trust_access_service_token.tf
@@ -1,0 +1,19 @@
+# Test Case 1: Basic access service token with all fields
+resource "cloudflare_zero_trust_access_service_token" "basic_token" {
+  account_id                        = "f037e56e89293a057740de681ac9abbe"
+  name                              = "basic_token"
+  duration                          = "8760h"
+  min_days_for_renewal              = 30
+  client_secret_version             = 2
+  previous_client_secret_expires_at = "2024-12-31T23:59:59Z"
+}
+
+# Test Case 2: Legacy access service token name
+resource "cloudflare_access_service_token" "basic_token_legacy" {
+  account_id                        = "f037e56e89293a057740de681ac9abbe"
+  name                              = "basic_token_legacy"
+  duration                          = "8760h"
+  min_days_for_renewal              = 30
+  client_secret_version             = 2
+  previous_client_secret_expires_at = "2024-12-31T23:59:59Z"
+}

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -4,6 +4,7 @@ import (
 	"github.com/cloudflare/tf-migrate/internal/resources/account_member"
 	"github.com/cloudflare/tf-migrate/internal/resources/api_token"
 	"github.com/cloudflare/tf-migrate/internal/resources/dns_record"
+	"github.com/cloudflare/tf-migrate/internal/resources/zero_trust_access_service_token"
 	"github.com/cloudflare/tf-migrate/internal/resources/zero_trust_list"
 )
 
@@ -16,4 +17,5 @@ func RegisterAllMigrations() {
 	api_token.NewV4ToV5Migrator()
 	dns_record.NewV4ToV5Migrator()
 	zero_trust_list.NewV4ToV5Migrator()
+	zero_trust_access_service_token.NewV4ToV5Migrator()
 }

--- a/internal/resources/zero_trust_access_service_token/v4_to_v5.go
+++ b/internal/resources/zero_trust_access_service_token/v4_to_v5.go
@@ -1,0 +1,128 @@
+package zero_trust_access_service_token
+
+import (
+	"github.com/cloudflare/tf-migrate/internal"
+	"github.com/hashicorp/hcl/v2/hclwrite"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+
+	"github.com/cloudflare/tf-migrate/internal/transform"
+	tfhcl "github.com/cloudflare/tf-migrate/internal/transform/hcl"
+	"github.com/cloudflare/tf-migrate/internal/transform/state"
+)
+
+type V4ToV5Migrator struct {
+}
+
+func NewV4ToV5Migrator() transform.ResourceTransformer {
+	migrator := &V4ToV5Migrator{}
+
+	// Deprecated v4 Name
+	internal.RegisterMigrator("cloudflare_access_service_token", "v4", "v5", migrator)
+	internal.RegisterMigrator("cloudflare_zero_trust_access_service_token", "v4", "v5", migrator)
+
+	return migrator
+}
+
+func (m *V4ToV5Migrator) GetResourceType() string {
+	return "cloudflare_zero_trust_access_service_token"
+}
+
+func (m *V4ToV5Migrator) CanHandle(resourceType string) bool {
+	// Handle both the current name and the deprecated v4 name
+	return resourceType == "cloudflare_access_service_token" || resourceType == "cloudflare_zero_trust_access_service_token"
+}
+
+func (m *V4ToV5Migrator) Preprocess(content string) string {
+	return content
+}
+
+func (m *V4ToV5Migrator) TransformConfig(ctx *transform.Context, block *hclwrite.Block) (*transform.TransformResult, error) {
+	resourceType := tfhcl.GetResourceType(block)
+	if resourceType == "cloudflare_access_service_token" {
+		tfhcl.RenameResourceType(block, "cloudflare_access_service_token", "cloudflare_zero_trust_access_service_token")
+	}
+
+	body := block.Body()
+
+	// Remove deprecated field: min_days_for_renewal
+	tfhcl.RemoveAttributes(body, "min_days_for_renewal")
+
+	return &transform.TransformResult{
+		Blocks:         []*hclwrite.Block{block},
+		RemoveOriginal: false,
+	}, nil
+}
+
+func (m *V4ToV5Migrator) TransformState(ctx *transform.Context, stateJSON gjson.Result, resourcePath string) (string, error) {
+	result := stateJSON.String()
+
+	if stateJSON.Get("resources").Exists() {
+		return m.transformFullState(result, stateJSON)
+	}
+
+	if !stateJSON.Exists() || !stateJSON.Get("attributes").Exists() {
+		return result, nil
+	}
+
+	result = m.transformSingleInstance(result, stateJSON)
+
+	return result, nil
+}
+
+func (m *V4ToV5Migrator) transformFullState(result string, stateJSON gjson.Result) (string, error) {
+	resources := stateJSON.Get("resources")
+	if !resources.Exists() {
+		return result, nil
+	}
+
+	resources.ForEach(func(key, resource gjson.Result) bool {
+		resourceType := resource.Get("type").String()
+
+		if !m.CanHandle(resourceType) {
+			return true // continue
+		}
+
+		// Rename cloudflare_access_service_token to cloudflare_zero_trust_access_service_token
+		if resourceType == "cloudflare_access_service_token" {
+			resourcePath := "resources." + key.String() + ".type"
+			result, _ = sjson.Set(result, resourcePath, "cloudflare_zero_trust_access_service_token")
+		}
+
+		instances := resource.Get("instances")
+		instances.ForEach(func(instKey, instance gjson.Result) bool {
+			instPath := "resources." + key.String() + ".instances." + instKey.String()
+
+			attrs := instance.Get("attributes")
+			if attrs.Exists() {
+				instJSON := instance.String()
+				transformedInst := m.transformSingleInstance(instJSON, instance)
+				transformedInstParsed := gjson.Parse(transformedInst)
+				result, _ = sjson.SetRaw(result, instPath, transformedInstParsed.Raw)
+			}
+			return true
+		})
+
+		return true
+	})
+
+	return result, nil
+}
+
+func (m *V4ToV5Migrator) transformSingleInstance(result string, instance gjson.Result) string {
+	attrs := instance.Get("attributes")
+
+	// Remove deprecated field: min_days_for_renewal
+	result = state.RemoveFields(result, "attributes", attrs, "min_days_for_renewal")
+
+	// Convert client_secret_version from int to float64
+	clientSecretVersion := instance.Get("attributes.client_secret_version")
+	if clientSecretVersion.Exists() && clientSecretVersion.Type == gjson.Number {
+		result, _ = sjson.Set(result, "attributes.client_secret_version", clientSecretVersion.Float())
+	} else {
+		// Set default 1.0
+		result, _ = sjson.Set(result, "attributes.client_secret_version", 1.0)
+	}
+
+	return result
+}

--- a/internal/resources/zero_trust_access_service_token/v4_to_v5_test.go
+++ b/internal/resources/zero_trust_access_service_token/v4_to_v5_test.go
@@ -1,0 +1,485 @@
+package zero_trust_access_service_token
+
+import (
+	"testing"
+
+	"github.com/cloudflare/tf-migrate/internal/testhelpers"
+)
+
+func TestV4ToV5Transformation(t *testing.T) {
+	migrator := NewV4ToV5Migrator()
+
+	// Test configuration transformations
+	t.Run("ConfigTransformation", func(t *testing.T) {
+		tests := []testhelpers.ConfigTestCase{
+			{
+				Name: "Basic resource with all fields - min_days_for_renewal removed",
+				Input: `
+resource "cloudflare_zero_trust_access_service_token" "test" {
+  account_id                         = "account123"
+  name                               = "my_token"
+  duration                           = "8760h"
+  min_days_for_renewal               = 30
+  client_secret_version              = 2
+  previous_client_secret_expires_at  = "2024-12-31T23:59:59Z"
+}`,
+				Expected: `resource "cloudflare_zero_trust_access_service_token" "test" {
+  account_id                        = "account123"
+  name                              = "my_token"
+  duration                          = "8760h"
+  client_secret_version             = 2
+  previous_client_secret_expires_at = "2024-12-31T23:59:59Z"
+}`,
+			},
+			{
+				Name: "Minimal resource with only required fields",
+				Input: `
+resource "cloudflare_zero_trust_access_service_token" "minimal" {
+  zone_id = "zone456"
+  name    = "minimal_token"
+}`,
+				Expected: `resource "cloudflare_zero_trust_access_service_token" "minimal" {
+  zone_id = "zone456"
+  name    = "minimal_token"
+}`,
+			},
+			{
+				Name: "Legacy resource name - cloudflare_access_service_token",
+				Input: `
+resource "cloudflare_access_service_token" "legacy" {
+  account_id = "account123"
+  name       = "legacy_token"
+}`,
+				Expected: `resource "cloudflare_zero_trust_access_service_token" "legacy" {
+  account_id = "account123"
+  name       = "legacy_token"
+}`,
+			},
+			{
+				Name: "Resource with min_days_for_renewal = 0 (should still be removed)",
+				Input: `
+resource "cloudflare_zero_trust_access_service_token" "test" {
+  account_id           = "account123"
+  name                 = "test_token"
+  min_days_for_renewal = 0
+}`,
+				Expected: `resource "cloudflare_zero_trust_access_service_token" "test" {
+  account_id = "account123"
+  name       = "test_token"
+}`,
+			},
+			{
+				Name: "Multiple resources in one file",
+				Input: `
+resource "cloudflare_zero_trust_access_service_token" "first" {
+  account_id           = "account123"
+  name                 = "first_token"
+  min_days_for_renewal = 30
+}
+
+resource "cloudflare_zero_trust_access_service_token" "second" {
+  zone_id              = "zone456"
+  name                 = "second_token"
+  min_days_for_renewal = 60
+}`,
+				Expected: `resource "cloudflare_zero_trust_access_service_token" "first" {
+  account_id = "account123"
+  name       = "first_token"
+}
+
+resource "cloudflare_zero_trust_access_service_token" "second" {
+  zone_id = "zone456"
+  name    = "second_token"
+}`,
+			},
+			{
+				Name: "Resource without min_days_for_renewal (should be unchanged)",
+				Input: `
+resource "cloudflare_zero_trust_access_service_token" "no_renewal" {
+  account_id = "account123"
+  name       = "no_renewal_token"
+  duration   = "17520h"
+}`,
+				Expected: `resource "cloudflare_zero_trust_access_service_token" "no_renewal" {
+  account_id = "account123"
+  name       = "no_renewal_token"
+  duration   = "17520h"
+}`,
+			},
+		}
+
+		testhelpers.RunConfigTransformTests(t, tests, migrator)
+	})
+
+	// Test state transformations
+	t.Run("StateTransformation", func(t *testing.T) {
+		tests := []testhelpers.StateTestCase{
+			{
+				Name: "Type conversion - client_secret_version from int to float64",
+				Input: `{
+  "version": 4,
+  "terraform_version": "1.5.0",
+  "resources": [{
+    "type": "cloudflare_zero_trust_access_service_token",
+    "name": "test",
+    "instances": [{
+      "attributes": {
+        "id": "token123",
+        "account_id": "account456",
+        "name": "my_token",
+        "client_id": "client789",
+        "client_secret": "secret_abc",
+        "expires_at": "2025-12-31T23:59:59Z",
+        "duration": "8760h",
+        "client_secret_version": 1,
+        "min_days_for_renewal": 30
+      }
+    }]
+  }]
+}`,
+				Expected: `{
+  "version": 4,
+  "terraform_version": "1.5.0",
+  "resources": [{
+    "type": "cloudflare_zero_trust_access_service_token",
+    "name": "test",
+    "instances": [{
+      "attributes": {
+        "id": "token123",
+        "account_id": "account456",
+        "name": "my_token",
+        "client_id": "client789",
+        "client_secret": "secret_abc",
+        "expires_at": "2025-12-31T23:59:59Z",
+        "duration": "8760h",
+        "client_secret_version": 1.0
+      }
+    }]
+  }]
+}`,
+			},
+			{
+				Name: "Type conversion - larger client_secret_version values",
+				Input: `{
+  "version": 4,
+  "resources": [{
+    "type": "cloudflare_zero_trust_access_service_token",
+    "name": "test",
+    "instances": [{
+      "attributes": {
+        "id": "token123",
+        "name": "my_token",
+        "account_id": "account456",
+        "client_secret_version": 5
+      }
+    }]
+  }]
+}`,
+				Expected: `{
+  "version": 4,
+  "resources": [{
+    "type": "cloudflare_zero_trust_access_service_token",
+    "name": "test",
+    "instances": [{
+      "attributes": {
+        "id": "token123",
+        "name": "my_token",
+        "account_id": "account456",
+        "client_secret_version": 5.0
+      }
+    }]
+  }]
+}`,
+			},
+			{
+				Name: "Missing client_secret_version - should add default",
+				Input: `{
+  "version": 4,
+  "resources": [{
+    "type": "cloudflare_zero_trust_access_service_token",
+    "name": "test",
+    "instances": [{
+      "attributes": {
+        "id": "token123",
+        "name": "test_token",
+        "account_id": "account456"
+      }
+    }]
+  }]
+}`,
+				Expected: `{
+  "version": 4,
+  "resources": [{
+    "type": "cloudflare_zero_trust_access_service_token",
+    "name": "test",
+    "instances": [{
+      "attributes": {
+        "id": "token123",
+        "name": "test_token",
+        "account_id": "account456",
+		"client_secret_version": 1.0
+      }
+    }]
+  }]
+}`,
+			},
+			{
+				Name: "Field removal - min_days_for_renewal removed from state",
+				Input: `{
+  "version": 4,
+  "resources": [{
+    "type": "cloudflare_zero_trust_access_service_token",
+    "name": "test",
+    "instances": [{
+      "attributes": {
+        "id": "token123",
+        "name": "test_token",
+        "account_id": "account456",
+        "min_days_for_renewal": 30,
+        "client_secret_version": 1.0
+      }
+    }]
+  }]
+}`,
+				Expected: `{
+  "version": 4,
+  "resources": [{
+    "type": "cloudflare_zero_trust_access_service_token",
+    "name": "test",
+    "instances": [{
+      "attributes": {
+        "id": "token123",
+        "name": "test_token",
+        "account_id": "account456",
+        "client_secret_version": 1.0
+      }
+    }]
+  }]
+}`,
+			},
+			{
+				Name: "Complete state with all fields",
+				Input: `{
+  "version": 4,
+  "resources": [{
+    "type": "cloudflare_zero_trust_access_service_token",
+    "name": "complete",
+    "instances": [{
+      "attributes": {
+        "id": "token123",
+        "account_id": "account456",
+        "name": "complete_token",
+        "client_id": "client789",
+        "client_secret": "secret_abc",
+        "expires_at": "2025-12-31T23:59:59Z",
+        "duration": "8760h",
+        "client_secret_version": 2,
+        "previous_client_secret_expires_at": "2024-12-31T23:59:59Z",
+        "min_days_for_renewal": 30
+      }
+    }]
+  }]
+}`,
+				Expected: `{
+  "version": 4,
+  "resources": [{
+    "type": "cloudflare_zero_trust_access_service_token",
+    "name": "complete",
+    "instances": [{
+      "attributes": {
+        "id": "token123",
+        "account_id": "account456",
+        "name": "complete_token",
+        "client_id": "client789",
+        "client_secret": "secret_abc",
+        "expires_at": "2025-12-31T23:59:59Z",
+        "duration": "8760h",
+        "client_secret_version": 2.0,
+        "previous_client_secret_expires_at": "2024-12-31T23:59:59Z"
+      }
+    }]
+  }]
+}`,
+			},
+			{
+				Name: "Zone-scoped resource (zone_id instead of account_id)",
+				Input: `{
+  "version": 4,
+  "resources": [{
+    "type": "cloudflare_zero_trust_access_service_token",
+    "name": "zone_token",
+    "instances": [{
+      "attributes": {
+        "id": "token123",
+        "zone_id": "zone456",
+        "name": "zone_token",
+        "client_secret_version": 1,
+        "min_days_for_renewal": 15
+      }
+    }]
+  }]
+}`,
+				Expected: `{
+  "version": 4,
+  "resources": [{
+    "type": "cloudflare_zero_trust_access_service_token",
+    "name": "zone_token",
+    "instances": [{
+      "attributes": {
+        "id": "token123",
+        "zone_id": "zone456",
+        "name": "zone_token",
+        "client_secret_version": 1.0
+      }
+    }]
+  }]
+}`,
+			},
+			{
+				Name: "Legacy resource name - cloudflare_access_service_token in state",
+				Input: `{
+  "version": 4,
+  "resources": [{
+    "type": "cloudflare_access_service_token",
+    "name": "legacy",
+    "instances": [{
+      "attributes": {
+        "id": "token123",
+        "account_id": "account456",
+        "name": "legacy_token",
+        "client_secret_version": 1,
+        "min_days_for_renewal": 30
+      }
+    }]
+  }]
+}`,
+				Expected: `{
+  "version": 4,
+  "resources": [{
+    "type": "cloudflare_zero_trust_access_service_token",
+    "name": "legacy",
+    "instances": [{
+      "attributes": {
+        "id": "token123",
+        "account_id": "account456",
+        "name": "legacy_token",
+        "client_secret_version": 1.0
+      }
+    }]
+  }]
+}`,
+			},
+			{
+				Name: "Multiple instances of the same resource",
+				Input: `{
+  "version": 4,
+  "resources": [{
+    "type": "cloudflare_zero_trust_access_service_token",
+    "name": "multi",
+    "instances": [
+      {
+        "attributes": {
+          "id": "token1",
+          "account_id": "account456",
+          "name": "first_token",
+          "client_secret_version": 1,
+          "min_days_for_renewal": 30
+        }
+      },
+      {
+        "attributes": {
+          "id": "token2",
+          "account_id": "account456",
+          "name": "second_token",
+          "client_secret_version": 2,
+          "min_days_for_renewal": 60
+        }
+      }
+    ]
+  }]
+}`,
+				Expected: `{
+  "version": 4,
+  "resources": [{
+    "type": "cloudflare_zero_trust_access_service_token",
+    "name": "multi",
+    "instances": [
+      {
+        "attributes": {
+          "id": "token1",
+          "account_id": "account456",
+          "name": "first_token",
+          "client_secret_version": 1.0
+        }
+      },
+      {
+        "attributes": {
+          "id": "token2",
+          "account_id": "account456",
+          "name": "second_token",
+          "client_secret_version": 2.0
+        }
+      }
+    ]
+  }]
+}`,
+			},
+			{
+				Name: "State with empty resources",
+				Input: `{
+					"resources": []
+				}`,
+				Expected: `{
+					"resources": []
+				}`,
+			},
+			{
+				Name: "State without instances",
+				Input: `{
+					"resources": [{
+						"type": "cloudflare_zero_trust_access_service_token",
+						"name": "empty",
+						"instances": []
+					}]
+				}`,
+				Expected: `{
+					"resources": [{
+						"type": "cloudflare_zero_trust_access_service_token",
+						"name": "empty",
+						"instances": []
+					}]
+				}`,
+			},
+			{
+				Name: "Type conversion - single instance",
+				Input: `{
+      "attributes": {
+        "id": "token123",
+        "account_id": "account456",
+        "name": "my_token",
+        "client_id": "client789",
+        "client_secret": "secret_abc",
+        "expires_at": "2025-12-31T23:59:59Z",
+        "duration": "8760h",
+        "client_secret_version": 1,
+        "min_days_for_renewal": 30
+      }
+}`,
+				Expected: `{
+      "attributes": {
+        "id": "token123",
+        "account_id": "account456",
+        "name": "my_token",
+        "client_id": "client789",
+        "client_secret": "secret_abc",
+        "expires_at": "2025-12-31T23:59:59Z",
+        "duration": "8760h",
+        "client_secret_version": 1.0
+      }
+}`,
+			},
+		}
+
+		testhelpers.RunStateTransformTests(t, tests, migrator)
+	})
+}


### PR DESCRIPTION
Adds v4→v5 migration for zero_trust_access_service_token. 

```
Renames deprecated resource type `access_service_token` -> `zero_trust_access_service_token` 

Removes deprecated field `min_days_for_renewal`
Converts field `client_secret_version` from int -> float64
```