### PR TITLE
feat: v4 to v5 migrations - logpull_retention

### DIFF
--- a/integration/v4_to_v5/integration_test.go
+++ b/integration/v4_to_v5/integration_test.go
@@ -12,6 +12,7 @@ import (
 	_ "github.com/cloudflare/tf-migrate/internal/resources/account_member"
 	_ "github.com/cloudflare/tf-migrate/internal/resources/api_token"
 	_ "github.com/cloudflare/tf-migrate/internal/resources/dns_record"
+	_ "github.com/cloudflare/tf-migrate/internal/resources/logpull_retention"
 )
 
 // TestMain explicitly registers migrations for this version path
@@ -50,6 +51,11 @@ func TestV4ToV5Migration(t *testing.T) {
 			Name:        "APIToken",
 			Description: "Migrate cloudflare_api_token policy blocks to policies list",
 			Resource:    "api_token",
+		},
+		{
+			Name:        "LogpullRetention",
+			Description: "Migrate cloudflare_logpull_retention enabled to flag",
+			Resource:    "logpull_retention",
 		},
 		// Add more v4 to v5 migrations here as they are implemented
 	}

--- a/integration/v4_to_v5/testdata/logpull_retention/expected/logpull_retention.tf
+++ b/integration/v4_to_v5/testdata/logpull_retention/expected/logpull_retention.tf
@@ -1,0 +1,11 @@
+# Test Case 1: Basic logpull retention enabled
+resource "cloudflare_logpull_retention" "enabled_zone" {
+  zone_id = "d56084adb405e0b7e32c52321bf07be6"
+  flag    = true
+}
+
+# Test Case 2: Logpull retention disabled
+resource "cloudflare_logpull_retention" "disabled_zone" {
+  zone_id = "023e105f4ecef8ad9ca31a8372d0c353"
+  flag    = false
+}

--- a/integration/v4_to_v5/testdata/logpull_retention/expected/terraform.tfstate
+++ b/integration/v4_to_v5/testdata/logpull_retention/expected/terraform.tfstate
@@ -1,0 +1,41 @@
+{
+  "version": 4,
+  "terraform_version": "1.0.0",
+  "serial": 1,
+  "lineage": "b84c21a4-d553-5468-8b7d-341b3f34b531",
+  "outputs": {},
+  "resources": [
+    {
+      "mode": "managed",
+      "type": "cloudflare_logpull_retention",
+      "name": "enabled_zone",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "flag": true,
+            "id": "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6",
+            "zone_id": "d56084adb405e0b7e32c52321bf07be6"
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_logpull_retention",
+      "name": "disabled_zone",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "flag": false,
+            "id": "z9y8x7w6v5u4t3s2r1q0p9o8n7m6l5k4",
+            "zone_id": "023e105f4ecef8ad9ca31a8372d0c353"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/integration/v4_to_v5/testdata/logpull_retention/input/logpull_retention.tf
+++ b/integration/v4_to_v5/testdata/logpull_retention/input/logpull_retention.tf
@@ -1,0 +1,11 @@
+# Test Case 1: Basic logpull retention enabled
+resource "cloudflare_logpull_retention" "enabled_zone" {
+  zone_id = "d56084adb405e0b7e32c52321bf07be6"
+  enabled = true
+}
+
+# Test Case 2: Logpull retention disabled
+resource "cloudflare_logpull_retention" "disabled_zone" {
+  zone_id = "023e105f4ecef8ad9ca31a8372d0c353"
+  enabled = false
+}

--- a/integration/v4_to_v5/testdata/logpull_retention/input/terraform.tfstate
+++ b/integration/v4_to_v5/testdata/logpull_retention/input/terraform.tfstate
@@ -1,0 +1,41 @@
+{
+  "version": 4,
+  "terraform_version": "1.0.0",
+  "serial": 1,
+  "lineage": "b84c21a4-d553-5468-8b7d-341b3f34b531",
+  "outputs": {},
+  "resources": [
+    {
+      "mode": "managed",
+      "type": "cloudflare_logpull_retention",
+      "name": "enabled_zone",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "enabled": true,
+            "id": "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6",
+            "zone_id": "d56084adb405e0b7e32c52321bf07be6"
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_logpull_retention",
+      "name": "disabled_zone",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "enabled": false,
+            "id": "z9y8x7w6v5u4t3s2r1q0p9o8n7m6l5k4",
+            "zone_id": "023e105f4ecef8ad9ca31a8372d0c353"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -4,6 +4,7 @@ import (
 	"github.com/cloudflare/tf-migrate/internal/resources/account_member"
 	"github.com/cloudflare/tf-migrate/internal/resources/api_token"
 	"github.com/cloudflare/tf-migrate/internal/resources/dns_record"
+	"github.com/cloudflare/tf-migrate/internal/resources/logpull_retention"
 )
 
 // RegisterAllMigrations registers all resource migrations with the internal registry.
@@ -14,4 +15,5 @@ func RegisterAllMigrations() {
 	account_member.NewV4ToV5Migrator()
 	api_token.NewV4ToV5Migrator()
 	dns_record.NewV4ToV5Migrator()
+	logpull_retention.NewV4ToV5Migrator()
 }

--- a/internal/resources/logpull_retention/v4_to_v5.go
+++ b/internal/resources/logpull_retention/v4_to_v5.go
@@ -1,0 +1,59 @@
+package logpull_retention
+
+import (
+	"github.com/cloudflare/tf-migrate/internal"
+	"github.com/cloudflare/tf-migrate/internal/transform"
+	tfhcl "github.com/cloudflare/tf-migrate/internal/transform/hcl"
+	"github.com/cloudflare/tf-migrate/internal/transform/state"
+	"github.com/hashicorp/hcl/v2/hclwrite"
+	"github.com/tidwall/gjson"
+)
+
+type V4ToV5Migrator struct {
+}
+
+func NewV4ToV5Migrator() transform.ResourceTransformer {
+	migrator := &V4ToV5Migrator{}
+	internal.RegisterMigrator("cloudflare_logpull_retention", "v4", "v5", migrator)
+	return migrator
+}
+
+func (m *V4ToV5Migrator) GetResourceType() string {
+	return "cloudflare_logpull_retention"
+}
+
+func (m *V4ToV5Migrator) CanHandle(resourceType string) bool {
+	return resourceType == "cloudflare_logpull_retention"
+}
+
+func (m *V4ToV5Migrator) Preprocess(content string) string {
+	// No preprocessing needed for this simple migration
+	return content
+}
+
+func (m *V4ToV5Migrator) TransformConfig(ctx *transform.Context, block *hclwrite.Block) (*transform.TransformResult, error) {
+	body := block.Body()
+
+	// Rename enabled → flag
+	tfhcl.RenameAttribute(body, "enabled", "flag")
+
+	return &transform.TransformResult{
+		Blocks:         []*hclwrite.Block{block},
+		RemoveOriginal: false,
+	}, nil
+}
+
+func (m *V4ToV5Migrator) TransformState(ctx *transform.Context, stateJSON gjson.Result, resourcePath string) (string, error) {
+	result := stateJSON.String()
+
+	if !stateJSON.Exists() || !stateJSON.Get("attributes").Exists() {
+		return result, nil
+	}
+
+	attrs := stateJSON.Get("attributes")
+
+	// Rename enabled → flag
+	result = state.RenameField(result, "attributes", attrs, "enabled", "flag")
+
+	return result, nil
+}

--- a/internal/resources/logpull_retention/v4_to_v5_test.go
+++ b/internal/resources/logpull_retention/v4_to_v5_test.go
@@ -1,0 +1,127 @@
+package logpull_retention
+
+import (
+	"testing"
+
+	"github.com/cloudflare/tf-migrate/internal/testhelpers"
+)
+
+func TestV4ToV5Migration(t *testing.T) {
+	migrator := NewV4ToV5Migrator()
+
+	tests := []testhelpers.ConfigTestCase{
+		{
+			Name: "Basic resource with enabled true",
+			Input: `resource "cloudflare_logpull_retention" "example" {
+  zone_id = "zone123"
+  enabled = true
+}`,
+			Expected: `resource "cloudflare_logpull_retention" "example" {
+  zone_id = "zone123"
+  flag    = true
+}`,
+		},
+		{
+			Name: "Basic resource with enabled false",
+			Input: `resource "cloudflare_logpull_retention" "example" {
+  zone_id = "abc123def456"
+  enabled = false
+}`,
+			Expected: `resource "cloudflare_logpull_retention" "example" {
+  zone_id = "abc123def456"
+  flag    = false
+}`,
+		},
+		{
+			Name: "Multiple resources",
+			Input: `resource "cloudflare_logpull_retention" "zone1" {
+  zone_id = "zone111"
+  enabled = true
+}
+
+resource "cloudflare_logpull_retention" "zone2" {
+  zone_id = "zone222"
+  enabled = false
+}`,
+			Expected: `resource "cloudflare_logpull_retention" "zone1" {
+  zone_id = "zone111"
+  flag    = true
+}
+
+resource "cloudflare_logpull_retention" "zone2" {
+  zone_id = "zone222"
+  flag    = false
+}`,
+		},
+	}
+
+	testhelpers.RunConfigTransformTests(t, tests, migrator)
+}
+
+func TestV4ToV5StateTransformation(t *testing.T) {
+	migrator := NewV4ToV5Migrator()
+
+	tests := []testhelpers.StateTestCase{
+		{
+			Name: "Basic state with enabled true",
+			Input: `{
+  "type": "cloudflare_logpull_retention",
+  "name": "example",
+  "attributes": {
+    "zone_id": "zone123",
+    "enabled": true
+  }
+}`,
+			Expected: `{
+  "type": "cloudflare_logpull_retention",
+  "name": "example",
+  "attributes": {
+    "zone_id": "zone123",
+    "flag": true
+  }
+}`,
+		},
+		{
+			Name: "Basic state with enabled false",
+			Input: `{
+  "type": "cloudflare_logpull_retention",
+  "name": "example",
+  "attributes": {
+    "zone_id": "abc123def456",
+    "enabled": false
+  }
+}`,
+			Expected: `{
+  "type": "cloudflare_logpull_retention",
+  "name": "example",
+  "attributes": {
+    "zone_id": "abc123def456",
+    "flag": false
+  }
+}`,
+		},
+		{
+			Name: "State with additional computed fields",
+			Input: `{
+  "type": "cloudflare_logpull_retention",
+  "name": "example",
+  "attributes": {
+    "zone_id": "zone999",
+    "enabled": true,
+    "id": "some-checksum-value"
+  }
+}`,
+			Expected: `{
+  "type": "cloudflare_logpull_retention",
+  "name": "example",
+  "attributes": {
+    "zone_id": "zone999",
+    "flag": true,
+    "id": "some-checksum-value"
+  }
+}`,
+		},
+	}
+
+	testhelpers.RunStateTransformTests(t, tests, migrator)
+}


### PR DESCRIPTION
Support migrations for `logpull_retention` for v4 to v5. Changes include:
- rename of `enabled` to `flag`