### PR TITLE
feat(logpush_job): v4 to v5 migrations 

### DIFF
--- a/integration/v4_to_v5/testdata/logpush_job/expected/logpush_job.tf
+++ b/integration/v4_to_v5/testdata/logpush_job/expected/logpush_job.tf
@@ -49,12 +49,11 @@ resource "cloudflare_logpush_job" "with_cve_field" {
   }
 }
 
-# Job with instant-logs kind (should become empty string)
+# Job with instant-logs kind (should be removed)
 resource "cloudflare_logpush_job" "instant_logs" {
   zone_id          = var.cloudflare_zone_id
   dataset          = "http_requests"
   destination_conf = "https://logpush-receiver.sd.cfplat.com"
-  kind             = ""
 }
 
 # Job with edge kind (should be preserved)
@@ -65,12 +64,19 @@ resource "cloudflare_logpush_job" "edge_logs" {
   kind             = "edge"
 }
 
+# Job with "" kind (should be preserved)
+resource "cloudflare_logpush_job" "edge_logs" {
+  zone_id          = var.cloudflare_zone_id
+  dataset          = "http_requests"
+  destination_conf = "https://logpush-receiver.sd.cfplat.com"
+  kind             = ""
+}
+
 # Full featured job with all transformations
 resource "cloudflare_logpush_job" "full" {
   zone_id          = var.cloudflare_zone_id
   dataset          = "http_requests"
   destination_conf = "https://logpush-receiver.sd.cfplat.com"
-  kind             = ""
   enabled          = true
   name             = "my-logpush-job"
   frequency        = "high"

--- a/integration/v4_to_v5/testdata/logpush_job/expected/logpush_job.tf
+++ b/integration/v4_to_v5/testdata/logpush_job/expected/logpush_job.tf
@@ -34,6 +34,7 @@ resource "cloudflare_logpush_job" "with_output_options" {
     batch_suffix     = "}"
     field_names      = ["ClientIP", "EdgeStartTimestamp"]
     output_type      = "ndjson"
+    cve_2021_44228   = false
     field_delimiter  = ","
     record_prefix    = "{"
     record_suffix    = "}\n"

--- a/integration/v4_to_v5/testdata/logpush_job/expected/logpush_job.tf
+++ b/integration/v4_to_v5/testdata/logpush_job/expected/logpush_job.tf
@@ -60,13 +60,6 @@ resource "cloudflare_logpush_job" "with_cve_field" {
   }
 }
 
-# Job with instant-logs kind (should be removed)
-resource "cloudflare_logpush_job" "instant_logs" {
-  zone_id          = var.cloudflare_zone_id
-  dataset          = "http_requests"
-  destination_conf = "https://logpush-receiver.sd.cfplat.com"
-}
-
 # Job with edge kind (should be preserved)
 resource "cloudflare_logpush_job" "edge_logs" {
   zone_id          = var.cloudflare_zone_id
@@ -86,8 +79,9 @@ resource "cloudflare_logpush_job" "empty_kind" {
 # Full featured job with all transformations
 resource "cloudflare_logpush_job" "full" {
   zone_id          = var.cloudflare_zone_id
-  dataset          = "http_requests"
+  dataset          = "audit_logs"
   destination_conf = "https://logpush-receiver.sd.cfplat.com"
+  kind             = "edge"
   enabled          = true
   name             = "my-logpush-job"
   frequency        = "high"

--- a/integration/v4_to_v5/testdata/logpush_job/expected/logpush_job.tf
+++ b/integration/v4_to_v5/testdata/logpush_job/expected/logpush_job.tf
@@ -20,10 +20,15 @@ resource "cloudflare_logpush_job" "with_output_options" {
   destination_conf = "s3://mybucket/logs?region=us-west-2"
 
   output_options = {
-    batch_prefix = "{"
-    batch_suffix = "}"
-    field_names  = ["ClientIP", "EdgeStartTimestamp"]
-    output_type  = "ndjson"
+    batch_prefix     = "{"
+    batch_suffix     = "}"
+    field_names      = ["ClientIP", "EdgeStartTimestamp"]
+    output_type      = "ndjson"
+    field_delimiter  = ","
+    record_prefix    = "{"
+    record_suffix    = "}\n"
+    timestamp_format = "unixnano"
+    sample_rate      = 1
   }
 }
 
@@ -34,8 +39,13 @@ resource "cloudflare_logpush_job" "with_cve_field" {
   destination_conf = "s3://mybucket/logs?region=us-west-2"
 
   output_options = {
-    output_type    = "ndjson"
-    cve_2021_44228 = true
+    output_type      = "ndjson"
+    cve_2021_44228   = true
+    field_delimiter  = ","
+    record_prefix    = "{"
+    record_suffix    = "}\n"
+    timestamp_format = "unixnano"
+    sample_rate      = 1
   }
 }
 
@@ -73,5 +83,8 @@ resource "cloudflare_logpush_job" "full" {
     sample_rate      = 1.0
     timestamp_format = "unixnano"
     cve_2021_44228   = true
+    field_delimiter  = ","
+    record_prefix    = "{"
+    record_suffix    = "}\n"
   }
 }

--- a/integration/v4_to_v5/testdata/logpush_job/expected/logpush_job.tf
+++ b/integration/v4_to_v5/testdata/logpush_job/expected/logpush_job.tf
@@ -1,14 +1,14 @@
 # Minimal logpush job
 resource "cloudflare_logpush_job" "minimal" {
   account_id       = "f037e56e89293a057740de681ac9abbe"
-  dataset          = "http_requests"
+  dataset          = "audit_logs"
   destination_conf = "s3://mybucket/logs?region=us-west-2"
 }
 
 # Job with logpull_options only (no output_options)
 resource "cloudflare_logpush_job" "with_logpull_options" {
   account_id       = "f037e56e89293a057740de681ac9abbe"
-  dataset          = "http_requests"
+  dataset          = "audit_logs"
   destination_conf = "s3://mybucket/logs?region=us-west-2"
   logpull_options  = "fields=ClientIP,EdgeStartTimestamp&timestamps=unixnano"
 }
@@ -16,7 +16,7 @@ resource "cloudflare_logpush_job" "with_logpull_options" {
 # Job with output_options block
 resource "cloudflare_logpush_job" "with_output_options" {
   account_id       = "f037e56e89293a057740de681ac9abbe"
-  dataset          = "http_requests"
+  dataset          = "audit_logs"
   destination_conf = "s3://mybucket/logs?region=us-west-2"
 
   output_options = {
@@ -35,7 +35,7 @@ resource "cloudflare_logpush_job" "with_output_options" {
 # Job with cve20214428 field (should be renamed)
 resource "cloudflare_logpush_job" "with_cve_field" {
   account_id       = "f037e56e89293a057740de681ac9abbe"
-  dataset          = "http_requests"
+  dataset          = "audit_logs"
   destination_conf = "s3://mybucket/logs?region=us-west-2"
 
   output_options = {
@@ -51,7 +51,7 @@ resource "cloudflare_logpush_job" "with_cve_field" {
 
 # Job with instant-logs kind (should become empty string)
 resource "cloudflare_logpush_job" "instant_logs" {
-  account_id       = "f037e56e89293a057740de681ac9abbe"
+  zone_id          = "0da42c8d2132a9ddaf714f9e7c920711"
   dataset          = "http_requests"
   destination_conf = "s3://mybucket/logs?region=us-west-2"
   kind             = ""
@@ -59,7 +59,7 @@ resource "cloudflare_logpush_job" "instant_logs" {
 
 # Job with edge kind (should be preserved)
 resource "cloudflare_logpush_job" "edge_logs" {
-  account_id       = "f037e56e89293a057740de681ac9abbe"
+  zone_id          = "0da42c8d2132a9ddaf714f9e7c920711"
   dataset          = "http_requests"
   destination_conf = "s3://mybucket/logs?region=us-west-2"
   kind             = "edge"
@@ -67,7 +67,7 @@ resource "cloudflare_logpush_job" "edge_logs" {
 
 # Full featured job with all transformations
 resource "cloudflare_logpush_job" "full" {
-  account_id       = "f037e56e89293a057740de681ac9abbe"
+  zone_id          = "0da42c8d2132a9ddaf714f9e7c920711"
   dataset          = "http_requests"
   destination_conf = "s3://mybucket/logs?region=us-west-2"
   kind             = ""

--- a/integration/v4_to_v5/testdata/logpush_job/expected/logpush_job.tf
+++ b/integration/v4_to_v5/testdata/logpush_job/expected/logpush_job.tf
@@ -79,7 +79,7 @@ resource "cloudflare_logpush_job" "empty_kind" {
 # Full featured job with all transformations
 resource "cloudflare_logpush_job" "full" {
   zone_id          = var.cloudflare_zone_id
-  dataset          = "audit_logs"
+  dataset          = "http_requests"
   destination_conf = "https://logpush-receiver.sd.cfplat.com"
   kind             = "edge"
   enabled          = true

--- a/integration/v4_to_v5/testdata/logpush_job/expected/logpush_job.tf
+++ b/integration/v4_to_v5/testdata/logpush_job/expected/logpush_job.tf
@@ -1,3 +1,13 @@
+variable "cloudflare_account_id" {
+  description = "Cloudflare account ID"
+  type        = string
+}
+
+variable "cloudflare_zone_id" {
+  description = "Cloudflare zone ID"
+  type        = string
+}
+
 # Minimal logpush job
 resource "cloudflare_logpush_job" "minimal" {
   account_id       = var.cloudflare_account_id
@@ -65,7 +75,7 @@ resource "cloudflare_logpush_job" "edge_logs" {
 }
 
 # Job with "" kind (should be preserved)
-resource "cloudflare_logpush_job" "edge_logs" {
+resource "cloudflare_logpush_job" "empty_kind" {
   zone_id          = var.cloudflare_zone_id
   dataset          = "http_requests"
   destination_conf = "https://logpush-receiver.sd.cfplat.com"

--- a/integration/v4_to_v5/testdata/logpush_job/expected/logpush_job.tf
+++ b/integration/v4_to_v5/testdata/logpush_job/expected/logpush_job.tf
@@ -1,23 +1,23 @@
 # Minimal logpush job
 resource "cloudflare_logpush_job" "minimal" {
-  account_id       = "f037e56e89293a057740de681ac9abbe"
+  account_id       = var.cloudflare_account_id
   dataset          = "audit_logs"
-  destination_conf = "s3://mybucket/logs?region=us-west-2"
+  destination_conf = "https://logpush-receiver.sd.cfplat.com"
 }
 
 # Job with logpull_options only (no output_options)
 resource "cloudflare_logpush_job" "with_logpull_options" {
-  account_id       = "f037e56e89293a057740de681ac9abbe"
+  account_id       = var.cloudflare_account_id
   dataset          = "audit_logs"
-  destination_conf = "s3://mybucket/logs?region=us-west-2"
+  destination_conf = "https://logpush-receiver.sd.cfplat.com"
   logpull_options  = "fields=ClientIP,EdgeStartTimestamp&timestamps=unixnano"
 }
 
 # Job with output_options block
 resource "cloudflare_logpush_job" "with_output_options" {
-  account_id       = "f037e56e89293a057740de681ac9abbe"
+  account_id       = var.cloudflare_account_id
   dataset          = "audit_logs"
-  destination_conf = "s3://mybucket/logs?region=us-west-2"
+  destination_conf = "https://logpush-receiver.sd.cfplat.com"
 
   output_options = {
     batch_prefix     = "{"
@@ -34,9 +34,9 @@ resource "cloudflare_logpush_job" "with_output_options" {
 
 # Job with cve20214428 field (should be renamed)
 resource "cloudflare_logpush_job" "with_cve_field" {
-  account_id       = "f037e56e89293a057740de681ac9abbe"
+  account_id       = var.cloudflare_account_id
   dataset          = "audit_logs"
-  destination_conf = "s3://mybucket/logs?region=us-west-2"
+  destination_conf = "https://logpush-receiver.sd.cfplat.com"
 
   output_options = {
     output_type      = "ndjson"
@@ -51,25 +51,25 @@ resource "cloudflare_logpush_job" "with_cve_field" {
 
 # Job with instant-logs kind (should become empty string)
 resource "cloudflare_logpush_job" "instant_logs" {
-  zone_id          = "0da42c8d2132a9ddaf714f9e7c920711"
+  zone_id          = var.cloudflare_zone_id
   dataset          = "http_requests"
-  destination_conf = "s3://mybucket/logs?region=us-west-2"
+  destination_conf = "https://logpush-receiver.sd.cfplat.com"
   kind             = ""
 }
 
 # Job with edge kind (should be preserved)
 resource "cloudflare_logpush_job" "edge_logs" {
-  zone_id          = "0da42c8d2132a9ddaf714f9e7c920711"
+  zone_id          = var.cloudflare_zone_id
   dataset          = "http_requests"
-  destination_conf = "s3://mybucket/logs?region=us-west-2"
+  destination_conf = "https://logpush-receiver.sd.cfplat.com"
   kind             = "edge"
 }
 
 # Full featured job with all transformations
 resource "cloudflare_logpush_job" "full" {
-  zone_id          = "0da42c8d2132a9ddaf714f9e7c920711"
+  zone_id          = var.cloudflare_zone_id
   dataset          = "http_requests"
-  destination_conf = "s3://mybucket/logs?region=us-west-2"
+  destination_conf = "https://logpush-receiver.sd.cfplat.com"
   kind             = ""
   enabled          = true
   name             = "my-logpush-job"

--- a/integration/v4_to_v5/testdata/logpush_job/expected/logpush_job.tf
+++ b/integration/v4_to_v5/testdata/logpush_job/expected/logpush_job.tf
@@ -1,0 +1,77 @@
+# Minimal logpush job
+resource "cloudflare_logpush_job" "minimal" {
+  account_id       = "f037e56e89293a057740de681ac9abbe"
+  dataset          = "http_requests"
+  destination_conf = "s3://mybucket/logs?region=us-west-2"
+}
+
+# Job with logpull_options only (no output_options)
+resource "cloudflare_logpush_job" "with_logpull_options" {
+  account_id       = "f037e56e89293a057740de681ac9abbe"
+  dataset          = "http_requests"
+  destination_conf = "s3://mybucket/logs?region=us-west-2"
+  logpull_options  = "fields=ClientIP,EdgeStartTimestamp&timestamps=unixnano"
+}
+
+# Job with output_options block
+resource "cloudflare_logpush_job" "with_output_options" {
+  account_id       = "f037e56e89293a057740de681ac9abbe"
+  dataset          = "http_requests"
+  destination_conf = "s3://mybucket/logs?region=us-west-2"
+
+  output_options = {
+    batch_prefix = "{"
+    batch_suffix = "}"
+    field_names  = ["ClientIP", "EdgeStartTimestamp"]
+    output_type  = "ndjson"
+  }
+}
+
+# Job with cve20214428 field (should be renamed)
+resource "cloudflare_logpush_job" "with_cve_field" {
+  account_id       = "f037e56e89293a057740de681ac9abbe"
+  dataset          = "http_requests"
+  destination_conf = "s3://mybucket/logs?region=us-west-2"
+
+  output_options = {
+    output_type    = "ndjson"
+    cve_2021_44228 = true
+  }
+}
+
+# Job with instant-logs kind (should become empty string)
+resource "cloudflare_logpush_job" "instant_logs" {
+  account_id       = "f037e56e89293a057740de681ac9abbe"
+  dataset          = "http_requests"
+  destination_conf = "s3://mybucket/logs?region=us-west-2"
+  kind             = ""
+}
+
+# Job with edge kind (should be preserved)
+resource "cloudflare_logpush_job" "edge_logs" {
+  account_id       = "f037e56e89293a057740de681ac9abbe"
+  dataset          = "http_requests"
+  destination_conf = "s3://mybucket/logs?region=us-west-2"
+  kind             = "edge"
+}
+
+# Full featured job with all transformations
+resource "cloudflare_logpush_job" "full" {
+  account_id       = "f037e56e89293a057740de681ac9abbe"
+  dataset          = "http_requests"
+  destination_conf = "s3://mybucket/logs?region=us-west-2"
+  kind             = ""
+  enabled          = true
+  name             = "my-logpush-job"
+  frequency        = "high"
+
+  output_options = {
+    batch_prefix     = "{"
+    batch_suffix     = "}"
+    field_names      = ["ClientIP", "EdgeStartTimestamp", "RayID"]
+    output_type      = "ndjson"
+    sample_rate      = 1.0
+    timestamp_format = "unixnano"
+    cve_2021_44228   = true
+  }
+}

--- a/integration/v4_to_v5/testdata/logpush_job/expected/terraform.tfstate
+++ b/integration/v4_to_v5/testdata/logpush_job/expected/terraform.tfstate
@@ -148,7 +148,7 @@
           "attributes": {
             "id": "7",
             "zone_id": "0da42c8d2132a9ddaf714f9e7c920711",
-            "dataset": "audit_logs",
+            "dataset": "http_requests",
             "destination_conf": "https://logpush-receiver.sd.cfplat.com",
             "enabled": true,
             "kind": "edge",

--- a/integration/v4_to_v5/testdata/logpush_job/expected/terraform.tfstate
+++ b/integration/v4_to_v5/testdata/logpush_job/expected/terraform.tfstate
@@ -111,8 +111,7 @@
             "account_id": "f037e56e89293a057740de681ac9abbe",
             "dataset": "http_requests",
             "destination_conf": "https://logpush-receiver.sd.cfplat.com",
-            "enabled": true,
-            "kind": ""
+            "enabled": true
           }
         }
       ]
@@ -150,7 +149,6 @@
             "dataset": "http_requests",
             "destination_conf": "https://logpush-receiver.sd.cfplat.com",
             "enabled": true,
-            "kind": "",
             "name": "my-logpush-job",
             "frequency": "high",
             "max_upload_bytes": 5000000.0,

--- a/integration/v4_to_v5/testdata/logpush_job/expected/terraform.tfstate
+++ b/integration/v4_to_v5/testdata/logpush_job/expected/terraform.tfstate
@@ -60,7 +60,12 @@
               "batch_prefix": "{",
               "batch_suffix": "}",
               "field_names": ["ClientIP", "EdgeStartTimestamp"],
-              "output_type": "ndjson"
+              "output_type": "ndjson",
+              "field_delimiter": ",",
+              "record_prefix": "{",
+              "record_suffix": "}\n",
+              "timestamp_format": "unixnano",
+              "sample_rate": 1.0
             }
           }
         }
@@ -82,7 +87,12 @@
             "enabled": true,
             "output_options": {
               "cve_2021_44228": true,
-              "output_type": "ndjson"
+              "output_type": "ndjson",
+              "field_delimiter": ",",
+              "record_prefix": "{",
+              "record_suffix": "}\n",
+              "timestamp_format": "unixnano",
+              "sample_rate": 1.0
             }
           }
         }
@@ -153,7 +163,10 @@
               "field_names": ["ClientIP", "EdgeStartTimestamp", "RayID"],
               "output_type": "ndjson",
               "sample_rate": 1.0,
-              "timestamp_format": "unixnano"
+              "timestamp_format": "unixnano",
+              "field_delimiter": ",",
+              "record_prefix": "{",
+              "record_suffix": "}\n"
             }
           }
         }

--- a/integration/v4_to_v5/testdata/logpush_job/expected/terraform.tfstate
+++ b/integration/v4_to_v5/testdata/logpush_job/expected/terraform.tfstate
@@ -1,0 +1,163 @@
+{
+  "version": 4,
+  "terraform_version": "1.5.0",
+  "serial": 1,
+  "lineage": "test-logpush-job-lineage",
+  "outputs": {},
+  "resources": [
+    {
+      "mode": "managed",
+      "type": "cloudflare_logpush_job",
+      "name": "minimal",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "1",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "dataset": "http_requests",
+            "destination_conf": "s3://mybucket/logs?region=us-west-2",
+            "enabled": true
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_logpush_job",
+      "name": "with_logpull_options",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "2",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "dataset": "http_requests",
+            "destination_conf": "s3://mybucket/logs?region=us-west-2",
+            "enabled": true,
+            "logpull_options": "fields=ClientIP,EdgeStartTimestamp&timestamps=unixnano"
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_logpush_job",
+      "name": "with_output_options",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "3",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "dataset": "http_requests",
+            "destination_conf": "s3://mybucket/logs?region=us-west-2",
+            "enabled": true,
+            "output_options": {
+              "batch_prefix": "{",
+              "batch_suffix": "}",
+              "field_names": ["ClientIP", "EdgeStartTimestamp"],
+              "output_type": "ndjson"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_logpush_job",
+      "name": "with_cve_field",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "4",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "dataset": "http_requests",
+            "destination_conf": "s3://mybucket/logs?region=us-west-2",
+            "enabled": true,
+            "output_options": {
+              "cve_2021_44228": true,
+              "output_type": "ndjson"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_logpush_job",
+      "name": "instant_logs",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "5",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "dataset": "http_requests",
+            "destination_conf": "s3://mybucket/logs?region=us-west-2",
+            "enabled": true,
+            "kind": ""
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_logpush_job",
+      "name": "edge_logs",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "6",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "dataset": "http_requests",
+            "destination_conf": "s3://mybucket/logs?region=us-west-2",
+            "enabled": true,
+            "kind": "edge"
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_logpush_job",
+      "name": "full",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "7",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "dataset": "http_requests",
+            "destination_conf": "s3://mybucket/logs?region=us-west-2",
+            "enabled": true,
+            "kind": "",
+            "name": "my-logpush-job",
+            "frequency": "high",
+            "max_upload_bytes": 5000000.0,
+            "max_upload_records": 1000.0,
+            "max_upload_interval_seconds": 30.0,
+            "output_options": {
+              "cve_2021_44228": true,
+              "batch_prefix": "{",
+              "batch_suffix": "}",
+              "field_names": ["ClientIP", "EdgeStartTimestamp", "RayID"],
+              "output_type": "ndjson",
+              "sample_rate": 1.0,
+              "timestamp_format": "unixnano"
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/integration/v4_to_v5/testdata/logpush_job/expected/terraform.tfstate
+++ b/integration/v4_to_v5/testdata/logpush_job/expected/terraform.tfstate
@@ -17,7 +17,7 @@
             "id": "1",
             "account_id": "f037e56e89293a057740de681ac9abbe",
             "dataset": "http_requests",
-            "destination_conf": "s3://mybucket/logs?region=us-west-2",
+            "destination_conf": "https://logpush-receiver.sd.cfplat.com",
             "enabled": true
           }
         }
@@ -35,7 +35,7 @@
             "id": "2",
             "account_id": "f037e56e89293a057740de681ac9abbe",
             "dataset": "http_requests",
-            "destination_conf": "s3://mybucket/logs?region=us-west-2",
+            "destination_conf": "https://logpush-receiver.sd.cfplat.com",
             "enabled": true,
             "logpull_options": "fields=ClientIP,EdgeStartTimestamp&timestamps=unixnano"
           }
@@ -54,7 +54,7 @@
             "id": "3",
             "account_id": "f037e56e89293a057740de681ac9abbe",
             "dataset": "http_requests",
-            "destination_conf": "s3://mybucket/logs?region=us-west-2",
+            "destination_conf": "https://logpush-receiver.sd.cfplat.com",
             "enabled": true,
             "output_options": {
               "batch_prefix": "{",
@@ -83,7 +83,7 @@
             "id": "4",
             "account_id": "f037e56e89293a057740de681ac9abbe",
             "dataset": "http_requests",
-            "destination_conf": "s3://mybucket/logs?region=us-west-2",
+            "destination_conf": "https://logpush-receiver.sd.cfplat.com",
             "enabled": true,
             "output_options": {
               "cve_2021_44228": true,
@@ -110,7 +110,7 @@
             "id": "5",
             "account_id": "f037e56e89293a057740de681ac9abbe",
             "dataset": "http_requests",
-            "destination_conf": "s3://mybucket/logs?region=us-west-2",
+            "destination_conf": "https://logpush-receiver.sd.cfplat.com",
             "enabled": true,
             "kind": ""
           }
@@ -129,7 +129,7 @@
             "id": "6",
             "account_id": "f037e56e89293a057740de681ac9abbe",
             "dataset": "http_requests",
-            "destination_conf": "s3://mybucket/logs?region=us-west-2",
+            "destination_conf": "https://logpush-receiver.sd.cfplat.com",
             "enabled": true,
             "kind": "edge"
           }
@@ -148,7 +148,7 @@
             "id": "7",
             "account_id": "f037e56e89293a057740de681ac9abbe",
             "dataset": "http_requests",
-            "destination_conf": "s3://mybucket/logs?region=us-west-2",
+            "destination_conf": "https://logpush-receiver.sd.cfplat.com",
             "enabled": true,
             "kind": "",
             "name": "my-logpush-job",

--- a/integration/v4_to_v5/testdata/logpush_job/expected/terraform.tfstate
+++ b/integration/v4_to_v5/testdata/logpush_job/expected/terraform.tfstate
@@ -16,7 +16,7 @@
           "attributes": {
             "id": "1",
             "account_id": "f037e56e89293a057740de681ac9abbe",
-            "dataset": "http_requests",
+            "dataset": "audit_logs",
             "destination_conf": "https://logpush-receiver.sd.cfplat.com",
             "enabled": true
           }
@@ -66,7 +66,7 @@
               "record_prefix": "{",
               "record_suffix": "}\n",
               "timestamp_format": "unixnano",
-              "sample_rate": 1.0
+              "sample_rate": 1
             }
           }
         }
@@ -93,7 +93,7 @@
               "record_prefix": "{",
               "record_suffix": "}\n",
               "timestamp_format": "unixnano",
-              "sample_rate": 1.0
+              "sample_rate": 1
             }
           }
         }
@@ -102,17 +102,18 @@
     {
       "mode": "managed",
       "type": "cloudflare_logpush_job",
-      "name": "instant_logs",
+      "name": "empty_kind",
       "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
       "instances": [
         {
           "schema_version": 0,
           "attributes": {
             "id": "5",
-            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "zone_id": "0da42c8d2132a9ddaf714f9e7c920711",
             "dataset": "http_requests",
             "destination_conf": "https://logpush-receiver.sd.cfplat.com",
-            "enabled": true
+            "enabled": true,
+            "kind": ""
           }
         }
       ]
@@ -127,7 +128,7 @@
           "schema_version": 0,
           "attributes": {
             "id": "6",
-            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "zone_id": "0da42c8d2132a9ddaf714f9e7c920711",
             "dataset": "http_requests",
             "destination_conf": "https://logpush-receiver.sd.cfplat.com",
             "enabled": true,
@@ -146,22 +147,23 @@
           "schema_version": 0,
           "attributes": {
             "id": "7",
-            "account_id": "f037e56e89293a057740de681ac9abbe",
-            "dataset": "http_requests",
+            "zone_id": "0da42c8d2132a9ddaf714f9e7c920711",
+            "dataset": "audit_logs",
             "destination_conf": "https://logpush-receiver.sd.cfplat.com",
             "enabled": true,
+            "kind": "edge",
             "name": "my-logpush-job",
             "frequency": "high",
-            "max_upload_bytes": 5000000.0,
-            "max_upload_records": 1000.0,
-            "max_upload_interval_seconds": 30.0,
+            "max_upload_bytes": 5000000,
+            "max_upload_records": 1000,
+            "max_upload_interval_seconds": 30,
             "output_options": {
               "cve_2021_44228": true,
               "batch_prefix": "{",
               "batch_suffix": "}",
               "field_names": ["ClientIP", "EdgeStartTimestamp", "RayID"],
               "output_type": "ndjson",
-              "sample_rate": 1.0,
+              "sample_rate": 1,
               "timestamp_format": "unixnano",
               "field_delimiter": ",",
               "record_prefix": "{",

--- a/integration/v4_to_v5/testdata/logpush_job/expected/terraform.tfstate
+++ b/integration/v4_to_v5/testdata/logpush_job/expected/terraform.tfstate
@@ -61,6 +61,7 @@
               "batch_suffix": "}",
               "field_names": ["ClientIP", "EdgeStartTimestamp"],
               "output_type": "ndjson",
+              "cve_2021_44228": false,
               "field_delimiter": ",",
               "record_prefix": "{",
               "record_suffix": "}\n",

--- a/integration/v4_to_v5/testdata/logpush_job/input/logpush_job.tf
+++ b/integration/v4_to_v5/testdata/logpush_job/input/logpush_job.tf
@@ -1,0 +1,77 @@
+# Minimal logpush job
+resource "cloudflare_logpush_job" "minimal" {
+  account_id       = "f037e56e89293a057740de681ac9abbe"
+  dataset          = "http_requests"
+  destination_conf = "s3://mybucket/logs?region=us-west-2"
+}
+
+# Job with logpull_options only (no output_options)
+resource "cloudflare_logpush_job" "with_logpull_options" {
+  account_id       = "f037e56e89293a057740de681ac9abbe"
+  dataset          = "http_requests"
+  destination_conf = "s3://mybucket/logs?region=us-west-2"
+  logpull_options  = "fields=ClientIP,EdgeStartTimestamp&timestamps=unixnano"
+}
+
+# Job with output_options block
+resource "cloudflare_logpush_job" "with_output_options" {
+  account_id       = "f037e56e89293a057740de681ac9abbe"
+  dataset          = "http_requests"
+  destination_conf = "s3://mybucket/logs?region=us-west-2"
+
+  output_options {
+    batch_prefix = "{"
+    batch_suffix = "}"
+    field_names  = ["ClientIP", "EdgeStartTimestamp"]
+    output_type  = "ndjson"
+  }
+}
+
+# Job with cve20214428 field (should be renamed)
+resource "cloudflare_logpush_job" "with_cve_field" {
+  account_id       = "f037e56e89293a057740de681ac9abbe"
+  dataset          = "http_requests"
+  destination_conf = "s3://mybucket/logs?region=us-west-2"
+
+  output_options {
+    cve20214428 = true
+    output_type = "ndjson"
+  }
+}
+
+# Job with instant-logs kind (should become empty string)
+resource "cloudflare_logpush_job" "instant_logs" {
+  account_id       = "f037e56e89293a057740de681ac9abbe"
+  dataset          = "http_requests"
+  destination_conf = "s3://mybucket/logs?region=us-west-2"
+  kind             = "instant-logs"
+}
+
+# Job with edge kind (should be preserved)
+resource "cloudflare_logpush_job" "edge_logs" {
+  account_id       = "f037e56e89293a057740de681ac9abbe"
+  dataset          = "http_requests"
+  destination_conf = "s3://mybucket/logs?region=us-west-2"
+  kind             = "edge"
+}
+
+# Full featured job with all transformations
+resource "cloudflare_logpush_job" "full" {
+  account_id       = "f037e56e89293a057740de681ac9abbe"
+  dataset          = "http_requests"
+  destination_conf = "s3://mybucket/logs?region=us-west-2"
+  kind             = "instant-logs"
+  enabled          = true
+  name             = "my-logpush-job"
+  frequency        = "high"
+
+  output_options {
+    cve20214428      = true
+    batch_prefix     = "{"
+    batch_suffix     = "}"
+    field_names      = ["ClientIP", "EdgeStartTimestamp", "RayID"]
+    output_type      = "ndjson"
+    sample_rate      = 1.0
+    timestamp_format = "unixnano"
+  }
+}

--- a/integration/v4_to_v5/testdata/logpush_job/input/logpush_job.tf
+++ b/integration/v4_to_v5/testdata/logpush_job/input/logpush_job.tf
@@ -39,7 +39,7 @@ resource "cloudflare_logpush_job" "with_cve_field" {
   }
 }
 
-# Job with instant-logs kind (should become empty string)
+# Job with instant-logs kind (should be removed)
 resource "cloudflare_logpush_job" "instant_logs" {
   zone_id          = var.cloudflare_zone_id
   dataset          = "http_requests"
@@ -53,6 +53,14 @@ resource "cloudflare_logpush_job" "edge_logs" {
   dataset          = "http_requests"
   destination_conf = "https://logpush-receiver.sd.cfplat.com"
   kind             = "edge"
+}
+
+# Job with "" kind (should be preserved)
+resource "cloudflare_logpush_job" "edge_logs" {
+  zone_id          = var.cloudflare_zone_id
+  dataset          = "http_requests"
+  destination_conf = "https://logpush-receiver.sd.cfplat.com"
+  kind             = ""
 }
 
 # Full featured job with all transformations

--- a/integration/v4_to_v5/testdata/logpush_job/input/logpush_job.tf
+++ b/integration/v4_to_v5/testdata/logpush_job/input/logpush_job.tf
@@ -1,3 +1,13 @@
+variable "cloudflare_account_id" {
+  description = "Cloudflare account ID"
+  type        = string
+}
+
+variable "cloudflare_zone_id" {
+  description = "Cloudflare zone ID"
+  type        = string
+}
+
 # Minimal logpush job
 resource "cloudflare_logpush_job" "minimal" {
   account_id       = var.cloudflare_account_id
@@ -56,7 +66,7 @@ resource "cloudflare_logpush_job" "edge_logs" {
 }
 
 # Job with "" kind (should be preserved)
-resource "cloudflare_logpush_job" "edge_logs" {
+resource "cloudflare_logpush_job" "empty_kind" {
   zone_id          = var.cloudflare_zone_id
   dataset          = "http_requests"
   destination_conf = "https://logpush-receiver.sd.cfplat.com"

--- a/integration/v4_to_v5/testdata/logpush_job/input/logpush_job.tf
+++ b/integration/v4_to_v5/testdata/logpush_job/input/logpush_job.tf
@@ -68,7 +68,7 @@ resource "cloudflare_logpush_job" "empty_kind" {
 # Full featured job with all transformations
 resource "cloudflare_logpush_job" "full" {
   zone_id          = var.cloudflare_zone_id
-  dataset          = "audit_logs"
+  dataset          = "http_requests"
   destination_conf = "https://logpush-receiver.sd.cfplat.com"
   kind             = "edge"
   enabled          = true

--- a/integration/v4_to_v5/testdata/logpush_job/input/logpush_job.tf
+++ b/integration/v4_to_v5/testdata/logpush_job/input/logpush_job.tf
@@ -1,23 +1,23 @@
 # Minimal logpush job
 resource "cloudflare_logpush_job" "minimal" {
-  account_id       = "f037e56e89293a057740de681ac9abbe"
+  account_id       = var.cloudflare_account_id
   dataset          = "audit_logs"
-  destination_conf = "s3://mybucket/logs?region=us-west-2"
+  destination_conf = "https://logpush-receiver.sd.cfplat.com"
 }
 
 # Job with logpull_options only (no output_options)
 resource "cloudflare_logpush_job" "with_logpull_options" {
-  account_id       = "f037e56e89293a057740de681ac9abbe"
+  account_id       = var.cloudflare_account_id
   dataset          = "audit_logs"
-  destination_conf = "s3://mybucket/logs?region=us-west-2"
+  destination_conf = "https://logpush-receiver.sd.cfplat.com"
   logpull_options  = "fields=ClientIP,EdgeStartTimestamp&timestamps=unixnano"
 }
 
 # Job with output_options block
 resource "cloudflare_logpush_job" "with_output_options" {
-  account_id       = "f037e56e89293a057740de681ac9abbe"
+  account_id       = var.cloudflare_account_id
   dataset          = "audit_logs"
-  destination_conf = "s3://mybucket/logs?region=us-west-2"
+  destination_conf = "https://logpush-receiver.sd.cfplat.com"
 
   output_options {
     batch_prefix = "{"
@@ -29,9 +29,9 @@ resource "cloudflare_logpush_job" "with_output_options" {
 
 # Job with cve20214428 field (should be renamed)
 resource "cloudflare_logpush_job" "with_cve_field" {
-  account_id       = "f037e56e89293a057740de681ac9abbe"
+  account_id       = var.cloudflare_account_id
   dataset          = "audit_logs"
-  destination_conf = "s3://mybucket/logs?region=us-west-2"
+  destination_conf = "https://logpush-receiver.sd.cfplat.com"
 
   output_options {
     cve20214428 = true
@@ -41,25 +41,25 @@ resource "cloudflare_logpush_job" "with_cve_field" {
 
 # Job with instant-logs kind (should become empty string)
 resource "cloudflare_logpush_job" "instant_logs" {
-  zone_id       = "0da42c8d2132a9ddaf714f9e7c920711"
+  zone_id          = var.cloudflare_zone_id
   dataset          = "http_requests"
-  destination_conf = "s3://mybucket/logs?region=us-west-2"
+  destination_conf = "https://logpush-receiver.sd.cfplat.com"
   kind             = "instant-logs"
 }
 
 # Job with edge kind (should be preserved)
 resource "cloudflare_logpush_job" "edge_logs" {
-  zone_id       = "0da42c8d2132a9ddaf714f9e7c920711"
+  zone_id          = var.cloudflare_zone_id
   dataset          = "http_requests"
-  destination_conf = "s3://mybucket/logs?region=us-west-2"
+  destination_conf = "https://logpush-receiver.sd.cfplat.com"
   kind             = "edge"
 }
 
 # Full featured job with all transformations
 resource "cloudflare_logpush_job" "full" {
-  zone_id       = "0da42c8d2132a9ddaf714f9e7c920711"
+  zone_id          = var.cloudflare_zone_id
   dataset          = "http_requests"
-  destination_conf = "s3://mybucket/logs?region=us-west-2"
+  destination_conf = "https://logpush-receiver.sd.cfplat.com"
   kind             = "instant-logs"
   enabled          = true
   name             = "my-logpush-job"

--- a/integration/v4_to_v5/testdata/logpush_job/input/logpush_job.tf
+++ b/integration/v4_to_v5/testdata/logpush_job/input/logpush_job.tf
@@ -49,14 +49,6 @@ resource "cloudflare_logpush_job" "with_cve_field" {
   }
 }
 
-# Job with instant-logs kind (should be removed)
-resource "cloudflare_logpush_job" "instant_logs" {
-  zone_id          = var.cloudflare_zone_id
-  dataset          = "http_requests"
-  destination_conf = "https://logpush-receiver.sd.cfplat.com"
-  kind             = "instant-logs"
-}
-
 # Job with edge kind (should be preserved)
 resource "cloudflare_logpush_job" "edge_logs" {
   zone_id          = var.cloudflare_zone_id
@@ -76,9 +68,9 @@ resource "cloudflare_logpush_job" "empty_kind" {
 # Full featured job with all transformations
 resource "cloudflare_logpush_job" "full" {
   zone_id          = var.cloudflare_zone_id
-  dataset          = "http_requests"
+  dataset          = "audit_logs"
   destination_conf = "https://logpush-receiver.sd.cfplat.com"
-  kind             = "instant-logs"
+  kind             = "edge"
   enabled          = true
   name             = "my-logpush-job"
   frequency        = "high"

--- a/integration/v4_to_v5/testdata/logpush_job/input/logpush_job.tf
+++ b/integration/v4_to_v5/testdata/logpush_job/input/logpush_job.tf
@@ -1,14 +1,14 @@
 # Minimal logpush job
 resource "cloudflare_logpush_job" "minimal" {
   account_id       = "f037e56e89293a057740de681ac9abbe"
-  dataset          = "http_requests"
+  dataset          = "audit_logs"
   destination_conf = "s3://mybucket/logs?region=us-west-2"
 }
 
 # Job with logpull_options only (no output_options)
 resource "cloudflare_logpush_job" "with_logpull_options" {
   account_id       = "f037e56e89293a057740de681ac9abbe"
-  dataset          = "http_requests"
+  dataset          = "audit_logs"
   destination_conf = "s3://mybucket/logs?region=us-west-2"
   logpull_options  = "fields=ClientIP,EdgeStartTimestamp&timestamps=unixnano"
 }
@@ -16,7 +16,7 @@ resource "cloudflare_logpush_job" "with_logpull_options" {
 # Job with output_options block
 resource "cloudflare_logpush_job" "with_output_options" {
   account_id       = "f037e56e89293a057740de681ac9abbe"
-  dataset          = "http_requests"
+  dataset          = "audit_logs"
   destination_conf = "s3://mybucket/logs?region=us-west-2"
 
   output_options {
@@ -30,7 +30,7 @@ resource "cloudflare_logpush_job" "with_output_options" {
 # Job with cve20214428 field (should be renamed)
 resource "cloudflare_logpush_job" "with_cve_field" {
   account_id       = "f037e56e89293a057740de681ac9abbe"
-  dataset          = "http_requests"
+  dataset          = "audit_logs"
   destination_conf = "s3://mybucket/logs?region=us-west-2"
 
   output_options {
@@ -41,7 +41,7 @@ resource "cloudflare_logpush_job" "with_cve_field" {
 
 # Job with instant-logs kind (should become empty string)
 resource "cloudflare_logpush_job" "instant_logs" {
-  account_id       = "f037e56e89293a057740de681ac9abbe"
+  zone_id       = "0da42c8d2132a9ddaf714f9e7c920711"
   dataset          = "http_requests"
   destination_conf = "s3://mybucket/logs?region=us-west-2"
   kind             = "instant-logs"
@@ -49,7 +49,7 @@ resource "cloudflare_logpush_job" "instant_logs" {
 
 # Job with edge kind (should be preserved)
 resource "cloudflare_logpush_job" "edge_logs" {
-  account_id       = "f037e56e89293a057740de681ac9abbe"
+  zone_id       = "0da42c8d2132a9ddaf714f9e7c920711"
   dataset          = "http_requests"
   destination_conf = "s3://mybucket/logs?region=us-west-2"
   kind             = "edge"
@@ -57,7 +57,7 @@ resource "cloudflare_logpush_job" "edge_logs" {
 
 # Full featured job with all transformations
 resource "cloudflare_logpush_job" "full" {
-  account_id       = "f037e56e89293a057740de681ac9abbe"
+  zone_id       = "0da42c8d2132a9ddaf714f9e7c920711"
   dataset          = "http_requests"
   destination_conf = "s3://mybucket/logs?region=us-west-2"
   kind             = "instant-logs"

--- a/integration/v4_to_v5/testdata/logpush_job/input/terraform.tfstate
+++ b/integration/v4_to_v5/testdata/logpush_job/input/terraform.tfstate
@@ -148,7 +148,7 @@
           "attributes": {
             "id": "7",
             "zone_id": "0da42c8d2132a9ddaf714f9e7c920711",
-            "dataset": "audit_logs",
+            "dataset": "http_requests",
             "destination_conf": "https://logpush-receiver.sd.cfplat.com",
             "enabled": true,
             "kind": "edge",

--- a/integration/v4_to_v5/testdata/logpush_job/input/terraform.tfstate
+++ b/integration/v4_to_v5/testdata/logpush_job/input/terraform.tfstate
@@ -1,0 +1,172 @@
+{
+  "version": 4,
+  "terraform_version": "1.5.0",
+  "serial": 1,
+  "lineage": "test-logpush-job-lineage",
+  "outputs": {},
+  "resources": [
+    {
+      "mode": "managed",
+      "type": "cloudflare_logpush_job",
+      "name": "minimal",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "1",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "dataset": "http_requests",
+            "destination_conf": "s3://mybucket/logs?region=us-west-2",
+            "enabled": true
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_logpush_job",
+      "name": "with_logpull_options",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "2",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "dataset": "http_requests",
+            "destination_conf": "s3://mybucket/logs?region=us-west-2",
+            "enabled": true,
+            "logpull_options": "fields=ClientIP,EdgeStartTimestamp&timestamps=unixnano"
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_logpush_job",
+      "name": "with_output_options",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "3",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "dataset": "http_requests",
+            "destination_conf": "s3://mybucket/logs?region=us-west-2",
+            "enabled": true,
+            "output_options": [
+              {
+                "batch_prefix": "{",
+                "batch_suffix": "}",
+                "field_names": ["ClientIP", "EdgeStartTimestamp"],
+                "output_type": "ndjson"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_logpush_job",
+      "name": "with_cve_field",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "4",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "dataset": "http_requests",
+            "destination_conf": "s3://mybucket/logs?region=us-west-2",
+            "enabled": true,
+            "output_options": [
+              {
+                "cve20214428": true,
+                "output_type": "ndjson"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_logpush_job",
+      "name": "instant_logs",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "5",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "dataset": "http_requests",
+            "destination_conf": "s3://mybucket/logs?region=us-west-2",
+            "enabled": true,
+            "kind": "instant-logs"
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_logpush_job",
+      "name": "edge_logs",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "6",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "dataset": "http_requests",
+            "destination_conf": "s3://mybucket/logs?region=us-west-2",
+            "enabled": true,
+            "kind": "edge"
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_logpush_job",
+      "name": "full",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "7",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "dataset": "http_requests",
+            "destination_conf": "s3://mybucket/logs?region=us-west-2",
+            "enabled": true,
+            "kind": "instant-logs",
+            "name": "my-logpush-job",
+            "frequency": "high",
+            "max_upload_bytes": 5000000,
+            "max_upload_records": 1000,
+            "max_upload_interval_seconds": 30,
+            "output_options": [
+              {
+                "cve20214428": true,
+                "batch_prefix": "{",
+                "batch_suffix": "}",
+                "field_names": ["ClientIP", "EdgeStartTimestamp", "RayID"],
+                "output_type": "ndjson",
+                "sample_rate": 1.0,
+                "timestamp_format": "unixnano"
+              }
+            ],
+            "error_message": "Some error",
+            "last_complete": "2024-01-01T00:00:00Z",
+            "last_error": "2024-01-01T00:00:00Z"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/integration/v4_to_v5/testdata/logpush_job/input/terraform.tfstate
+++ b/integration/v4_to_v5/testdata/logpush_job/input/terraform.tfstate
@@ -17,7 +17,7 @@
             "id": "1",
             "account_id": "f037e56e89293a057740de681ac9abbe",
             "dataset": "http_requests",
-            "destination_conf": "s3://mybucket/logs?region=us-west-2",
+            "destination_conf": "https://logpush-receiver.sd.cfplat.com",
             "enabled": true
           }
         }
@@ -35,7 +35,7 @@
             "id": "2",
             "account_id": "f037e56e89293a057740de681ac9abbe",
             "dataset": "http_requests",
-            "destination_conf": "s3://mybucket/logs?region=us-west-2",
+            "destination_conf": "https://logpush-receiver.sd.cfplat.com",
             "enabled": true,
             "logpull_options": "fields=ClientIP,EdgeStartTimestamp&timestamps=unixnano"
           }
@@ -54,7 +54,7 @@
             "id": "3",
             "account_id": "f037e56e89293a057740de681ac9abbe",
             "dataset": "http_requests",
-            "destination_conf": "s3://mybucket/logs?region=us-west-2",
+            "destination_conf": "https://logpush-receiver.sd.cfplat.com",
             "enabled": true,
             "output_options": [
               {
@@ -80,7 +80,7 @@
             "id": "4",
             "account_id": "f037e56e89293a057740de681ac9abbe",
             "dataset": "http_requests",
-            "destination_conf": "s3://mybucket/logs?region=us-west-2",
+            "destination_conf": "https://logpush-receiver.sd.cfplat.com",
             "enabled": true,
             "output_options": [
               {
@@ -104,7 +104,7 @@
             "id": "5",
             "account_id": "f037e56e89293a057740de681ac9abbe",
             "dataset": "http_requests",
-            "destination_conf": "s3://mybucket/logs?region=us-west-2",
+            "destination_conf": "https://logpush-receiver.sd.cfplat.com",
             "enabled": true,
             "kind": "instant-logs"
           }
@@ -123,7 +123,7 @@
             "id": "6",
             "account_id": "f037e56e89293a057740de681ac9abbe",
             "dataset": "http_requests",
-            "destination_conf": "s3://mybucket/logs?region=us-west-2",
+            "destination_conf": "https://logpush-receiver.sd.cfplat.com",
             "enabled": true,
             "kind": "edge"
           }
@@ -142,7 +142,7 @@
             "id": "7",
             "account_id": "f037e56e89293a057740de681ac9abbe",
             "dataset": "http_requests",
-            "destination_conf": "s3://mybucket/logs?region=us-west-2",
+            "destination_conf": "https://logpush-receiver.sd.cfplat.com",
             "enabled": true,
             "kind": "instant-logs",
             "name": "my-logpush-job",

--- a/integration/v4_to_v5/testdata/logpush_job/input/terraform.tfstate
+++ b/integration/v4_to_v5/testdata/logpush_job/input/terraform.tfstate
@@ -16,7 +16,7 @@
           "attributes": {
             "id": "1",
             "account_id": "f037e56e89293a057740de681ac9abbe",
-            "dataset": "http_requests",
+            "dataset": "audit_logs",
             "destination_conf": "https://logpush-receiver.sd.cfplat.com",
             "enabled": true
           }
@@ -56,14 +56,18 @@
             "dataset": "http_requests",
             "destination_conf": "https://logpush-receiver.sd.cfplat.com",
             "enabled": true,
-            "output_options": [
-              {
-                "batch_prefix": "{",
-                "batch_suffix": "}",
-                "field_names": ["ClientIP", "EdgeStartTimestamp"],
-                "output_type": "ndjson"
-              }
-            ]
+            "output_options": {
+              "batch_prefix": "{",
+              "batch_suffix": "}",
+              "field_names": ["ClientIP", "EdgeStartTimestamp"],
+              "output_type": "ndjson",
+              "cve_2021_44228": false,
+              "field_delimiter": ",",
+              "record_prefix": "{",
+              "record_suffix": "}\n",
+              "timestamp_format": "unixnano",
+              "sample_rate": 1
+            }
           }
         }
       ]
@@ -82,12 +86,15 @@
             "dataset": "http_requests",
             "destination_conf": "https://logpush-receiver.sd.cfplat.com",
             "enabled": true,
-            "output_options": [
-              {
-                "cve20214428": true,
-                "output_type": "ndjson"
-              }
-            ]
+            "output_options": {
+              "cve_2021_44228": true,
+              "output_type": "ndjson",
+              "field_delimiter": ",",
+              "record_prefix": "{",
+              "record_suffix": "}\n",
+              "timestamp_format": "unixnano",
+              "sample_rate": 1
+            }
           }
         }
       ]
@@ -95,18 +102,18 @@
     {
       "mode": "managed",
       "type": "cloudflare_logpush_job",
-      "name": "instant_logs",
+      "name": "empty_kind",
       "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
       "instances": [
         {
           "schema_version": 0,
           "attributes": {
             "id": "5",
-            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "zone_id": "0da42c8d2132a9ddaf714f9e7c920711",
             "dataset": "http_requests",
             "destination_conf": "https://logpush-receiver.sd.cfplat.com",
             "enabled": true,
-            "kind": "instant-logs"
+            "kind": ""
           }
         }
       ]
@@ -121,7 +128,7 @@
           "schema_version": 0,
           "attributes": {
             "id": "6",
-            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "zone_id": "0da42c8d2132a9ddaf714f9e7c920711",
             "dataset": "http_requests",
             "destination_conf": "https://logpush-receiver.sd.cfplat.com",
             "enabled": true,
@@ -140,27 +147,28 @@
           "schema_version": 0,
           "attributes": {
             "id": "7",
-            "account_id": "f037e56e89293a057740de681ac9abbe",
-            "dataset": "http_requests",
+            "zone_id": "0da42c8d2132a9ddaf714f9e7c920711",
+            "dataset": "audit_logs",
             "destination_conf": "https://logpush-receiver.sd.cfplat.com",
             "enabled": true,
-            "kind": "instant-logs",
+            "kind": "edge",
             "name": "my-logpush-job",
             "frequency": "high",
             "max_upload_bytes": 5000000,
             "max_upload_records": 1000,
             "max_upload_interval_seconds": 30,
-            "output_options": [
-              {
-                "cve20214428": true,
-                "batch_prefix": "{",
-                "batch_suffix": "}",
-                "field_names": ["ClientIP", "EdgeStartTimestamp", "RayID"],
-                "output_type": "ndjson",
-                "sample_rate": 1.0,
-                "timestamp_format": "unixnano"
-              }
-            ],
+            "output_options": {
+              "cve_2021_44228": true,
+              "batch_prefix": "{",
+              "batch_suffix": "}",
+              "field_names": ["ClientIP", "EdgeStartTimestamp", "RayID"],
+              "output_type": "ndjson",
+              "sample_rate": 1,
+              "timestamp_format": "unixnano",
+              "field_delimiter": ",",
+              "record_prefix": "{",
+              "record_suffix": "}\n"
+            },
             "error_message": "Some error",
             "last_complete": "2024-01-01T00:00:00Z",
             "last_error": "2024-01-01T00:00:00Z"

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -7,14 +7,15 @@ import (
 	"github.com/cloudflare/tf-migrate/internal/resources/api_token"
 	"github.com/cloudflare/tf-migrate/internal/resources/dns_record"
 	"github.com/cloudflare/tf-migrate/internal/resources/logpull_retention"
+	"github.com/cloudflare/tf-migrate/internal/resources/logpush_job"
 	"github.com/cloudflare/tf-migrate/internal/resources/notification_policy_webhooks"
 	"github.com/cloudflare/tf-migrate/internal/resources/r2_bucket"
 	"github.com/cloudflare/tf-migrate/internal/resources/workers_kv"
 	"github.com/cloudflare/tf-migrate/internal/resources/workers_kv_namespace"
 	"github.com/cloudflare/tf-migrate/internal/resources/zero_trust_access_service_token"
+	"github.com/cloudflare/tf-migrate/internal/resources/zero_trust_device_posture_rule"
 	"github.com/cloudflare/tf-migrate/internal/resources/zero_trust_dlp_custom_profile"
 	"github.com/cloudflare/tf-migrate/internal/resources/zero_trust_gateway_policy"
-	"github.com/cloudflare/tf-migrate/internal/resources/zero_trust_device_posture_rule"
 	"github.com/cloudflare/tf-migrate/internal/resources/zero_trust_list"
 	"github.com/cloudflare/tf-migrate/internal/resources/zero_trust_tunnel_cloudflared"
 	"github.com/cloudflare/tf-migrate/internal/resources/zero_trust_tunnel_cloudflared_route"
@@ -37,6 +38,7 @@ func RegisterAllMigrations() {
 	zone.NewV4ToV5Migrator()
 	zone_dnssec.NewV4ToV5Migrator()
 	logpull_retention.NewV4ToV5Migrator()
+	logpush_job.NewV4ToV5Migrator()
 	notification_policy_webhooks.NewV4ToV5Migrator()
 	r2_bucket.NewV4ToV5Migrator()
 	workers_kv.NewV4ToV5Migrator()

--- a/internal/resources/logpush_job/v4_to_v5.go
+++ b/internal/resources/logpush_job/v4_to_v5.go
@@ -83,6 +83,7 @@ func (m *V4ToV5Migrator) ensureV4SchemaDefaults(body *hclwrite.Body) {
 	}
 
 	v4Defaults := []defaultPair{
+		{"cve_2021_44228", false},
 		{"field_delimiter", ","},
 		{"record_prefix", "{"},
 		{"record_suffix", "}\n"},
@@ -228,6 +229,7 @@ func (m *V4ToV5Migrator) transformOutputOptions(result string, attrs gjson.Resul
 // addV4SchemaDefaultsToState adds v4 schema defaults to state object if not present
 func (m *V4ToV5Migrator) addV4SchemaDefaultsToState(obj map[string]interface{}) {
 	v4Defaults := map[string]interface{}{
+		"cve_2021_44228":   false,
 		"field_delimiter":  ",",
 		"record_prefix":    "{",
 		"record_suffix":    "}\n",

--- a/internal/resources/logpush_job/v4_to_v5.go
+++ b/internal/resources/logpush_job/v4_to_v5.go
@@ -88,7 +88,7 @@ func (m *V4ToV5Migrator) ensureV4SchemaDefaults(body *hclwrite.Body) {
 		{"record_prefix", "{"},
 		{"record_suffix", "}\n"},
 		{"timestamp_format", "unixnano"},
-		{"sample_rate", 1.0},
+		{"sample_rate", 1},
 	}
 
 	for _, pair := range v4Defaults {
@@ -234,7 +234,7 @@ func (m *V4ToV5Migrator) addV4SchemaDefaultsToState(obj map[string]interface{}) 
 		"record_prefix":    "{",
 		"record_suffix":    "}\n",
 		"timestamp_format": "unixnano",
-		"sample_rate":      1.0,
+		"sample_rate":      1,
 	}
 
 	for field, defaultValue := range v4Defaults {

--- a/internal/resources/logpush_job/v4_to_v5.go
+++ b/internal/resources/logpush_job/v4_to_v5.go
@@ -23,17 +23,20 @@ func NewV4ToV5Migrator() transform.ResourceTransformer {
 }
 
 func (m *V4ToV5Migrator) GetResourceType() string {
-	// Return the NEW (v5) resource name - same as v4
 	return "cloudflare_logpush_job"
 }
 
 func (m *V4ToV5Migrator) CanHandle(resourceType string) bool {
-	// Check for the OLD (v4) resource name
 	return resourceType == "cloudflare_logpush_job"
 }
 
 func (m *V4ToV5Migrator) Preprocess(content string) string {
 	return content
+}
+
+// This resource does not rename, so we return the same name for both old and new
+func (m *V4ToV5Migrator) GetResourceRename() (string, string) {
+	return "cloudflare_logpush_job", "cloudflare_logpush_job"
 }
 
 func (m *V4ToV5Migrator) TransformConfig(ctx *transform.Context, block *hclwrite.Block) (*transform.TransformResult, error) {
@@ -98,7 +101,7 @@ func (m *V4ToV5Migrator) ensureV4SchemaDefaults(body *hclwrite.Body) {
 	}
 }
 
-func (m *V4ToV5Migrator) TransformState(ctx *transform.Context, stateJSON gjson.Result, resourcePath string) (string, error) {
+func (m *V4ToV5Migrator) TransformState(ctx *transform.Context, stateJSON gjson.Result, resourcePath string, resourceName string) (string, error) {
 	result := stateJSON.String()
 
 	if !stateJSON.Exists() || !stateJSON.Get("attributes").Exists() {

--- a/internal/resources/logpush_job/v4_to_v5.go
+++ b/internal/resources/logpush_job/v4_to_v5.go
@@ -129,7 +129,6 @@ func (m *V4ToV5Migrator) TransformState(ctx *transform.Context, stateJSON gjson.
 }
 
 // convertNumericFields converts integer fields to float64 for int64 compatibility
-// and removes fields with value 0 since they're API defaults and marked as no_refresh in v5
 func (m *V4ToV5Migrator) convertNumericFields(result string, attrs gjson.Result) string {
 	numericFields := []string{
 		"max_upload_bytes",

--- a/internal/resources/logpush_job/v4_to_v5.go
+++ b/internal/resources/logpush_job/v4_to_v5.go
@@ -139,16 +139,8 @@ func (m *V4ToV5Migrator) convertNumericFields(result string, attrs gjson.Result)
 
 	for _, field := range numericFields {
 		if val := attrs.Get(field); val.Exists() {
-			// These fields are marked as no_refresh in v5, so if they're 0 (API default),
-			// they should not be in state unless explicitly set in config.
-			// Since we can't determine if they were in config, we remove 0 values
-			// to match v5's behavior where these are only in state if explicitly configured.
-			if val.Type == gjson.Number && val.Float() == 0 {
-				result, _ = sjson.Delete(result, "attributes."+field)
-			} else {
-				// Convert to float64 for int64 compatibility
-				result, _ = sjson.Set(result, "attributes."+field, state.ConvertToFloat64(val))
-			}
+			// Convert to float64 for int64 compatibility
+			result, _ = sjson.Set(result, "attributes."+field, state.ConvertToFloat64(val))
 		}
 	}
 

--- a/internal/resources/logpush_job/v4_to_v5.go
+++ b/internal/resources/logpush_job/v4_to_v5.go
@@ -1,0 +1,154 @@
+package logpush_job
+
+import (
+	"github.com/hashicorp/hcl/v2/hclwrite"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+
+	"github.com/cloudflare/tf-migrate/internal"
+	"github.com/cloudflare/tf-migrate/internal/hcl"
+	"github.com/cloudflare/tf-migrate/internal/transform"
+	tfhcl "github.com/cloudflare/tf-migrate/internal/transform/hcl"
+	"github.com/cloudflare/tf-migrate/internal/transform/state"
+)
+
+type V4ToV5Migrator struct {
+}
+
+func NewV4ToV5Migrator() transform.ResourceTransformer {
+	migrator := &V4ToV5Migrator{}
+	// Register with the OLD (v4) resource name - same as v5 in this case
+	internal.RegisterMigrator("cloudflare_logpush_job", "v4", "v5", migrator)
+	return migrator
+}
+
+func (m *V4ToV5Migrator) GetResourceType() string {
+	// Return the NEW (v5) resource name - same as v4
+	return "cloudflare_logpush_job"
+}
+
+func (m *V4ToV5Migrator) CanHandle(resourceType string) bool {
+	// Check for the OLD (v4) resource name
+	return resourceType == "cloudflare_logpush_job"
+}
+
+func (m *V4ToV5Migrator) Preprocess(content string) string {
+	return content
+}
+
+func (m *V4ToV5Migrator) TransformConfig(ctx *transform.Context, block *hclwrite.Block) (*transform.TransformResult, error) {
+	body := block.Body()
+
+	// 1. Convert output_options block to attribute (block → attribute syntax)
+	// This handles: output_options { ... } → output_options = { ... }
+	if outputBlock := tfhcl.FindBlockByType(body, "output_options"); outputBlock != nil {
+		// Rename cve20214428 → cve_2021_44228 BEFORE conversion
+		tfhcl.RenameAttribute(outputBlock.Body(), "cve20214428", "cve_2021_44228")
+		tfhcl.ConvertSingleBlockToAttribute(body, "output_options", "output_options")
+	}
+
+	// 2. Handle kind = "instant-logs" → kind = ""
+	// "instant-logs" is no longer valid in v5, convert to empty string
+	if kindAttr := body.GetAttribute("kind"); kindAttr != nil {
+		kindValue := tfhcl.ExtractStringFromAttribute(kindAttr)
+		if kindValue == "instant-logs" {
+			// Set to empty string (default in v5)
+			tokens := hcl.TokensForSimpleValue("")
+			if tokens != nil {
+				body.SetAttributeRaw("kind", tokens)
+			}
+		}
+	}
+
+	return &transform.TransformResult{
+		Blocks:         []*hclwrite.Block{block},
+		RemoveOriginal: false,
+	}, nil
+}
+
+func (m *V4ToV5Migrator) TransformState(ctx *transform.Context, stateJSON gjson.Result, resourcePath string) (string, error) {
+	result := stateJSON.String()
+
+	if !stateJSON.Exists() || !stateJSON.Get("attributes").Exists() {
+		return result, nil
+	}
+
+	attrs := stateJSON.Get("attributes")
+
+	// 1. Convert integer fields to float64 for int64 compatibility
+	result = m.convertNumericFields(result, attrs)
+
+	// 2. Transform output_options array to object
+	result = m.transformOutputOptions(result, attrs)
+
+	// 3. Remove computed-only fields (these should not be in state)
+	result = state.RemoveFields(result, "attributes", attrs,
+		"error_message", "last_complete", "last_error")
+
+	// 4. Handle kind value change: "instant-logs" → ""
+	if kind := attrs.Get("kind"); kind.Exists() && kind.String() == "instant-logs" {
+		result, _ = sjson.Set(result, "attributes.kind", "")
+	}
+
+	return result, nil
+}
+
+// convertNumericFields converts integer fields to float64 for int64 compatibility
+func (m *V4ToV5Migrator) convertNumericFields(result string, attrs gjson.Result) string {
+	numericFields := []string{
+		"max_upload_bytes",
+		"max_upload_records",
+		"max_upload_interval_seconds",
+	}
+
+	for _, field := range numericFields {
+		if val := attrs.Get(field); val.Exists() && val.Type == gjson.Number {
+			// Convert to float64 for int64 compatibility
+			result, _ = sjson.Set(result, "attributes."+field, val.Float())
+		}
+	}
+
+	return result
+}
+
+// transformOutputOptions transforms output_options from array to object and renames fields
+func (m *V4ToV5Migrator) transformOutputOptions(result string, attrs gjson.Result) string {
+	outputOpts := attrs.Get("output_options")
+
+	if !outputOpts.Exists() {
+		return result
+	}
+
+	// Handle array → object transformation
+	if outputOpts.IsArray() {
+		array := outputOpts.Array()
+		if len(array) == 0 {
+			// Empty array → remove field
+			result, _ = sjson.Delete(result, "attributes.output_options")
+		} else {
+			// Take first element and convert to object
+			firstElem := array[0]
+			obj := make(map[string]interface{})
+
+			firstElem.ForEach(func(key, value gjson.Result) bool {
+				k := key.String()
+
+				// Rename cve20214428 → cve_2021_44228
+				if k == "cve20214428" {
+					k = "cve_2021_44228"
+				}
+
+				obj[k] = state.ConvertGjsonValue(value)
+				return true
+			})
+
+			result, _ = sjson.Set(result, "attributes.output_options", obj)
+		}
+	} else if outputOpts.IsObject() {
+		// Already an object, just rename field if needed
+		result = state.RenameField(result, "attributes.output_options", outputOpts,
+			"cve20214428", "cve_2021_44228")
+	}
+
+	return result
+}

--- a/internal/resources/logpush_job/v4_to_v5_test.go
+++ b/internal/resources/logpush_job/v4_to_v5_test.go
@@ -147,7 +147,7 @@ func TestV4ToV5Transformation(t *testing.T) {
 }`,
 			},
 			{
-				Name: "Handle kind instant-logs to empty string",
+				Name: "Handle kind instant-logs by removing attribute",
 				Input: `resource "cloudflare_logpush_job" "example" {
   dataset          = "http_requests"
   destination_conf = "s3://mybucket/logs?region=us-west-2"
@@ -156,7 +156,6 @@ func TestV4ToV5Transformation(t *testing.T) {
 				Expected: `resource "cloudflare_logpush_job" "example" {
   dataset          = "http_requests"
   destination_conf = "s3://mybucket/logs?region=us-west-2"
-  kind             = ""
 }`,
 			},
 			{
@@ -208,7 +207,6 @@ func TestV4ToV5Transformation(t *testing.T) {
   account_id       = "abc123"
   dataset          = "http_requests"
   destination_conf = "s3://mybucket/logs?region=us-west-2"
-  kind             = ""
   enabled          = true
 
   output_options = {
@@ -249,7 +247,6 @@ resource "cloudflare_logpush_job" "job2" {
 				Expected: `resource "cloudflare_logpush_job" "job1" {
   dataset          = "http_requests"
   destination_conf = "s3://bucket1/logs?region=us-west-2"
-  kind             = ""
 
   output_options = {
     output_type       = "ndjson"
@@ -539,7 +536,7 @@ resource "cloudflare_logpush_job" "job2" {
 }`,
 			},
 			{
-				Name: "Handle kind instant-logs to empty string",
+				Name: "Handle kind instant-logs by removing attribute",
 				Input: `{
   "attributes": {
     "dataset": "http_requests",
@@ -550,8 +547,7 @@ resource "cloudflare_logpush_job" "job2" {
 				Expected: `{
   "attributes": {
     "dataset": "http_requests",
-    "destination_conf": "s3://mybucket/logs?region=us-west-2",
-    "kind": ""
+    "destination_conf": "s3://mybucket/logs?region=us-west-2"
   }
 }`,
 			},
@@ -639,7 +635,6 @@ resource "cloudflare_logpush_job" "job2" {
     "account_id": "abc123",
     "dataset": "http_requests",
     "destination_conf": "s3://mybucket/logs?region=us-west-2",
-    "kind": "",
     "enabled": true,
     "max_upload_bytes": 5000000.0,
     "max_upload_records": 1000.0,

--- a/internal/resources/logpush_job/v4_to_v5_test.go
+++ b/internal/resources/logpush_job/v4_to_v5_test.go
@@ -1,0 +1,496 @@
+package logpush_job
+
+import (
+	"testing"
+
+	"github.com/cloudflare/tf-migrate/internal/testhelpers"
+)
+
+func TestV4ToV5Transformation(t *testing.T) {
+	migrator := NewV4ToV5Migrator()
+
+	t.Run("ConfigTransformation", func(t *testing.T) {
+		tests := []testhelpers.ConfigTestCase{
+			{
+				Name: "Minimal resource",
+				Input: `resource "cloudflare_logpush_job" "example" {
+  dataset          = "http_requests"
+  destination_conf = "s3://mybucket/logs?region=us-west-2"
+}`,
+				Expected: `resource "cloudflare_logpush_job" "example" {
+  dataset          = "http_requests"
+  destination_conf = "s3://mybucket/logs?region=us-west-2"
+}`,
+			},
+			{
+				Name: "Resource with logpull_options only (no output_options)",
+				Input: `resource "cloudflare_logpush_job" "example" {
+  dataset          = "http_requests"
+  destination_conf = "s3://mybucket/logs?region=us-west-2"
+  logpull_options  = "fields=ClientIP,EdgeStartTimestamp&timestamps=unixnano"
+}`,
+				Expected: `resource "cloudflare_logpush_job" "example" {
+  dataset          = "http_requests"
+  destination_conf = "s3://mybucket/logs?region=us-west-2"
+  logpull_options  = "fields=ClientIP,EdgeStartTimestamp&timestamps=unixnano"
+}`,
+			},
+			{
+				Name: "Convert output_options block to attribute",
+				Input: `resource "cloudflare_logpush_job" "example" {
+  dataset          = "http_requests"
+  destination_conf = "s3://mybucket/logs?region=us-west-2"
+
+  output_options {
+    batch_prefix = "{"
+    batch_suffix = "}"
+    field_names  = ["ClientIP", "EdgeStartTimestamp"]
+    output_type  = "ndjson"
+  }
+}`,
+				Expected: `resource "cloudflare_logpush_job" "example" {
+  dataset          = "http_requests"
+  destination_conf = "s3://mybucket/logs?region=us-west-2"
+
+  output_options = {
+    batch_prefix = "{"
+    batch_suffix = "}"
+    field_names  = ["ClientIP", "EdgeStartTimestamp"]
+    output_type  = "ndjson"
+  }
+}`,
+			},
+			{
+				Name: "Rename cve20214428 to cve_2021_44228",
+				Input: `resource "cloudflare_logpush_job" "example" {
+  dataset          = "http_requests"
+  destination_conf = "s3://mybucket/logs?region=us-west-2"
+
+  output_options {
+    cve20214428 = true
+    output_type = "ndjson"
+  }
+}`,
+				Expected: `resource "cloudflare_logpush_job" "example" {
+  dataset          = "http_requests"
+  destination_conf = "s3://mybucket/logs?region=us-west-2"
+
+  output_options = {
+    output_type    = "ndjson"
+    cve_2021_44228 = true
+  }
+}`,
+			},
+			{
+				Name: "Handle kind instant-logs to empty string",
+				Input: `resource "cloudflare_logpush_job" "example" {
+  dataset          = "http_requests"
+  destination_conf = "s3://mybucket/logs?region=us-west-2"
+  kind             = "instant-logs"
+}`,
+				Expected: `resource "cloudflare_logpush_job" "example" {
+  dataset          = "http_requests"
+  destination_conf = "s3://mybucket/logs?region=us-west-2"
+  kind             = ""
+}`,
+			},
+			{
+				Name: "Preserve kind edge value",
+				Input: `resource "cloudflare_logpush_job" "example" {
+  dataset          = "http_requests"
+  destination_conf = "s3://mybucket/logs?region=us-west-2"
+  kind             = "edge"
+}`,
+				Expected: `resource "cloudflare_logpush_job" "example" {
+  dataset          = "http_requests"
+  destination_conf = "s3://mybucket/logs?region=us-west-2"
+  kind             = "edge"
+}`,
+			},
+			{
+				Name: "Preserve kind empty string",
+				Input: `resource "cloudflare_logpush_job" "example" {
+  dataset          = "http_requests"
+  destination_conf = "s3://mybucket/logs?region=us-west-2"
+  kind             = ""
+}`,
+				Expected: `resource "cloudflare_logpush_job" "example" {
+  dataset          = "http_requests"
+  destination_conf = "s3://mybucket/logs?region=us-west-2"
+  kind             = ""
+}`,
+			},
+			{
+				Name: "Full transformation with all changes",
+				Input: `resource "cloudflare_logpush_job" "example" {
+  account_id       = "abc123"
+  dataset          = "http_requests"
+  destination_conf = "s3://mybucket/logs?region=us-west-2"
+  kind             = "instant-logs"
+  enabled          = true
+
+  output_options {
+    cve20214428      = true
+    batch_prefix     = "{"
+    batch_suffix     = "}"
+    field_names      = ["ClientIP", "EdgeStartTimestamp", "RayID"]
+    output_type      = "ndjson"
+    sample_rate      = 1.0
+    timestamp_format = "unixnano"
+  }
+}`,
+				Expected: `resource "cloudflare_logpush_job" "example" {
+  account_id       = "abc123"
+  dataset          = "http_requests"
+  destination_conf = "s3://mybucket/logs?region=us-west-2"
+  kind             = ""
+  enabled          = true
+
+  output_options = {
+    batch_prefix     = "{"
+    batch_suffix     = "}"
+    field_names      = ["ClientIP", "EdgeStartTimestamp", "RayID"]
+    output_type      = "ndjson"
+    sample_rate      = 1.0
+    timestamp_format = "unixnano"
+    cve_2021_44228   = true
+  }
+}`,
+			},
+			{
+				Name: "Multiple resources in one file",
+				Input: `resource "cloudflare_logpush_job" "job1" {
+  dataset          = "http_requests"
+  destination_conf = "s3://bucket1/logs?region=us-west-2"
+  kind             = "instant-logs"
+
+  output_options {
+    cve20214428 = true
+    output_type = "ndjson"
+  }
+}
+
+resource "cloudflare_logpush_job" "job2" {
+  dataset          = "firewall_events"
+  destination_conf = "s3://bucket2/logs?region=us-east-1"
+
+  output_options {
+    output_type = "csv"
+  }
+}`,
+				Expected: `resource "cloudflare_logpush_job" "job1" {
+  dataset          = "http_requests"
+  destination_conf = "s3://bucket1/logs?region=us-west-2"
+  kind             = ""
+
+  output_options = {
+    output_type    = "ndjson"
+    cve_2021_44228 = true
+  }
+}
+
+resource "cloudflare_logpush_job" "job2" {
+  dataset          = "firewall_events"
+  destination_conf = "s3://bucket2/logs?region=us-east-1"
+
+  output_options = {
+    output_type = "csv"
+  }
+}`,
+			},
+			{
+				Name: "With variable references",
+				Input: `resource "cloudflare_logpush_job" "example" {
+  account_id       = var.account_id
+  dataset          = var.dataset
+  destination_conf = var.destination_conf
+
+  output_options {
+    field_names = var.field_names
+    output_type = "ndjson"
+  }
+}`,
+				Expected: `resource "cloudflare_logpush_job" "example" {
+  account_id       = var.account_id
+  dataset          = var.dataset
+  destination_conf = var.destination_conf
+
+  output_options = {
+    field_names = var.field_names
+    output_type = "ndjson"
+  }
+}`,
+			},
+			{
+				Name: "With deprecated frequency field",
+				Input: `resource "cloudflare_logpush_job" "example" {
+  dataset          = "http_requests"
+  destination_conf = "s3://mybucket/logs?region=us-west-2"
+  frequency        = "high"
+}`,
+				Expected: `resource "cloudflare_logpush_job" "example" {
+  dataset          = "http_requests"
+  destination_conf = "s3://mybucket/logs?region=us-west-2"
+  frequency        = "high"
+}`,
+			},
+		}
+
+		testhelpers.RunConfigTransformTests(t, tests, migrator)
+	})
+
+	t.Run("StateTransformation", func(t *testing.T) {
+		tests := []testhelpers.StateTestCase{
+			{
+				Name: "Minimal state",
+				Input: `{
+  "attributes": {
+    "dataset": "http_requests",
+    "destination_conf": "s3://mybucket/logs?region=us-west-2"
+  }
+}`,
+				Expected: `{
+  "attributes": {
+    "dataset": "http_requests",
+    "destination_conf": "s3://mybucket/logs?region=us-west-2"
+  }
+}`,
+			},
+			{
+				Name: "State with logpull_options only (no output_options)",
+				Input: `{
+  "attributes": {
+    "dataset": "http_requests",
+    "destination_conf": "s3://mybucket/logs?region=us-west-2",
+    "logpull_options": "fields=ClientIP,EdgeStartTimestamp&timestamps=unixnano"
+  }
+}`,
+				Expected: `{
+  "attributes": {
+    "dataset": "http_requests",
+    "destination_conf": "s3://mybucket/logs?region=us-west-2",
+    "logpull_options": "fields=ClientIP,EdgeStartTimestamp&timestamps=unixnano"
+  }
+}`,
+			},
+			{
+				Name: "Transform output_options array to object",
+				Input: `{
+  "attributes": {
+    "dataset": "http_requests",
+    "destination_conf": "s3://mybucket/logs?region=us-west-2",
+    "output_options": [
+      {
+        "batch_prefix": "{",
+        "batch_suffix": "}",
+        "field_names": ["ClientIP", "EdgeStartTimestamp"],
+        "output_type": "ndjson"
+      }
+    ]
+  }
+}`,
+				Expected: `{
+  "attributes": {
+    "dataset": "http_requests",
+    "destination_conf": "s3://mybucket/logs?region=us-west-2",
+    "output_options": {
+      "batch_prefix": "{",
+      "batch_suffix": "}",
+      "field_names": ["ClientIP", "EdgeStartTimestamp"],
+      "output_type": "ndjson"
+    }
+  }
+}`,
+			},
+			{
+				Name: "Rename cve20214428 in output_options array",
+				Input: `{
+  "attributes": {
+    "dataset": "http_requests",
+    "destination_conf": "s3://mybucket/logs?region=us-west-2",
+    "output_options": [
+      {
+        "cve20214428": true,
+        "output_type": "ndjson"
+      }
+    ]
+  }
+}`,
+				Expected: `{
+  "attributes": {
+    "dataset": "http_requests",
+    "destination_conf": "s3://mybucket/logs?region=us-west-2",
+    "output_options": {
+      "cve_2021_44228": true,
+      "output_type": "ndjson"
+    }
+  }
+}`,
+			},
+			{
+				Name: "Rename cve20214428 in output_options object",
+				Input: `{
+  "attributes": {
+    "dataset": "http_requests",
+    "destination_conf": "s3://mybucket/logs?region=us-west-2",
+    "output_options": {
+      "cve20214428": true,
+      "output_type": "ndjson"
+    }
+  }
+}`,
+				Expected: `{
+  "attributes": {
+    "dataset": "http_requests",
+    "destination_conf": "s3://mybucket/logs?region=us-west-2",
+    "output_options": {
+      "cve_2021_44228": true,
+      "output_type": "ndjson"
+    }
+  }
+}`,
+			},
+			{
+				Name: "Convert numeric fields to float64",
+				Input: `{
+  "attributes": {
+    "dataset": "http_requests",
+    "destination_conf": "s3://mybucket/logs?region=us-west-2",
+    "max_upload_bytes": 5000000,
+    "max_upload_records": 1000,
+    "max_upload_interval_seconds": 30
+  }
+}`,
+				Expected: `{
+  "attributes": {
+    "dataset": "http_requests",
+    "destination_conf": "s3://mybucket/logs?region=us-west-2",
+    "max_upload_bytes": 5000000.0,
+    "max_upload_records": 1000.0,
+    "max_upload_interval_seconds": 30.0
+  }
+}`,
+			},
+			{
+				Name: "Handle kind instant-logs to empty string",
+				Input: `{
+  "attributes": {
+    "dataset": "http_requests",
+    "destination_conf": "s3://mybucket/logs?region=us-west-2",
+    "kind": "instant-logs"
+  }
+}`,
+				Expected: `{
+  "attributes": {
+    "dataset": "http_requests",
+    "destination_conf": "s3://mybucket/logs?region=us-west-2",
+    "kind": ""
+  }
+}`,
+			},
+			{
+				Name: "Preserve kind edge value",
+				Input: `{
+  "attributes": {
+    "dataset": "http_requests",
+    "destination_conf": "s3://mybucket/logs?region=us-west-2",
+    "kind": "edge"
+  }
+}`,
+				Expected: `{
+  "attributes": {
+    "dataset": "http_requests",
+    "destination_conf": "s3://mybucket/logs?region=us-west-2",
+    "kind": "edge"
+  }
+}`,
+			},
+			{
+				Name: "Remove computed-only fields",
+				Input: `{
+  "attributes": {
+    "dataset": "http_requests",
+    "destination_conf": "s3://mybucket/logs?region=us-west-2",
+    "error_message": "Some error",
+    "last_complete": "2024-01-01T00:00:00Z",
+    "last_error": "2024-01-01T00:00:00Z"
+  }
+}`,
+				Expected: `{
+  "attributes": {
+    "dataset": "http_requests",
+    "destination_conf": "s3://mybucket/logs?region=us-west-2"
+  }
+}`,
+			},
+			{
+				Name: "Empty output_options array removed",
+				Input: `{
+  "attributes": {
+    "dataset": "http_requests",
+    "destination_conf": "s3://mybucket/logs?region=us-west-2",
+    "output_options": []
+  }
+}`,
+				Expected: `{
+  "attributes": {
+    "dataset": "http_requests",
+    "destination_conf": "s3://mybucket/logs?region=us-west-2"
+  }
+}`,
+			},
+			{
+				Name: "Full state transformation",
+				Input: `{
+  "attributes": {
+    "account_id": "abc123",
+    "dataset": "http_requests",
+    "destination_conf": "s3://mybucket/logs?region=us-west-2",
+    "kind": "instant-logs",
+    "enabled": true,
+    "max_upload_bytes": 5000000,
+    "max_upload_records": 1000,
+    "max_upload_interval_seconds": 30,
+    "output_options": [
+      {
+        "cve20214428": true,
+        "batch_prefix": "{",
+        "batch_suffix": "}",
+        "field_names": ["ClientIP", "EdgeStartTimestamp", "RayID"],
+        "output_type": "ndjson",
+        "sample_rate": 1.0,
+        "timestamp_format": "unixnano"
+      }
+    ],
+    "error_message": "Some error",
+    "last_complete": "2024-01-01T00:00:00Z",
+    "last_error": "2024-01-01T00:00:00Z"
+  }
+}`,
+				Expected: `{
+  "attributes": {
+    "account_id": "abc123",
+    "dataset": "http_requests",
+    "destination_conf": "s3://mybucket/logs?region=us-west-2",
+    "kind": "",
+    "enabled": true,
+    "max_upload_bytes": 5000000.0,
+    "max_upload_records": 1000.0,
+    "max_upload_interval_seconds": 30.0,
+    "output_options": {
+      "cve_2021_44228": true,
+      "batch_prefix": "{",
+      "batch_suffix": "}",
+      "field_names": ["ClientIP", "EdgeStartTimestamp", "RayID"],
+      "output_type": "ndjson",
+      "sample_rate": 1.0,
+      "timestamp_format": "unixnano"
+    }
+  }
+}`,
+			},
+		}
+
+		testhelpers.RunStateTransformTests(t, tests, migrator)
+	})
+}

--- a/internal/resources/logpush_job/v4_to_v5_test.go
+++ b/internal/resources/logpush_job/v4_to_v5_test.go
@@ -57,6 +57,7 @@ func TestV4ToV5Transformation(t *testing.T) {
     batch_suffix      = "}"
     field_names       = ["ClientIP", "EdgeStartTimestamp"]
     output_type       = "ndjson"
+    cve_2021_44228    = false
     field_delimiter   = ","
     record_prefix     = "{"
     record_suffix     = "}\n"
@@ -111,6 +112,7 @@ func TestV4ToV5Transformation(t *testing.T) {
     output_type       = "ndjson"
     field_delimiter   = "|"
     sample_rate       = 0.5
+    cve_2021_44228    = false
     record_prefix     = "{"
     record_suffix     = "}\n"
     timestamp_format  = "unixnano"
@@ -143,6 +145,7 @@ func TestV4ToV5Transformation(t *testing.T) {
     record_suffix     = "]"
     timestamp_format  = "rfc3339"
     sample_rate       = 0.1
+    cve_2021_44228    = false
   }
 }`,
 			},
@@ -265,6 +268,7 @@ resource "cloudflare_logpush_job" "job2" {
 
   output_options = {
     output_type       = "csv"
+    cve_2021_44228    = false
     field_delimiter   = ","
     record_prefix     = "{"
     record_suffix     = "}\n"
@@ -293,6 +297,7 @@ resource "cloudflare_logpush_job" "job2" {
   output_options = {
     field_names       = var.field_names
     output_type       = "ndjson"
+    cve_2021_44228    = false
     field_delimiter   = ","
     record_prefix     = "{"
     record_suffix     = "}\n"
@@ -378,6 +383,7 @@ resource "cloudflare_logpush_job" "job2" {
       "batch_suffix": "}",
       "field_names": ["ClientIP", "EdgeStartTimestamp"],
       "output_type": "ndjson",
+      "cve_2021_44228": false,
       "field_delimiter": ",",
       "record_prefix": "{",
       "record_suffix": "}\n",
@@ -530,6 +536,7 @@ resource "cloudflare_logpush_job" "job2" {
       "record_prefix": "[",
       "sample_rate": 0.5,
       "timestamp_format": "rfc3339",
+      "cve_2021_44228": false,
       "record_suffix": "}\n"
     }
   }

--- a/internal/resources/logpush_job/v4_to_v5_test.go
+++ b/internal/resources/logpush_job/v4_to_v5_test.go
@@ -470,24 +470,6 @@ resource "cloudflare_logpush_job" "job2" {
 }`,
 			},
 			{
-				Name: "Remove numeric fields with value 0 (API defaults)",
-				Input: `{
-  "attributes": {
-    "dataset": "http_requests",
-    "destination_conf": "s3://mybucket/logs?region=us-west-2",
-    "max_upload_bytes": 0,
-    "max_upload_records": 0,
-    "max_upload_interval_seconds": 0
-  }
-}`,
-				Expected: `{
-  "attributes": {
-    "dataset": "http_requests",
-    "destination_conf": "s3://mybucket/logs?region=us-west-2"
-  }
-}`,
-			},
-			{
 				Name: "Preserve v4 schema defaults in output_options state",
 				Input: `{
   "attributes": {

--- a/internal/transform/empty_values.go
+++ b/internal/transform/empty_values.go
@@ -1,0 +1,128 @@
+// Package transform provides utilities for transforming Terraform configurations and state
+package transform
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+
+	tfhcl "github.com/cloudflare/tf-migrate/internal/transform/hcl"
+	"github.com/cloudflare/tf-migrate/internal/transform/state"
+)
+
+// TransformEmptyValuesToNullOptions contains options for TransformEmptyValuesToNull
+type TransformEmptyValuesToNullOptions struct {
+	// Context for accessing HCL files and diagnostics
+	Ctx *Context
+	// The state JSON string being transformed
+	Result string
+	// JSON path to the object/fields (e.g., "attributes" for top-level, "attributes.input" for nested)
+	FieldPath string
+	// Parsed gjson result for the field (can be object or attributes)
+	FieldResult gjson.Result
+	// Resource name to match in HCL
+	ResourceName string
+	// HCL attribute path (empty string for top-level, "input" for nested in input block)
+	HCLAttributePath string
+	// Function to check if a resource type can be handled by this migrator
+	CanHandle func(string) bool
+}
+
+// TransformEmptyValuesToNull transforms empty values to null in state, but only if they were not
+// explicitly set in the HCL configuration. This handles the v4→v5 migration where v4 sets empty
+// strings for optional fields while v5 uses null.
+//
+// This is a common pattern needed when:
+//   - v4 provider sets fields to empty string ("") when not configured
+//   - v5 provider sets fields to null when not configured
+//   - We need to transform the state to match v5 behavior
+//   - But preserve explicitly configured empty strings in the config
+//
+// Example usage in logpush_job (top-level fields):
+//
+//	result = transform.TransformEmptyValuesToNull(transform.TransformEmptyValuesToNullOptions{
+//	    Ctx:              ctx,
+//	    Result:           result,
+//	    FieldPath:        "attributes",
+//	    FieldResult:      attrs,
+//	    ResourceName:     resourceName,
+//	    HCLAttributePath: "",
+//	    CanHandle:        m.CanHandle,
+//	})
+//
+// Example usage in zero_trust_device_posture_rule (nested input fields):
+//
+//	result = transform.TransformEmptyValuesToNull(transform.TransformEmptyValuesToNullOptions{
+//	    Ctx:              ctx,
+//	    Result:           result,
+//	    FieldPath:        "attributes.input",
+//	    FieldResult:      inputField,
+//	    ResourceName:     resourceName,
+//	    HCLAttributePath: "input",
+//	    CanHandle:        m.CanHandle,
+//	})
+func TransformEmptyValuesToNull(opts TransformEmptyValuesToNullOptions) string {
+	if !opts.FieldResult.Exists() {
+		return opts.Result
+	}
+
+	result := opts.Result
+
+	// Iterate over each field in the object
+	opts.FieldResult.ForEach(func(key, value gjson.Result) bool {
+		fieldName := key.String()
+
+		// Check if this is an empty value
+		if !state.IsEmptyValue(value) {
+			return true // continue iteration
+		}
+
+		// Check if this empty value was explicitly defined in HCL
+		emptyValueDefinedInHCL := false
+
+		if len(opts.Ctx.CFGFiles) > 0 {
+		HCL_SEARCH:
+			for _, file := range opts.Ctx.CFGFiles {
+				resourceBlocks := tfhcl.FindBlocksByType(file.Body(), "resource")
+				for _, resourceBlock := range resourceBlocks {
+					resourceBlockType := tfhcl.GetResourceType(resourceBlock)
+					resourceBlockName := tfhcl.GetResourceName(resourceBlock)
+
+					// Check if this is the resource we're transforming
+					if opts.CanHandle(resourceBlockType) && resourceBlockName == opts.ResourceName {
+						// Check if the field is defined in HCL config
+						if opts.HCLAttributePath == "" {
+							// Top-level field - check directly in resource body
+							if resourceBlock.Body().GetAttribute(fieldName) != nil {
+								emptyValueDefinedInHCL = true
+							}
+						} else {
+							// Nested field - check in the specified attribute
+							if attr := resourceBlock.Body().GetAttribute(opts.HCLAttributePath); attr != nil {
+								if tfhcl.AttributeValueContainsKey(attr, fieldName) {
+									emptyValueDefinedInHCL = true
+								}
+							}
+						}
+						break HCL_SEARCH
+					}
+				}
+			}
+		}
+
+		// If empty value was not explicitly defined in HCL, transform it to null
+		if !emptyValueDefinedInHCL {
+			result, _ = sjson.Set(result, opts.FieldPath+"."+fieldName, nil)
+			opts.Ctx.Diagnostics = append(opts.Ctx.Diagnostics, &hcl.Diagnostic{
+				Severity: hcl.DiagWarning,
+				Summary:  fmt.Sprintf("Transforming state for attribute %s from empty value to null. Will require an update in place.", fieldName),
+			})
+		}
+
+		return true // continue iteration
+	})
+
+	return result
+}

--- a/internal/transform/state/fields.go
+++ b/internal/transform/state/fields.go
@@ -346,7 +346,7 @@ func ConvertGjsonToJSON(value gjson.Result) interface{} {
 	}
 }
 
-// isEmptyValue checks if a gjson.Result value is considered "empty" (default/zero)
+// IsEmptyValue checks if a gjson.Result value is considered "empty" (default/zero)
 func IsEmptyValue(value gjson.Result) bool {
 	if !value.Exists() {
 		return true


### PR DESCRIPTION
1. Supports migrations of the logpush_job resource from v4 to v5. Will migrate the following:
- rename attribute in output_options of `cve20214428` to `cve_2021_44228`
- any `kind` of "instant-logs" is no longer supported. It now transforms into ""
- `max_upload_bytes`, `max_upload_records`, and `max_upload_interval_seconds` all convert from an int to Float64
- convert `output_options` from block to attribute

2. Moves the function for nulling out empty values from `zero_trust_device_posture_rule` to a helper for use across various resources. 

## Assertions Made
The following assertions were made within this implementation:
- `max_upload_bytes`, `max_upload_records`, and `max_upload_interval_seconds` had default values of 0 in v4. This is not a valid value for any of these fields, so the tool will delete these fields to null them out to match v5 state. 
- The defaults for `output_options` in v4 are retained as the tool migrates to v5. They will now be explicitly set in customer's config and state after migration. 
- empty string defaults are nulled out to match v5 state and avoid drift

## End to End Tests
The output of the end to end tests are seen below. There are two drifts, which are _expected_, as they are a result of kind allowing less values in v5 than in v4 for instant-logs. 

```bash
Running terraform plan in v5/...
⚠ Terraform plan shows changes
  Plan: 0 to add, 2 to change, 0 to destroy.

Detailed changes:

  # module.logpush_job.cloudflare_logpush_job.full will be updated in-place
  ~ resource "cloudflare_logpush_job" "full" {
      + error_message    = (known after apply)
        id               = 1300622
      ~ kind             = "instant-logs" -> ""
      + last_complete    = (known after apply)
      + last_error       = (known after apply)
        name             = "my-logpush-job"
        # (6 unchanged attributes hidden)

  # module.logpush_job.cloudflare_logpush_job.instant_logs will be updated in-place
  ~ resource "cloudflare_logpush_job" "instant_logs" {
      + error_message    = (known after apply)
        id               = 1300615
      ~ kind             = "instant-logs" -> ""
      + last_complete    = (known after apply)
      + last_error       = (known after apply)
        # (5 unchanged attributes hidden)


```