### PR TITLE
Migrate zero trust device posture rule

### DIFF
--- a/integration/v4_to_v5/testdata/zero_trust_device_posture_rule/expected/terraform.tfstate
+++ b/integration/v4_to_v5/testdata/zero_trust_device_posture_rule/expected/terraform.tfstate
@@ -1,0 +1,359 @@
+{
+  "version": 4,
+  "terraform_version": "1.15.0",
+  "serial": 15,
+  "lineage": "2e525f2f-6f5f-a864-283c-e2b07953ecb4",
+  "outputs": {},
+  "resources": [
+    {
+      "mode": "managed",
+      "type": "cloudflare_zero_trust_device_posture_rule",
+      "name": "basic",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "f1d0ab1b-2db2-4283-ab9c-b809faced013",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "name": "tf-test-posture-basic",
+            "type": "os_version",
+            "description": "Device posture rule for corporate devices.",
+            "schedule": "24h",
+            "expiration": "24h",
+            "match": [
+              {
+                "platform": "linux"
+              }
+            ],
+            "input": {
+              "version": "1.0.0",
+              "operator": "<",
+              "os_distro_name": "ubuntu",
+              "os_distro_revision": "1.0.0",
+              "os_version_extra": "(a)",
+              "active_threats": null,
+              "certificate_id": null,
+              "check_disks": null,
+              "check_private_key": null,
+              "cn": null,
+              "compliance_status": null,
+              "connection_id": null,
+              "count_operator": null,
+              "domain": null,
+              "eid_last_seen": null,
+              "enabled": null,
+              "exists": null,
+              "extended_key_usage": null,
+              "id": null,
+              "infected": null,
+              "is_active": null,
+              "issue_count": null,
+              "last_seen": null,
+              "locations": null,
+              "network_status": null,
+              "operational_state": null,
+              "os": null,
+              "overall": null,
+              "path": null,
+              "require_all": null,
+              "risk_level": null,
+              "score": null,
+              "sensor_config": null,
+              "sha256": null,
+              "state": null,
+              "thumbprint": null,
+              "total_score": null,
+              "version_operator": null
+            }
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA==",
+          "identity_schema_version": 0
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_zero_trust_device_posture_rule",
+      "name": "disk_encryption",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "10fd8575-3a0e-44c5-a771-73a2815a644c",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "name": "tf-test-disk",
+            "type": "disk_encryption",
+            "description": "",
+            "schedule": "5m",
+            "expiration": "",
+            "match": [
+              {
+                "platform": "windows"
+              }
+            ],
+            "input": {
+              "check_disks": [
+                "C:",
+                "D:"
+              ],
+              "require_all": true,
+              "active_threats": null,
+              "certificate_id": null,
+              "check_private_key": null,
+              "cn": null,
+              "compliance_status": null,
+              "connection_id": null,
+              "count_operator": null,
+              "domain": null,
+              "eid_last_seen": null,
+              "enabled": null,
+              "exists": null,
+              "extended_key_usage": null,
+              "id": null,
+              "infected": null,
+              "is_active": null,
+              "issue_count": null,
+              "last_seen": null,
+              "locations": null,
+              "network_status": null,
+              "operational_state": null,
+              "operator": null,
+              "os": null,
+              "os_distro_name": null,
+              "os_distro_revision": null,
+              "os_version_extra": null,
+              "overall": null,
+              "path": null,
+              "risk_level": null,
+              "score": null,
+              "sensor_config": null,
+              "sha256": null,
+              "state": null,
+              "thumbprint": null,
+              "total_score": null,
+              "version": null,
+              "version_operator": null
+            }
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA==",
+          "identity_schema_version": 0
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_zero_trust_device_posture_rule",
+      "name": "firewall",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "82648948-0bcc-49af-8b80-071e0bd69f6d",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "name": "tf-test-firewall",
+            "type": "firewall",
+            "description": "",
+            "schedule": "5m",
+            "expiration": "",
+            "match": [
+              {
+                "platform": "windows"
+              }
+            ],
+            "input": {
+              "enabled": true,
+              "active_threats": null,
+              "certificate_id": null,
+              "check_disks": null,
+              "check_private_key": null,
+              "cn": null,
+              "compliance_status": null,
+              "connection_id": null,
+              "count_operator": null,
+              "domain": null,
+              "eid_last_seen": null,
+              "exists": null,
+              "extended_key_usage": null,
+              "id": null,
+              "infected": null,
+              "is_active": null,
+              "issue_count": null,
+              "last_seen": null,
+              "locations": null,
+              "network_status": null,
+              "operational_state": null,
+              "operator": null,
+              "os": null,
+              "os_distro_name": null,
+              "os_distro_revision": null,
+              "os_version_extra": null,
+              "overall": null,
+              "path": null,
+              "require_all": null,
+              "risk_level": null,
+              "score": null,
+              "sensor_config": null,
+              "sha256": null,
+              "state": null,
+              "thumbprint": null,
+              "total_score": null,
+              "version": null,
+              "version_operator": null
+            }
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA==",
+          "identity_schema_version": 0
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_zero_trust_device_posture_rule",
+      "name": "multi_platform",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "91f41a4a-4dcb-4585-92cc-fe59dd78243b",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "name": "tf-test-multi",
+            "type": "firewall",
+            "description": "",
+            "schedule": "5m",
+            "expiration": "",
+            "match": [
+              {
+                "platform": "windows"
+              },
+              {
+                "platform": "mac"
+              },
+              {
+                "platform": "linux"
+              }
+            ],
+            "input": {
+              "enabled": true,
+              "active_threats": null,
+              "certificate_id": null,
+              "check_disks": null,
+              "check_private_key": null,
+              "cn": null,
+              "compliance_status": null,
+              "connection_id": null,
+              "count_operator": null,
+              "domain": null,
+              "eid_last_seen": null,
+              "exists": null,
+              "extended_key_usage": null,
+              "id": null,
+              "infected": null,
+              "is_active": null,
+              "issue_count": null,
+              "last_seen": null,
+              "locations": null,
+              "network_status": null,
+              "operational_state": null,
+              "operator": null,
+              "os": null,
+              "os_distro_name": null,
+              "os_distro_revision": null,
+              "os_version_extra": null,
+              "overall": null,
+              "path": null,
+              "require_all": null,
+              "risk_level": null,
+              "score": null,
+              "sensor_config": null,
+              "sha256": null,
+              "state": null,
+              "thumbprint": null,
+              "total_score": null,
+              "version": null,
+              "version_operator": null
+            }
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA==",
+          "identity_schema_version": 0
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_zero_trust_device_posture_rule",
+      "name": "application",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "c3d4e5f6-7890-abcd-ef12-3456789abcde",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "name": "tf-test-application",
+            "type": "application",
+            "description": "",
+            "schedule": "30m",
+            "expiration": "",
+            "match": [
+              {
+                "platform": "linux"
+              }
+            ],
+            "input": {
+              "path": "/usr/bin/security-app",
+              "sha256": "abc123def456",
+              "active_threats": null,
+              "certificate_id": null,
+              "check_disks": null,
+              "check_private_key": null,
+              "cn": null,
+              "compliance_status": null,
+              "connection_id": null,
+              "count_operator": null,
+              "domain": null,
+              "eid_last_seen": null,
+              "enabled": null,
+              "exists": null,
+              "extended_key_usage": null,
+              "id": null,
+              "infected": null,
+              "is_active": null,
+              "issue_count": null,
+              "last_seen": null,
+              "locations": null,
+              "network_status": null,
+              "operational_state": null,
+              "operator": null,
+              "os": null,
+              "os_distro_name": null,
+              "os_distro_revision": null,
+              "os_version_extra": null,
+              "overall": null,
+              "require_all": null,
+              "risk_level": null,
+              "score": null,
+              "sensor_config": null,
+              "state": null,
+              "thumbprint": null,
+              "total_score": null,
+              "version": null,
+              "version_operator": null
+            }
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA==",
+          "identity_schema_version": 0
+        }
+      ]
+    }
+  ],
+  "check_results": null
+}

--- a/integration/v4_to_v5/testdata/zero_trust_device_posture_rule/expected/zero_trust_device_posture_rule.tf
+++ b/integration/v4_to_v5/testdata/zero_trust_device_posture_rule/expected/zero_trust_device_posture_rule.tf
@@ -1,0 +1,93 @@
+# Test case 1: Basic os_version rule with input and match
+resource "cloudflare_zero_trust_device_posture_rule" "basic" {
+  account_id  = var.cloudflare_account_id
+  name        = "tf-test-posture-basic"
+  type        = "os_version"
+  description = "Device posture rule for corporate devices."
+  schedule    = "24h"
+  expiration  = "24h"
+
+
+  input = {
+    version            = "1.0.0"
+    operator           = "<"
+    os_distro_name     = "ubuntu"
+    os_distro_revision = "1.0.0"
+    os_version_extra   = "(a)"
+  }
+  match = [{
+    platform = "linux"
+  }]
+}
+
+# Test case 2: Firewall rule with enabled input
+resource "cloudflare_zero_trust_device_posture_rule" "firewall" {
+  account_id = var.cloudflare_account_id
+  name       = "tf-test-firewall"
+  type       = "firewall"
+  schedule   = "5m"
+
+
+  input = {
+    enabled = true
+  }
+  match = [{
+    platform = "windows"
+  }]
+}
+
+# Test case 3: Disk encryption with check_disks (Set->List conversion)
+resource "cloudflare_zero_trust_device_posture_rule" "disk_encryption" {
+  account_id = var.cloudflare_account_id
+  name       = "tf-test-disk"
+  type       = "disk_encryption"
+  schedule   = "5m"
+
+
+  input = {
+    check_disks = ["C:", "D:"]
+    require_all = true
+  }
+  match = [{
+    platform = "windows"
+  }]
+}
+
+# Test case 4: Multiple platforms (multiple match blocks)
+resource "cloudflare_zero_trust_device_posture_rule" "multi_platform" {
+  account_id = var.cloudflare_account_id
+  name       = "tf-test-multi"
+  type       = "firewall"
+  schedule   = "5m"
+
+
+
+
+  input = {
+    enabled = true
+  }
+  match = [{
+    platform = "windows"
+    }, {
+    platform = "mac"
+    }, {
+    platform = "linux"
+  }]
+}
+
+# Test case 5: Application rule with path and running (removed attribute)
+resource "cloudflare_zero_trust_device_posture_rule" "application" {
+  account_id = var.cloudflare_account_id
+  name       = "tf-test-application"
+  type       = "application"
+  schedule   = "30m"
+
+
+  input = {
+    path   = "/usr/bin/security-app"
+    sha256 = "abc123def456"
+  }
+  match = [{
+    platform = "linux"
+  }]
+}

--- a/integration/v4_to_v5/testdata/zero_trust_device_posture_rule/input/terraform.tfstate
+++ b/integration/v4_to_v5/testdata/zero_trust_device_posture_rule/input/terraform.tfstate
@@ -1,0 +1,374 @@
+{
+  "version": 4,
+  "terraform_version": "1.15.0",
+  "serial": 15,
+  "lineage": "2e525f2f-6f5f-a864-283c-e2b07953ecb4",
+  "outputs": {},
+  "resources": [
+    {
+      "mode": "managed",
+      "type": "cloudflare_device_posture_rule",
+      "name": "basic",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "description": "Device posture rule for corporate devices.",
+            "expiration": "24h",
+            "id": "f1d0ab1b-2db2-4283-ab9c-b809faced013",
+            "input": [
+              {
+                "active_threats": 0,
+                "certificate_id": "",
+                "check_disks": null,
+                "check_private_key": false,
+                "cn": "",
+                "compliance_status": "",
+                "connection_id": "",
+                "count_operator": "",
+                "domain": "",
+                "eid_last_seen": "",
+                "enabled": false,
+                "exists": false,
+                "extended_key_usage": null,
+                "id": "",
+                "infected": false,
+                "is_active": false,
+                "issue_count": "",
+                "last_seen": "",
+                "locations": [],
+                "network_status": "",
+                "operational_state": "",
+                "operator": "<",
+                "os": "",
+                "os_distro_name": "ubuntu",
+                "os_distro_revision": "1.0.0",
+                "os_version_extra": "(a)",
+                "overall": "",
+                "path": "",
+                "require_all": false,
+                "risk_level": "",
+                "running": false,
+                "score": 0,
+                "sensor_config": "",
+                "sha256": "",
+                "state": "",
+                "thumbprint": "",
+                "total_score": 0,
+                "version": "1.0.0",
+                "version_operator": ""
+              }
+            ],
+            "match": [
+              {
+                "platform": "linux"
+              }
+            ],
+            "name": "tf-test-posture-basic",
+            "schedule": "24h",
+            "type": "os_version"
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0,
+          "private": "bnVsbA=="
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_device_posture_rule",
+      "name": "disk_encryption",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "description": "",
+            "expiration": "",
+            "id": "10fd8575-3a0e-44c5-a771-73a2815a644c",
+            "input": [
+              {
+                "active_threats": 0,
+                "certificate_id": "",
+                "check_disks": [
+                  "C:",
+                  "D:"
+                ],
+                "check_private_key": false,
+                "cn": "",
+                "compliance_status": "",
+                "connection_id": "",
+                "count_operator": "",
+                "domain": "",
+                "eid_last_seen": "",
+                "enabled": false,
+                "exists": false,
+                "extended_key_usage": null,
+                "id": "",
+                "infected": false,
+                "is_active": false,
+                "issue_count": "",
+                "last_seen": "",
+                "locations": [],
+                "network_status": "",
+                "operational_state": "",
+                "operator": "",
+                "os": "",
+                "os_distro_name": "",
+                "os_distro_revision": "",
+                "os_version_extra": "",
+                "overall": "",
+                "path": "",
+                "require_all": true,
+                "risk_level": "",
+                "running": false,
+                "score": 0,
+                "sensor_config": "",
+                "sha256": "",
+                "state": "",
+                "thumbprint": "",
+                "total_score": 0,
+                "version": "",
+                "version_operator": ""
+              }
+            ],
+            "match": [
+              {
+                "platform": "windows"
+              }
+            ],
+            "name": "tf-test-disk",
+            "schedule": "5m",
+            "type": "disk_encryption"
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0,
+          "private": "bnVsbA=="
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_device_posture_rule",
+      "name": "firewall",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "description": "",
+            "expiration": "",
+            "id": "82648948-0bcc-49af-8b80-071e0bd69f6d",
+            "input": [
+              {
+                "active_threats": 0,
+                "certificate_id": "",
+                "check_disks": null,
+                "check_private_key": false,
+                "cn": "",
+                "compliance_status": "",
+                "connection_id": "",
+                "count_operator": "",
+                "domain": "",
+                "eid_last_seen": "",
+                "enabled": true,
+                "exists": false,
+                "extended_key_usage": null,
+                "id": "",
+                "infected": false,
+                "is_active": false,
+                "issue_count": "",
+                "last_seen": "",
+                "locations": [],
+                "network_status": "",
+                "operational_state": "",
+                "operator": "",
+                "os": "",
+                "os_distro_name": "",
+                "os_distro_revision": "",
+                "os_version_extra": "",
+                "overall": "",
+                "path": "",
+                "require_all": false,
+                "risk_level": "",
+                "running": false,
+                "score": 0,
+                "sensor_config": "",
+                "sha256": "",
+                "state": "",
+                "thumbprint": "",
+                "total_score": 0,
+                "version": "",
+                "version_operator": ""
+              }
+            ],
+            "match": [
+              {
+                "platform": "windows"
+              }
+            ],
+            "name": "tf-test-firewall",
+            "schedule": "5m",
+            "type": "firewall"
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0,
+          "private": "bnVsbA=="
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_device_posture_rule",
+      "name": "multi_platform",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "description": "",
+            "expiration": "",
+            "id": "91f41a4a-4dcb-4585-92cc-fe59dd78243b",
+            "input": [
+              {
+                "active_threats": 0,
+                "certificate_id": "",
+                "check_disks": null,
+                "check_private_key": false,
+                "cn": "",
+                "compliance_status": "",
+                "connection_id": "",
+                "count_operator": "",
+                "domain": "",
+                "eid_last_seen": "",
+                "enabled": true,
+                "exists": false,
+                "extended_key_usage": null,
+                "id": "",
+                "infected": false,
+                "is_active": false,
+                "issue_count": "",
+                "last_seen": "",
+                "locations": [],
+                "network_status": "",
+                "operational_state": "",
+                "operator": "",
+                "os": "",
+                "os_distro_name": "",
+                "os_distro_revision": "",
+                "os_version_extra": "",
+                "overall": "",
+                "path": "",
+                "require_all": false,
+                "risk_level": "",
+                "running": false,
+                "score": 0,
+                "sensor_config": "",
+                "sha256": "",
+                "state": "",
+                "thumbprint": "",
+                "total_score": 0,
+                "version": "",
+                "version_operator": ""
+              }
+            ],
+            "match": [
+              {
+                "platform": "windows"
+              },
+              {
+                "platform": "mac"
+              },
+              {
+                "platform": "linux"
+              }
+            ],
+            "name": "tf-test-multi",
+            "schedule": "5m",
+            "type": "firewall"
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0,
+          "private": "bnVsbA=="
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_device_posture_rule",
+      "name": "application",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "description": "",
+            "expiration": "",
+            "id": "c3d4e5f6-7890-abcd-ef12-3456789abcde",
+            "input": [
+              {
+                "active_threats": 0,
+                "certificate_id": "",
+                "check_disks": null,
+                "check_private_key": false,
+                "cn": "",
+                "compliance_status": "",
+                "connection_id": "",
+                "count_operator": "",
+                "domain": "",
+                "eid_last_seen": "",
+                "enabled": false,
+                "exists": false,
+                "extended_key_usage": null,
+                "id": "",
+                "infected": false,
+                "is_active": false,
+                "issue_count": "",
+                "last_seen": "",
+                "locations": [],
+                "network_status": "",
+                "operational_state": "",
+                "operator": "",
+                "os": "",
+                "os_distro_name": "",
+                "os_distro_revision": "",
+                "os_version_extra": "",
+                "overall": "",
+                "path": "/usr/bin/security-app",
+                "require_all": false,
+                "risk_level": "",
+                "running": true,
+                "score": 0,
+                "sensor_config": "",
+                "sha256": "abc123def456",
+                "state": "",
+                "thumbprint": "",
+                "total_score": 0,
+                "version": "",
+                "version_operator": ""
+              }
+            ],
+            "match": [
+              {
+                "platform": "linux"
+              }
+            ],
+            "name": "tf-test-application",
+            "schedule": "30m",
+            "type": "application"
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0,
+          "private": "bnVsbA=="
+        }
+      ]
+    }
+  ],
+  "check_results": null
+}

--- a/integration/v4_to_v5/testdata/zero_trust_device_posture_rule/input/zero_trust_device_posture_rule.tf
+++ b/integration/v4_to_v5/testdata/zero_trust_device_posture_rule/input/zero_trust_device_posture_rule.tf
@@ -1,0 +1,96 @@
+# Test case 1: Basic os_version rule with input and match
+resource "cloudflare_device_posture_rule" "basic" {
+  account_id  = var.cloudflare_account_id
+  name        = "tf-test-posture-basic"
+  type        = "os_version"
+  description = "Device posture rule for corporate devices."
+  schedule    = "24h"
+  expiration  = "24h"
+
+  match {
+    platform = "linux"
+  }
+
+  input {
+    version            = "1.0.0"
+    operator           = "<"
+    os_distro_name     = "ubuntu"
+    os_distro_revision = "1.0.0"
+    os_version_extra   = "(a)"
+  }
+}
+
+# Test case 2: Firewall rule with enabled input
+resource "cloudflare_device_posture_rule" "firewall" {
+  account_id = var.cloudflare_account_id
+  name       = "tf-test-firewall"
+  type       = "firewall"
+  schedule   = "5m"
+
+  match {
+    platform = "windows"
+  }
+
+  input {
+    enabled = true
+  }
+}
+
+# Test case 3: Disk encryption with check_disks (Set->List conversion)
+resource "cloudflare_device_posture_rule" "disk_encryption" {
+  account_id = var.cloudflare_account_id
+  name       = "tf-test-disk"
+  type       = "disk_encryption"
+  schedule   = "5m"
+
+  match {
+    platform = "windows"
+  }
+
+  input {
+    check_disks = ["C:", "D:"]
+    require_all = true
+  }
+}
+
+# Test case 4: Multiple platforms (multiple match blocks)
+resource "cloudflare_device_posture_rule" "multi_platform" {
+  account_id = var.cloudflare_account_id
+  name       = "tf-test-multi"
+  type       = "firewall"
+  schedule   = "5m"
+
+  match {
+    platform = "windows"
+  }
+
+  match {
+    platform = "mac"
+  }
+
+  match {
+    platform = "linux"
+  }
+
+  input {
+    enabled = true
+  }
+}
+
+# Test case 5: Application rule with path and running (removed attribute)
+resource "cloudflare_device_posture_rule" "application" {
+  account_id = var.cloudflare_account_id
+  name       = "tf-test-application"
+  type       = "application"
+  schedule   = "30m"
+
+  match {
+    platform = "linux"
+  }
+
+  input {
+    path    = "/usr/bin/security-app"
+    sha256  = "abc123def456"
+    running = true
+  }
+}

--- a/internal/handlers/formatter.go
+++ b/internal/handlers/formatter.go
@@ -21,11 +21,11 @@ func NewFormatterHandler(log hclog.Logger) transform.TransformationHandler {
 }
 
 func (h *FormatterHandler) Handle(ctx *transform.Context) (*transform.Context, error) {
-	if ctx.AST == nil {
-		return ctx, fmt.Errorf("AST is nil - cannot format without AST")
+	if ctx.CFGFile == nil {
+		return ctx, fmt.Errorf("CFGFile is nil - cannot format without CFGFile")
 	}
 
-	bytes := ctx.AST.Bytes()
+	bytes := ctx.CFGFile.Bytes()
 	formatted := hclwrite.Format(bytes)
 
 	ctx.Content = formatted

--- a/internal/handlers/formatter_test.go
+++ b/internal/handlers/formatter_test.go
@@ -96,7 +96,7 @@ resource "resource_b" "b" {
 				block := f.Body().AppendNewBlock("resource", []string{"test", "example"})
 				block.Body().SetAttributeValue("name", cty.StringVal("test"))
 
-				// Note: hclwrite doesn't preserve comments in the AST,
+				// Note: hclwrite doesn't preserve comments in the CFGFile,
 				// so this test mainly ensures formatting doesn't break
 				return f
 			},
@@ -150,9 +150,9 @@ resource "resource_b" "b" {
 			// Create handler
 			handler := handlers.NewFormatterHandler(log)
 
-			// Create context with AST
+			// Create context with CFGFile
 			ctx := &transform.Context{
-				AST:      tt.setupAST(),
+				CFGFile:  tt.setupAST(),
 				Filename: "test.tf",
 			}
 
@@ -191,11 +191,11 @@ func TestFormatterHandlerRequiresAST(t *testing.T) {
 
 	_, err := handler.Handle(ctx)
 	if err == nil {
-		t.Fatal("Expected error when AST is nil")
+		t.Fatal("Expected error when CFGFile is nil")
 	}
 
-	if !strings.Contains(err.Error(), "AST is nil") {
-		t.Errorf("Expected error about nil AST, got: %v", err)
+	if !strings.Contains(err.Error(), "CFGFile is nil") {
+		t.Errorf("Expected error about nil CFGFile, got: %v", err)
 	}
 }
 
@@ -219,7 +219,7 @@ func TestFormatterHandlerChaining(t *testing.T) {
 	f.Body().AppendNewBlock("resource", []string{"test", "example"})
 
 	ctx := &transform.Context{
-		AST: f,
+		CFGFile: f,
 	}
 
 	_, err := handler.Handle(ctx)
@@ -240,7 +240,7 @@ func TestFormatterPreservesAST(t *testing.T) {
 	originalBlock.Body().SetAttributeValue("name", cty.StringVal("test"))
 
 	ctx := &transform.Context{
-		AST: f,
+		CFGFile: f,
 	}
 
 	originalBlockCount := len(f.Body().Blocks())
@@ -250,12 +250,12 @@ func TestFormatterPreservesAST(t *testing.T) {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 
-	if result.AST != f {
-		t.Error("AST reference should be unchanged")
+	if result.CFGFile != f {
+		t.Error("CFGFile reference should be unchanged")
 	}
 
-	if len(result.AST.Body().Blocks()) != originalBlockCount {
-		t.Error("AST structure should be unchanged after formatting")
+	if len(result.CFGFile.Body().Blocks()) != originalBlockCount {
+		t.Error("CFGFile structure should be unchanged after formatting")
 	}
 }
 
@@ -271,7 +271,7 @@ func TestFormatterSpecialCharacters(t *testing.T) {
 	block.Body().SetAttributeValue("tabs", cty.StringVal("col1\tcol2"))
 
 	ctx := &transform.Context{
-		AST: f,
+		CFGFile: f,
 	}
 
 	result, err := handler.Handle(ctx)

--- a/internal/handlers/parse.go
+++ b/internal/handlers/parse.go
@@ -29,7 +29,7 @@ func (h *ParseHandler) Handle(ctx *transform.Context) (*transform.Context, error
 		return ctx, fmt.Errorf("failed to parse HCL: %s", diags.Error())
 	}
 
-	ctx.AST = file
+	ctx.CFGFile = file
 
 	if diags != nil && !diags.HasErrors() {
 		ctx.Diagnostics = append(ctx.Diagnostics, diags...)

--- a/internal/handlers/parse_test.go
+++ b/internal/handlers/parse_test.go
@@ -24,11 +24,11 @@ func TestParseHandler(t *testing.T) {
 }`,
 			expectError: false,
 			checkAST: func(t *testing.T, ctx *transform.Context) {
-				if ctx.AST == nil {
-					t.Fatal("AST should not be nil")
+				if ctx.CFGFile == nil {
+					t.Fatal("CFGFile should not be nil")
 				}
 
-				blocks := ctx.AST.Body().Blocks()
+				blocks := ctx.CFGFile.Body().Blocks()
 				if len(blocks) != 1 {
 					t.Errorf("Expected 1 block, got %d", len(blocks))
 				}
@@ -58,7 +58,7 @@ data "data_source" "example" {
 }`,
 			expectError: false,
 			checkAST: func(t *testing.T, ctx *transform.Context) {
-				blocks := ctx.AST.Body().Blocks()
+				blocks := ctx.CFGFile.Body().Blocks()
 				if len(blocks) != 3 {
 					t.Errorf("Expected 3 blocks, got %d", len(blocks))
 				}
@@ -89,10 +89,10 @@ data "data_source" "example" {
 			input:       "",
 			expectError: false,
 			checkAST: func(t *testing.T, ctx *transform.Context) {
-				if ctx.AST == nil {
-					t.Fatal("AST should not be nil even for empty file")
+				if ctx.CFGFile == nil {
+					t.Fatal("CFGFile should not be nil even for empty file")
 				}
-				blocks := ctx.AST.Body().Blocks()
+				blocks := ctx.CFGFile.Body().Blocks()
 				if len(blocks) != 0 {
 					t.Errorf("Expected 0 blocks for empty file, got %d", len(blocks))
 				}
@@ -104,7 +104,7 @@ data "data_source" "example" {
 /* Block comment */`,
 			expectError: false,
 			checkAST: func(t *testing.T, ctx *transform.Context) {
-				blocks := ctx.AST.Body().Blocks()
+				blocks := ctx.CFGFile.Body().Blocks()
 				if len(blocks) != 0 {
 					t.Errorf("Expected 0 blocks for file with only comments, got %d", len(blocks))
 				}
@@ -129,7 +129,7 @@ data "data_source" "example" {
 }`,
 			expectError: false,
 			checkAST: func(t *testing.T, ctx *transform.Context) {
-				blocks := ctx.AST.Body().Blocks()
+				blocks := ctx.CFGFile.Body().Blocks()
 				if len(blocks) != 1 {
 					t.Errorf("Expected 1 block, got %d", len(blocks))
 				}
@@ -203,8 +203,8 @@ func TestParseHandlerChaining(t *testing.T) {
 	mockNext := &mockHandler{
 		handleFunc: func(ctx *transform.Context) (*transform.Context, error) {
 			nextHandlerCalled = true
-			if ctx.AST == nil {
-				t.Error("AST should be set when next handler is called")
+			if ctx.CFGFile == nil {
+				t.Error("CFGFile should be set when next handler is called")
 			}
 			return ctx, nil
 		},

--- a/internal/handlers/resource_transform.go
+++ b/internal/handlers/resource_transform.go
@@ -24,11 +24,11 @@ func NewResourceTransformHandler(log hclog.Logger, provider transform.MigrationP
 }
 
 func (h *ResourceTransformHandler) Handle(ctx *transform.Context) (*transform.Context, error) {
-	if ctx.AST == nil {
-		return ctx, fmt.Errorf("AST is nil - ParseHandler must run before ResourceTransformHandler")
+	if ctx.CFGFile == nil {
+		return ctx, fmt.Errorf("CFGFile is nil - ParseHandler must run before ResourceTransformHandler")
 	}
 
-	body := ctx.AST.Body()
+	body := ctx.CFGFile.Body()
 	blocks := body.Blocks()
 
 	var blocksToRemove []*hclwrite.Block

--- a/internal/handlers/state_transform.go
+++ b/internal/handlers/state_transform.go
@@ -77,10 +77,11 @@ func (h *StateTransformHandler) Handle(ctx *transform.Context) (*transform.Conte
 			}
 		}
 
+		resourceName := resource.Get("name").String()
 		instances.ForEach(func(instKey, instance gjson.Result) bool {
 			resourcePath := fmt.Sprintf("resources.%d.instances.%d", key.Int(), instKey.Int())
 
-			transformedJSON, err := migrator.TransformState(ctx, instance, resourcePath)
+			transformedJSON, err := migrator.TransformState(ctx, instance, resourcePath, resourceName)
 			if err != nil {
 				h.log.Error("Error transforming state resource",
 					"type", resourceType,

--- a/internal/migrator_test.go
+++ b/internal/migrator_test.go
@@ -21,7 +21,7 @@ func (m *mockMigrator) TransformConfig(ctx *transform.Context, block *hclwrite.B
 	return nil, nil
 }
 
-func (m *mockMigrator) TransformState(ctx *transform.Context, json gjson.Result, resourcePath string) (string, error) {
+func (m *mockMigrator) TransformState(ctx *transform.Context, stateJSON gjson.Result, resourcePath, resourceName string) (string, error) {
 	return "", nil
 }
 

--- a/internal/pipeline/pipeline_test.go
+++ b/internal/pipeline/pipeline_test.go
@@ -63,7 +63,7 @@ func (m *MockResourceTransformer) TransformConfig(ctx *transform.Context, block 
 	}, nil
 }
 
-func (m *MockResourceTransformer) TransformState(ctx *transform.Context, json gjson.Result, resourcePath string) (string, error) {
+func (m *MockResourceTransformer) TransformState(ctx *transform.Context, stateJSON gjson.Result, resourcePath, resourceName string) (string, error) {
 	m.transformStateCalls++
 	return "", nil
 }

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cloudflare/tf-migrate/internal/resources/zero_trust_access_service_token"
 	"github.com/cloudflare/tf-migrate/internal/resources/zero_trust_dlp_custom_profile"
 	"github.com/cloudflare/tf-migrate/internal/resources/zero_trust_gateway_policy"
+	"github.com/cloudflare/tf-migrate/internal/resources/zero_trust_device_posture_rule"
 	"github.com/cloudflare/tf-migrate/internal/resources/zero_trust_list"
 	"github.com/cloudflare/tf-migrate/internal/resources/zero_trust_tunnel_cloudflared"
 	"github.com/cloudflare/tf-migrate/internal/resources/zero_trust_tunnel_cloudflared_route"
@@ -34,6 +35,7 @@ func RegisterAllMigrations() {
 	zero_trust_access_service_token.NewV4ToV5Migrator()
 	zero_trust_dlp_custom_profile.NewV4ToV5Migrator()
 	zero_trust_gateway_policy.NewV4ToV5Migrator()
+	zero_trust_device_posture_rule.NewV4ToV5Migrator()
 	zero_trust_list.NewV4ToV5Migrator()
 	zero_trust_tunnel_cloudflared.NewV4ToV5Migrator()
 	zero_trust_tunnel_cloudflared_route.NewV4ToV5Migrator()

--- a/internal/resources/account_member/v4_to_v5.go
+++ b/internal/resources/account_member/v4_to_v5.go
@@ -48,7 +48,7 @@ func (m *V4ToV5Migrator) TransformConfig(ctx *transform.Context, block *hclwrite
 	}, nil
 }
 
-func (m *V4ToV5Migrator) TransformState(ctx *transform.Context, stateJSON gjson.Result, resourcePath string) (string, error) {
+func (m *V4ToV5Migrator) TransformState(ctx *transform.Context, stateJSON gjson.Result, resourcePath, resourceName string) (string, error) {
 	result := stateJSON.String()
 
 	if !stateJSON.Exists() || !stateJSON.Get("attributes").Exists() {

--- a/internal/resources/api_token/v4_to_v5.go
+++ b/internal/resources/api_token/v4_to_v5.go
@@ -164,7 +164,7 @@ func (m *V4ToV5Migrator) transformConditionBlock(body *hclwrite.Body) {
 	body.RemoveBlock(conditionBlock)
 }
 
-func (m *V4ToV5Migrator) TransformState(ctx *transform.Context, stateJSON gjson.Result, resourcePath string) (string, error) {
+func (m *V4ToV5Migrator) TransformState(ctx *transform.Context, stateJSON gjson.Result, resourcePath, resourceName string) (string, error) {
 	result := stateJSON.String()
 
 	attributesPath := "attributes"

--- a/internal/resources/dns_record/v4_to_v5.go
+++ b/internal/resources/dns_record/v4_to_v5.go
@@ -162,16 +162,16 @@ func (m *V4ToV5Migrator) processDataAttribute(block *hclwrite.Block, recordType 
 	}
 }
 
-func (m *V4ToV5Migrator) TransformState(ctx *transform.Context, instance gjson.Result, resourcePath string) (string, error) {
+func (m *V4ToV5Migrator) TransformState(ctx *transform.Context, stateJSON gjson.Result, resourcePath, resourceName string) (string, error) {
 	// This function receives a single instance and needs to return the transformed instance JSON
-	result := instance.String()
+	result := stateJSON.String()
 
 	// Single instance - check if it's a valid DNS record instance
-	if !instance.Exists() || !instance.Get("attributes").Exists() {
+	if !stateJSON.Exists() || !stateJSON.Get("attributes").Exists() {
 		return result, nil
 	}
 
-	attrs := instance.Get("attributes")
+	attrs := stateJSON.Get("attributes")
 	if !attrs.Get("name").Exists() || !attrs.Get("type").Exists() || !attrs.Get("zone_id").Exists() {
 		// Even for invalid/incomplete instances, we need to set schema_version for v5
 		result, _ = sjson.Set(result, "schema_version", 0)
@@ -179,7 +179,7 @@ func (m *V4ToV5Migrator) TransformState(ctx *transform.Context, instance gjson.R
 	}
 
 	// Transform the single instance
-	result = m.transformSingleDNSInstance(result, instance)
+	result = m.transformSingleDNSInstance(result, stateJSON)
 
 	// Ensure schema_version is set to 0 for v5
 	result, _ = sjson.Set(result, "schema_version", 0)

--- a/internal/resources/logpull_retention/v4_to_v5.go
+++ b/internal/resources/logpull_retention/v4_to_v5.go
@@ -49,7 +49,7 @@ func (m *V4ToV5Migrator) TransformConfig(ctx *transform.Context, block *hclwrite
 	}, nil
 }
 
-func (m *V4ToV5Migrator) TransformState(ctx *transform.Context, stateJSON gjson.Result, resourcePath string) (string, error) {
+func (m *V4ToV5Migrator) TransformState(ctx *transform.Context, stateJSON gjson.Result, resourcePath, resourceName string) (string, error) {
 	result := stateJSON.String()
 
 	if !stateJSON.Exists() || !stateJSON.Get("attributes").Exists() {

--- a/internal/resources/notification_policy_webhooks/v4_to_v5.go
+++ b/internal/resources/notification_policy_webhooks/v4_to_v5.go
@@ -45,7 +45,7 @@ func (m *V4ToV5Migrator) TransformConfig(ctx *transform.Context, block *hclwrite
 	}, nil
 }
 
-func (m *V4ToV5Migrator) TransformState(ctx *transform.Context, stateJSON gjson.Result, resourcePath string) (string, error) {
+func (m *V4ToV5Migrator) TransformState(ctx *transform.Context, stateJSON gjson.Result, resourcePath, resourceName string) (string, error) {
 	result := stateJSON.String()
 
 	if !stateJSON.Exists() {

--- a/internal/resources/r2_bucket/v4_to_v5.go
+++ b/internal/resources/r2_bucket/v4_to_v5.go
@@ -50,7 +50,7 @@ func (m *V4ToV5Migrator) TransformConfig(ctx *transform.Context, block *hclwrite
 // TransformState transforms the JSON state from v4 to v5.
 // For r2_bucket, we need to add the new v5 fields with their default values
 // to prevent plan changes after migration.
-func (m *V4ToV5Migrator) TransformState(ctx *transform.Context, stateJSON gjson.Result, resourcePath string) (string, error) {
+func (m *V4ToV5Migrator) TransformState(ctx *transform.Context, stateJSON gjson.Result, resourcePath, resourceName string) (string, error) {
 	result := stateJSON.String()
 
 	if !stateJSON.Exists() || !stateJSON.Get("attributes").Exists() {

--- a/internal/resources/workers_kv/v4_to_v5.go
+++ b/internal/resources/workers_kv/v4_to_v5.go
@@ -52,7 +52,7 @@ func (m *V4ToV5Migrator) TransformConfig(ctx *transform.Context, block *hclwrite
 	}, nil
 }
 
-func (m *V4ToV5Migrator) TransformState(ctx *transform.Context, stateJSON gjson.Result, resourcePath string) (string, error) {
+func (m *V4ToV5Migrator) TransformState(ctx *transform.Context, stateJSON gjson.Result, resourcePath, resourceName string) (string, error) {
 	result := stateJSON.String()
 
 	if !stateJSON.Exists() || !stateJSON.Get("attributes").Exists() {

--- a/internal/resources/workers_kv_namespace/v4_to_v5.go
+++ b/internal/resources/workers_kv_namespace/v4_to_v5.go
@@ -50,7 +50,7 @@ func (m *V4ToV5Migrator) TransformConfig(ctx *transform.Context, block *hclwrite
 // For workers_kv_namespace, the state is identical between v4 and v5.
 // The id field exists in both v4 (implicit) and v5 (explicit in schema).
 // The supports_url_encoding field is new in v5 and will be populated by the provider on first refresh.
-func (m *V4ToV5Migrator) TransformState(ctx *transform.Context, stateJSON gjson.Result, resourcePath string) (string, error) {
+func (m *V4ToV5Migrator) TransformState(ctx *transform.Context, stateJSON gjson.Result, resourcePath, resourceName string) (string, error) {
 	result := stateJSON.String()
 
 	if !stateJSON.Exists() || !stateJSON.Get("attributes").Exists() {

--- a/internal/resources/zero_trust_access_service_token/v4_to_v5.go
+++ b/internal/resources/zero_trust_access_service_token/v4_to_v5.go
@@ -60,7 +60,7 @@ func (m *V4ToV5Migrator) TransformConfig(ctx *transform.Context, block *hclwrite
 	}, nil
 }
 
-func (m *V4ToV5Migrator) TransformState(ctx *transform.Context, stateJSON gjson.Result, resourcePath string) (string, error) {
+func (m *V4ToV5Migrator) TransformState(ctx *transform.Context, stateJSON gjson.Result, resourcePath, resourceName string) (string, error) {
 	result := stateJSON.String()
 
 	if stateJSON.Get("resources").Exists() {

--- a/internal/resources/zero_trust_device_posture_rule/v4_to_v5.go
+++ b/internal/resources/zero_trust_device_posture_rule/v4_to_v5.go
@@ -1,0 +1,286 @@
+package zero_trust_device_posture_rule
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclwrite"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+	"github.com/zclconf/go-cty/cty"
+
+	"github.com/cloudflare/tf-migrate/internal"
+	"github.com/cloudflare/tf-migrate/internal/transform"
+	tfhcl "github.com/cloudflare/tf-migrate/internal/transform/hcl"
+	"github.com/cloudflare/tf-migrate/internal/transform/state"
+)
+
+// V4ToV5Migrator handles migration of device posture rule resources from v4 to v5
+type V4ToV5Migrator struct {
+}
+
+func NewV4ToV5Migrator() transform.ResourceTransformer {
+	migrator := &V4ToV5Migrator{}
+
+	internal.RegisterMigrator("cloudflare_device_posture_rule", "v4", "v5", migrator)
+	internal.RegisterMigrator("cloudflare_zero_trust_device_posture_rule", "v4", "v5", migrator)
+
+	return migrator
+}
+
+func (m *V4ToV5Migrator) GetResourceType() string {
+	return "cloudflare_zero_trust_device_posture_rule"
+}
+
+func (m *V4ToV5Migrator) CanHandle(resourceType string) bool {
+	return resourceType == "cloudflare_device_posture_rule" ||
+		resourceType == "cloudflare_zero_trust_device_posture_rule"
+}
+
+func (m *V4ToV5Migrator) Preprocess(content string) string {
+	// No preprocessing needed - all transformations done at HCL level
+	return content
+}
+
+func (m *V4ToV5Migrator) TransformConfig(ctx *transform.Context, block *hclwrite.Block) (*transform.TransformResult, error) {
+	tfhcl.RenameResourceType(block, "cloudflare_device_posture_rule", "cloudflare_zero_trust_device_posture_rule")
+
+	body := block.Body()
+
+	// Convert optional input block to attribute, handling nested locations attribute
+	if inputBlock := tfhcl.FindBlockByType(body, "input"); inputBlock != nil {
+		tfhcl.ConvertBlocksToAttribute(body, "input", "input", func(inputBlock *hclwrite.Block) {
+			tfhcl.RemoveAttributes(inputBlock.Body(), "running")
+			tfhcl.ConvertBlocksToAttribute(inputBlock.Body(), "locations", "locations", func(locationsBlock *hclwrite.Block) {})
+		})
+	}
+
+	// Convert optional match blocks to attribute array
+	if matchBlocks := tfhcl.FindBlocksByType(body, "match"); len(matchBlocks) > 0 {
+		tfhcl.MergeAttributeAndBlocksToObjectArray(body, "", "match", "match", "platform", []string{}, true)
+	}
+
+	// IF there is no name attribute, check in state for a name value and if so, use it
+	if !tfhcl.HasAttribute(body, "name") {
+		if ctx.StateJSON != "" {
+			labels := block.Labels()
+			resourceName := labels[1]
+			gjson.Parse(ctx.StateJSON).Get("resources").ForEach(func(key, resource gjson.Result) bool {
+				if m.CanHandle(resource.Get("type").String()) && resource.Get("name").String() == resourceName {
+					if resource.Get("instances.0.attributes.name").Exists() {
+						body.SetAttributeValue("name", cty.StringVal(resource.Get("instances.0.attributes.name").String()))
+					}
+					return false
+				}
+				return true
+			})
+		}
+	}
+
+	return &transform.TransformResult{
+		Blocks:         []*hclwrite.Block{block},
+		RemoveOriginal: false,
+	}, nil
+}
+
+func (m *V4ToV5Migrator) TransformState(ctx *transform.Context, stateJSON gjson.Result, resourcePath, resourceName string) (string, error) {
+	result := stateJSON.String()
+
+	attrs := stateJSON.Get("attributes")
+	if !attrs.Exists() {
+		result, _ = sjson.Set(result, "schema_version", 0)
+		return result, nil
+	}
+
+	inputField := attrs.Get("input")
+	if inputField.Exists() {
+		if m.inputFieldIsEmpty(attrs) {
+			result, _ = sjson.Delete(result, "attributes.input")
+		} else {
+			result = m.transformInputArrayToObject(result, attrs)
+		}
+	}
+
+	// Re-parse attrs after transformation to get updated structure
+	updatedAttrs := gjson.Parse(result).Get("attributes")
+
+	result = m.convertNumericFields(result, updatedAttrs)
+
+	inputField = updatedAttrs.Get("input")
+	if inputField.Exists() {
+		result = m.transformInputEmptyValuesToNull(ctx, result, updatedAttrs, resourceName)
+		if inputField.Get("running").Exists() {
+			result, _ = sjson.Delete(result, "attributes.input.running")
+		}
+	}
+
+	result, _ = sjson.Set(result, "schema_version", 0)
+
+	return result, nil
+}
+
+// stateHasEmptyInputAttribute checks if the state file's input attribute consists entirely of empty values
+func (m *V4ToV5Migrator) inputFieldIsEmpty(attrs gjson.Result) bool {
+	emptyInput := `
+{
+	"active_threats": 0,
+	"certificate_id": "",
+	"check_disks": null,
+	"check_private_key": false,
+	"cn": "",
+	"compliance_status": "",
+	"connection_id": "",
+	"count_operator": "",
+	"domain": "",
+	"eid_last_seen": "",
+	"enabled": false,
+	"exists": false,
+	"extended_key_usage": null,
+	"id": "",
+	"infected": false,
+	"is_active": false,
+	"issue_count": "",
+	"last_seen": "",
+	"locations": [],
+	"network_status": "",
+	"operational_state": "",
+	"operator": "",
+	"os": "",
+	"os_distro_name": "",
+	"os_distro_revision": "",
+	"os_version_extra": "",
+	"overall": "",
+	"path": "",
+	"require_all": false,
+	"risk_level": "",
+	"running": false,
+	"score": 0,
+	"sensor_config": "",
+	"sha256": "",
+	"state": "",
+	"thumbprint": "",
+	"total_score": 0,
+	"version": "",
+	"version_operator": ""
+}`
+
+	inputField := attrs.Get("input")
+	if !inputField.Exists() {
+		return false
+	}
+
+	if !inputField.IsArray() || len(inputField.Array()) == 0 {
+		return true
+	}
+
+	inputObj := inputField.Array()[0]
+
+	var actual, expected map[string]interface{}
+	json.Unmarshal([]byte(inputObj.Raw), &actual)
+	json.Unmarshal([]byte(emptyInput), &expected)
+
+	return reflect.DeepEqual(actual, expected)
+}
+
+func (m *V4ToV5Migrator) transformInputEmptyValuesToNull(ctx *transform.Context, result string, attrs gjson.Result, resourceName string) string {
+	inputField := attrs.Get("input")
+	if !inputField.Exists() {
+		return result
+	}
+
+	inputField.ForEach(func(key, value gjson.Result) bool {
+		if state.IsEmptyValue(value) {
+			emptyValueDefineInHCL := false
+
+			// Check if this empty value was defined in HCL and if so don't transform it to null
+			if len(ctx.CFGFiles) > 0 {
+			HCL_SEARCH:
+				for _, file := range ctx.CFGFiles {
+					resourceBlocks := tfhcl.FindBlocksByType(file.Body(), "resource")
+					for _, resourceBlock := range resourceBlocks {
+						resourceBlockType := tfhcl.GetResourceType(resourceBlock)
+						resourceBlockName := tfhcl.GetResourceName(resourceBlock)
+
+						if m.CanHandle(resourceBlockType) && resourceBlockName == resourceName {
+							inputAttribute := resourceBlock.Body().GetAttribute("input")
+							if tfhcl.AttributeValueContainsKey(inputAttribute, key.String()) {
+								emptyValueDefineInHCL = true
+							}
+							break HCL_SEARCH
+						}
+					}
+				}
+			}
+
+			// If empty value was not explicity defined in HCL, carry out empty value -> null transformation
+			if !emptyValueDefineInHCL {
+				result, _ = sjson.Set(result, "attributes.input."+key.String(), nil)
+				ctx.Diagnostics = append(ctx.Diagnostics, &hcl.Diagnostic{
+					Severity: hcl.DiagWarning,
+					Summary:  fmt.Sprintf("Transforming state for attribute %s from empty value to null. Will require an update in place.", key.String()),
+				})
+			}
+		}
+
+		return true
+	})
+
+	return result
+}
+
+// transformInputArrayToObject converts input field from array to object
+func (m *V4ToV5Migrator) transformInputArrayToObject(stateJSON string, attrs gjson.Result) string {
+	inputField := attrs.Get("input")
+
+	if !inputField.Exists() {
+		return stateJSON
+	}
+
+	if inputField.IsArray() && len(inputField.Array()) > 0 {
+		inputObj := inputField.Array()[0]
+
+		// First, transform nested locations if it exists and is an array
+		if locationsField := inputObj.Get("locations"); locationsField.Exists() {
+			if locationsField.IsArray() && len(locationsField.Array()) > 0 {
+				locationsObj := locationsField.Array()[0]
+				inputObjMap := inputObj.Value().(map[string]interface{})
+				inputObjMap["locations"] = locationsObj.Value()
+				stateJSON, _ = sjson.Set(stateJSON, "attributes.input", inputObjMap)
+				return stateJSON
+			}
+		}
+
+		stateJSON, _ = sjson.Set(stateJSON, "attributes.input", inputObj.Value())
+	} else if inputField.IsArray() && len(inputField.Array()) == 0 {
+		stateJSON, _ = sjson.Delete(stateJSON, "attributes.input")
+	}
+
+	return stateJSON
+}
+
+// convertNumericFields converts TypeInt fields to Float64Attribute
+func (m *V4ToV5Migrator) convertNumericFields(stateJSON string, attrs gjson.Result) string {
+	inputField := attrs.Get("input")
+	if !inputField.Exists() || !inputField.IsObject() {
+		return stateJSON
+	}
+
+	if activeThreats := inputField.Get("active_threats"); activeThreats.Exists() {
+		floatVal := state.ConvertToFloat64(activeThreats)
+		stateJSON, _ = sjson.Set(stateJSON, "attributes.input.active_threats", floatVal)
+	}
+
+	if totalScore := inputField.Get("total_score"); totalScore.Exists() {
+		floatVal := state.ConvertToFloat64(totalScore)
+		stateJSON, _ = sjson.Set(stateJSON, "attributes.input.total_score", floatVal)
+	}
+
+	if score := inputField.Get("score"); score.Exists() {
+		floatVal := state.ConvertToFloat64(score)
+		stateJSON, _ = sjson.Set(stateJSON, "attributes.input.score", floatVal)
+	}
+
+	return stateJSON
+}

--- a/internal/resources/zero_trust_device_posture_rule/v4_to_v5_test.go
+++ b/internal/resources/zero_trust_device_posture_rule/v4_to_v5_test.go
@@ -1,0 +1,1383 @@
+package zero_trust_device_posture_rule
+
+import (
+	"testing"
+
+	"github.com/cloudflare/tf-migrate/internal/testhelpers"
+)
+
+func TestConfigTransformation(t *testing.T) {
+	migrator := NewV4ToV5Migrator()
+
+	tests := []testhelpers.ConfigTestCase{
+		{
+			Name: "minimal resource - rename",
+			Input: `
+resource "cloudflare_device_posture_rule" "test" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+  name       = "name"
+  type       = "serial_number"
+}
+`,
+			Expected: `
+resource "cloudflare_zero_trust_device_posture_rule" "test" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+  name       = "name"
+  type       = "serial_number"
+}
+`,
+		},
+		{
+			Name: "minimal resource - no rename",
+			Input: `
+resource "cloudflare_zero_trust_device_posture_rule" "test" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+  name       = "name"
+  type       = "serial_number"
+}
+`,
+			Expected: `
+resource "cloudflare_zero_trust_device_posture_rule" "test" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+  name       = "name"
+  type       = "serial_number"
+}
+`,
+		},
+		{
+			Name: "minimal resource - no name",
+			Input: `
+resource "cloudflare_zero_trust_device_posture_rule" "test" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+  type       = "serial_number"
+}
+`,
+			Expected: `
+resource "cloudflare_zero_trust_device_posture_rule" "test" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+  type       = "serial_number"
+}
+`,
+		},
+		{
+			Name: "resource with input block",
+			Input: `
+resource "cloudflare_device_posture_rule" "test" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+  name       = "name"
+  type       = "os_version"
+  input {
+    version  = "10.0"
+    operator = ">="
+    enabled  = true
+  }
+}
+`,
+			Expected: `
+resource "cloudflare_zero_trust_device_posture_rule" "test" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+  name       = "name"
+  type       = "os_version"
+  input = {
+    version  = "10.0"
+    operator = ">="
+    enabled  = true
+  }
+}
+`,
+		},
+		{
+			Name: "resource with input block and nested locations block",
+			Input: `
+resource "cloudflare_device_posture_rule" "test" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+  name       = "name"
+  type       = "os_version"
+  input {
+    version  = "10.0"
+    operator = ">="
+    enabled  = true
+    locations {
+      paths        = ["/etc/ssl/certs"]
+      trust_stores = ["system"]
+    }
+  }
+}
+`,
+			Expected: `
+resource "cloudflare_zero_trust_device_posture_rule" "test" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+  name       = "name"
+  type       = "os_version"
+  input = {
+    version  = "10.0"
+    operator = ">="
+    enabled  = true
+    locations = {
+      paths        = ["/etc/ssl/certs"]
+      trust_stores = ["system"]
+    }
+  }
+}
+`,
+		},
+		{
+			Name: "resource with match blocks",
+			Input: `
+resource "cloudflare_device_posture_rule" "test" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+  name       = "name"
+  type       = "os_version"
+  match {
+    platform = "windows"
+  }
+  match {
+    platform = "mac"
+  }
+}
+`,
+			Expected: `
+resource "cloudflare_zero_trust_device_posture_rule" "test" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+  name       = "name"
+  type       = "os_version"
+  match = [{
+    platform = "windows"
+    }, {
+    platform = "mac"
+  }]
+}
+`,
+		},
+		{
+			Name: "resource with removed running attribute",
+			Input: `
+resource "cloudflare_device_posture_rule" "test" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+  name       = "name"
+  type       = "serial_number"
+  input {
+    exists  = true
+    running = 1
+  }
+}
+`,
+			Expected: `
+resource "cloudflare_zero_trust_device_posture_rule" "test" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+  name       = "name"
+  type       = "serial_number"
+  input      = {
+    exists = true
+  }
+}
+`,
+		},
+		{
+			Name: "comprehensive resource with all field types",
+			Input: `
+resource "cloudflare_device_posture_rule" "test" {
+  account_id  = "f037e56e89293a057740de681ac9abbe"
+  name        = "name"
+  description = "Tests all field types and transformations"
+  type        = "client_certificate_v2"
+  schedule    = "5m"
+  expiration  = "1h"
+  input {
+    id                   = "test-id-123"
+    path                 = "/usr/bin/app"
+    exists               = true
+    thumbprint           = "abc123def456"
+    sha256               = "sha256hash"
+    running              = true
+    require_all          = true
+    check_disks          = ["C:", "D:", "E:"]
+    enabled              = true
+    version              = "1.0.0"
+    os_version_extra     = "build-123"
+    operator             = ">="
+    domain               = "example.com"
+    connection_id        = "conn-123"
+    compliance_status    = "compliant"
+    os_distro_name       = "Ubuntu"
+    os_distro_revision   = "22.04"
+    os                   = "linux"
+    overall              = "pass"
+    sensor_config        = "sensor-config-123"
+    version_operator     = ">="
+    last_seen            = "2024-01-01T00:00:00Z"
+    state                = "active"
+    count_operator       = ">"
+    issue_count          = "5"
+    certificate_id       = "cert-123"
+    cn                   = "device.example.com"
+    active_threats       = 1
+    operational_state    = "active"
+    network_status       = "connected"
+    infected             = false
+    is_active            = true
+    eid_last_seen        = "2024-01-01T00:00:00Z"
+    risk_level           = "low"
+    total_score          = 85
+    check_private_key    = true
+    extended_key_usage   = ["clientAuth", "serverAuth"]
+    score                = 100
+    locations {
+      paths        = ["/etc/ssl/certs", "/usr/local/share/certs", "/opt/certs"]
+      trust_stores = ["system", "user", "custom"]
+    }
+  }
+  match {
+    platform = "windows"
+  }
+  match {
+    platform = "mac"
+  }
+  match {
+    platform = "linux"
+  }
+}
+`,
+			Expected: `
+resource "cloudflare_zero_trust_device_posture_rule" "test" {
+  account_id  = "f037e56e89293a057740de681ac9abbe"
+  name        = "name"
+  description = "Tests all field types and transformations"
+  type        = "client_certificate_v2"
+  schedule    = "5m"
+  expiration  = "1h"
+  input = {
+    id                   = "test-id-123"
+    path                 = "/usr/bin/app"
+    exists               = true
+    thumbprint           = "abc123def456"
+    sha256               = "sha256hash"
+    require_all          = true
+    check_disks          = ["C:", "D:", "E:"]
+    enabled              = true
+    version              = "1.0.0"
+    os_version_extra     = "build-123"
+    operator             = ">="
+    domain               = "example.com"
+    connection_id        = "conn-123"
+    compliance_status    = "compliant"
+    os_distro_name       = "Ubuntu"
+    os_distro_revision   = "22.04"
+    os                   = "linux"
+    overall              = "pass"
+    sensor_config        = "sensor-config-123"
+    version_operator     = ">="
+    last_seen            = "2024-01-01T00:00:00Z"
+    state                = "active"
+    count_operator       = ">"
+    issue_count          = "5"
+    certificate_id       = "cert-123"
+    cn                   = "device.example.com"
+    active_threats       = 1
+    operational_state    = "active"
+    network_status       = "connected"
+    infected             = false
+    is_active            = true
+    eid_last_seen        = "2024-01-01T00:00:00Z"
+    risk_level           = "low"
+    total_score          = 85
+    check_private_key    = true
+    extended_key_usage   = ["clientAuth", "serverAuth"]
+    score                = 100
+    locations = {
+      paths        = ["/etc/ssl/certs", "/usr/local/share/certs", "/opt/certs"]
+      trust_stores = ["system", "user", "custom"]
+    }
+  }
+  match = [{
+    platform = "windows"
+    }, {
+    platform = "mac"
+    }, {
+    platform = "linux"
+  }]
+}
+`,
+		},
+	}
+
+	testhelpers.RunConfigTransformTests(t, tests, migrator)
+}
+
+func TestStateTransformation(t *testing.T) {
+	migrator := NewV4ToV5Migrator()
+
+	tests := []testhelpers.StateTestCase{
+		{
+			Name: "empty input block",
+			Input: `{
+			"version": 4,
+			"terraform_version": "1.5.0",
+			"resources": [{
+				"type": "cloudflare_device_posture_rule",
+				"name": "name",
+				"instances": [{
+					"attributes": {
+						"id": "test-rule-id",
+						"account_id": "f037e56e89293a057740de681ac9abbe",
+						"name": "name",
+						"type": "serial_number",
+						"input": [{
+							"active_threats": 0,
+							"certificate_id": "",
+							"check_disks": null,
+							"check_private_key": false,
+							"cn": "",
+							"compliance_status": "",
+							"connection_id": "",
+							"count_operator": "",
+							"domain": "",
+							"eid_last_seen": "",
+							"enabled": false,
+							"exists": false,
+							"extended_key_usage": null,
+							"id": "",
+							"infected": false,
+							"is_active": false,
+							"issue_count": "",
+							"last_seen": "",
+							"locations": [],
+							"network_status": "",
+							"operational_state": "",
+							"operator": "",
+							"os": "",
+							"os_distro_name": "",
+							"os_distro_revision": "",
+							"os_version_extra": "",
+							"overall": "",
+							"path": "",
+							"require_all": false,
+							"risk_level": "",
+							"running": false,
+							"score": 0,
+							"sensor_config": "",
+							"sha256": "",
+							"state": "",
+							"thumbprint": "",
+							"total_score": 0,
+							"version": "",
+							"version_operator": ""
+  						}]
+					},
+					"schema_version": 1
+				}]
+			}]
+		}`,
+			Expected: `{
+			"version": 4,
+			"terraform_version": "1.5.0",
+			"resources": [{
+				"type": "cloudflare_zero_trust_device_posture_rule",
+				"name": "name",
+				"instances": [{
+					"attributes": {
+						"id": "test-rule-id",
+						"account_id": "f037e56e89293a057740de681ac9abbe",
+						"name": "name",
+						"type": "serial_number"
+					},
+					"schema_version": 0
+				}]
+			}]
+		}`,
+		},
+		{
+			Name: "non empty input block",
+			Input: `{
+			"version": 4,
+			"terraform_version": "1.5.0",
+			"resources": [{
+				"type": "cloudflare_device_posture_rule",
+				"name": "name",
+				"instances": [{
+					"attributes": {
+						"id": "test-rule-id",
+						"account_id": "f037e56e89293a057740de681ac9abbe",
+						"name": "name",
+						"type": "os_version",
+						"input": [{
+							"active_threats": 0,
+							"certificate_id": "",
+							"check_disks": null,
+							"check_private_key": false,
+							"cn": "",
+							"compliance_status": "",
+							"connection_id": "",
+							"count_operator": "",
+							"domain": "",
+							"eid_last_seen": "",
+							"enabled": false,
+							"exists": false,
+							"extended_key_usage": null,
+							"id": "",
+							"infected": false,
+							"is_active": false,
+							"issue_count": "",
+							"last_seen": "",
+							"locations": [],
+							"network_status": "",
+							"operational_state": "",
+							"operator": "",
+							"os": "linux",
+							"os_distro_name": "",
+							"os_distro_revision": "",
+							"os_version_extra": "",
+							"overall": "",
+							"path": "",
+							"require_all": false,
+							"risk_level": "",
+							"running": false,
+							"score": 0,
+							"sensor_config": "",
+							"sha256": "",
+							"state": "",
+							"thumbprint": "",
+							"total_score": 0,
+							"version": "",
+							"version_operator": ""
+  						}]
+					},
+					"schema_version": 1
+				}]
+			}]
+		}`,
+			Expected: `{
+			"version": 4,
+			"terraform_version": "1.5.0",
+			"resources": [{
+				"type": "cloudflare_zero_trust_device_posture_rule",
+				"name": "name",
+				"instances": [{
+					"attributes": {
+						"id": "test-rule-id",
+						"account_id": "f037e56e89293a057740de681ac9abbe",
+						"name": "name",
+						"type": "os_version",
+						"input": {
+							"active_threats": null,
+							"certificate_id": null,
+							"check_disks": null,
+							"check_private_key": null,
+							"cn": null,
+							"compliance_status": null,
+							"connection_id": null,
+							"count_operator": null,
+							"domain": null,
+							"eid_last_seen": null,
+							"enabled": null,
+							"exists": null,
+							"extended_key_usage": null,
+							"id": null,
+							"infected": null,
+							"is_active": null,
+							"issue_count": null,
+							"last_seen": null,
+							"locations": null,
+							"network_status": null,
+							"operational_state": null,
+							"operator": null,
+							"os": "linux",
+							"os_distro_name": null,
+							"os_distro_revision": null,
+							"os_version_extra": null,
+							"overall": null,
+							"path": null,
+							"require_all": null,
+							"risk_level": null,
+							"score": null,
+							"sensor_config": null,
+							"sha256": null,
+							"state": null,
+							"thumbprint": null,
+							"total_score": null,
+							"version": null,
+							"version_operator": null
+  						}
+					},
+					"schema_version": 0
+				}]
+			}]
+		}`,
+		},
+		{
+			Name: "minimal resource - rename",
+			Input: `{
+			"version": 4,
+			"terraform_version": "1.5.0",
+			"resources": [{
+				"type": "cloudflare_device_posture_rule",
+				"name": "name",
+				"instances": [{
+					"attributes": {
+						"id": "test-rule-id",
+						"account_id": "f037e56e89293a057740de681ac9abbe",
+						"name": "name",
+						"type": "serial_number"
+					},
+					"schema_version": 1
+				}]
+			}]
+		}`,
+			Expected: `{
+			"version": 4,
+			"terraform_version": "1.5.0",
+			"resources": [{
+				"type": "cloudflare_zero_trust_device_posture_rule",
+				"name": "name",
+				"instances": [{
+					"attributes": {
+						"id": "test-rule-id",
+						"account_id": "f037e56e89293a057740de681ac9abbe",
+						"name": "name",
+						"type": "serial_number"
+					},
+					"schema_version": 0
+				}]
+			}]
+		}`,
+		},
+		{
+			Name: "minimal resource - no rename",
+			Input: `{
+			"version": 4,
+			"terraform_version": "1.5.0",
+			"resources": [{
+				"type": "cloudflare_zero_trust_device_posture_rule",
+				"name": "name",
+				"instances": [{
+					"attributes": {
+						"id": "test-rule-id",
+						"account_id": "f037e56e89293a057740de681ac9abbe",
+						"name": "name",
+						"type": "serial_number"
+					},
+					"schema_version": 1
+				}]
+			}]
+		}`,
+			Expected: `{
+			"version": 4,
+			"terraform_version": "1.5.0",
+			"resources": [{
+				"type": "cloudflare_zero_trust_device_posture_rule",
+				"name": "name",
+				"instances": [{
+					"attributes": {
+						"id": "test-rule-id",
+						"account_id": "f037e56e89293a057740de681ac9abbe",
+						"name": "name",
+						"type": "serial_number"
+					},
+					"schema_version": 0
+				}]
+			}]
+		}`,
+		},
+		{
+			Name: "resource with input block",
+			Input: `{
+			"version": 4,
+			"terraform_version": "1.5.0",
+			"resources": [{
+				"type": "cloudflare_device_posture_rule",
+				"name": "name",
+				"instances": [{
+					"attributes": {
+						"id": "test-rule-id",
+						"account_id": "f037e56e89293a057740de681ac9abbe",
+						"name": "name",
+						"type": "os_version",
+						"input": [{
+							"active_threats": 0,
+							"certificate_id": "",
+							"check_disks": null,
+							"check_private_key": false,
+							"cn": "",
+							"compliance_status": "",
+							"connection_id": "",
+							"count_operator": "",
+							"domain": "",
+							"eid_last_seen": "",
+							"enabled": true,
+							"exists": false,
+							"extended_key_usage": null,
+							"id": "",
+							"infected": false,
+							"is_active": false,
+							"issue_count": "",
+							"last_seen": "",
+							"locations": [],
+							"network_status": "",
+							"operational_state": "",
+							"operator": ">=",
+							"os": "",
+							"os_distro_name": "",
+							"os_distro_revision": "",
+							"os_version_extra": "",
+							"overall": "",
+							"path": "",
+							"require_all": false,
+							"risk_level": "",
+							"running": false,
+							"score": 0,
+							"sensor_config": "",
+							"sha256": "",
+							"state": "",
+							"thumbprint": "",
+							"total_score": 0,
+							"version": "10.0",
+							"version_operator": ""
+						}]
+					},
+					"schema_version": 1
+				}]
+			}]
+		}`,
+			Expected: `{
+			"version": 4,
+			"terraform_version": "1.5.0",
+			"resources": [{
+				"type": "cloudflare_zero_trust_device_posture_rule",
+				"name": "name",
+				"instances": [{
+					"attributes": {
+						"id": "test-rule-id",
+						"account_id": "f037e56e89293a057740de681ac9abbe",
+						"name": "name",
+						"type": "os_version",
+						"input": {
+							"active_threats": null,
+							"certificate_id": null,
+							"check_disks": null,
+							"check_private_key": null,
+							"cn": null,
+							"compliance_status": null,
+							"connection_id": null,
+							"count_operator": null,
+							"domain": null,
+							"eid_last_seen": null,
+							"enabled": true,
+							"exists": null,
+							"extended_key_usage": null,
+							"id": null,
+							"infected": null,
+							"is_active": null,
+							"issue_count": null,
+							"last_seen": null,
+							"locations": null,
+							"network_status": null,
+							"operational_state": null,
+							"operator": ">=",
+							"os": null,
+							"os_distro_name": null,
+							"os_distro_revision": null,
+							"os_version_extra": null,
+							"overall": null,
+							"path": null,
+							"require_all": null,
+							"risk_level": null,
+							"score": null,
+							"sensor_config": null,
+							"sha256": null,
+							"state": null,
+							"thumbprint": null,
+							"total_score": null,
+							"version": "10.0",
+							"version_operator": null
+						}
+					},
+					"schema_version": 0
+				}]
+			}]
+		}`,
+		},
+		{
+			Name: "resource with input block and nested locations block",
+			Input: `{
+			"version": 4,
+			"terraform_version": "1.5.0",
+			"resources": [{
+				"type": "cloudflare_device_posture_rule",
+				"name": "name",
+				"instances": [{
+					"attributes": {
+						"id": "test-rule-id",
+						"account_id": "f037e56e89293a057740de681ac9abbe",
+						"name": "name",
+						"type": "client_certificate_v2",
+						"input": [{
+							"active_threats": 0,
+							"certificate_id": "",
+							"check_disks": null,
+							"check_private_key": true,
+							"cn": "device.example.com",
+							"compliance_status": "",
+							"connection_id": "",
+							"count_operator": "",
+							"domain": "",
+							"eid_last_seen": "",
+							"enabled": false,
+							"exists": false,
+							"extended_key_usage": null,
+							"id": "",
+							"infected": false,
+							"is_active": false,
+							"issue_count": "",
+							"last_seen": "",
+							"locations": [{
+								"paths": ["/etc/ssl/certs", "/usr/local/share/certs"],
+								"trust_stores": ["system", "user"]
+							}],
+							"network_status": "",
+							"operational_state": "",
+							"operator": "",
+							"os": "",
+							"os_distro_name": "",
+							"os_distro_revision": "",
+							"os_version_extra": "",
+							"overall": "",
+							"path": "",
+							"require_all": false,
+							"risk_level": "",
+							"running": false,
+							"score": 0,
+							"sensor_config": "",
+							"sha256": "",
+							"state": "",
+							"thumbprint": "",
+							"total_score": 0,
+							"version": "",
+							"version_operator": ""
+						}]
+					},
+					"schema_version": 1
+				}]
+			}]
+		}`,
+			Expected: `{
+			"version": 4,
+			"terraform_version": "1.5.0",
+			"resources": [{
+				"type": "cloudflare_zero_trust_device_posture_rule",
+				"name": "name",
+				"instances": [{
+					"attributes": {
+						"id": "test-rule-id",
+						"account_id": "f037e56e89293a057740de681ac9abbe",
+						"name": "name",
+						"type": "client_certificate_v2",
+						"input": {
+							"active_threats": null,
+							"certificate_id": null,
+							"check_disks": null,
+							"check_private_key": true,
+							"cn": "device.example.com",
+							"compliance_status": null,
+							"connection_id": null,
+							"count_operator": null,
+							"domain": null,
+							"eid_last_seen": null,
+							"enabled": null,
+							"exists": null,
+							"extended_key_usage": null,
+							"id": null,
+							"infected": null,
+							"is_active": null,
+							"issue_count": null,
+							"last_seen": null,
+							"locations": {
+								"paths": ["/etc/ssl/certs", "/usr/local/share/certs"],
+								"trust_stores": ["system", "user"]
+							},
+							"network_status": null,
+							"operational_state": null,
+							"operator": null,
+							"os": null,
+							"os_distro_name": null,
+							"os_distro_revision": null,
+							"os_version_extra": null,
+							"overall": null,
+							"path": null,
+							"require_all": null,
+							"risk_level": null,
+							"score": null,
+							"sensor_config": null,
+							"sha256": null,
+							"state": null,
+							"thumbprint": null,
+							"total_score": null,
+							"version": null,
+							"version_operator": null
+						}
+					},
+					"schema_version": 0
+				}]
+			}]
+		}`,
+		},
+		{
+			Name: "removed running attribute",
+			Input: `{
+			"version": 4,
+			"terraform_version": "1.5.0",
+			"resources": [{
+				"type": "cloudflare_device_posture_rule",
+				"name": "name",
+				"instances": [{
+					"attributes": {
+						"id": "test-rule-id",
+						"account_id": "f037e56e89293a057740de681ac9abbe",
+						"name": "name",
+						"type": "application",
+						"input": [{
+							"active_threats": 0,
+							"certificate_id": "",
+							"check_disks": null,
+							"check_private_key": false,
+							"cn": "",
+							"compliance_status": "",
+							"connection_id": "",
+							"count_operator": "",
+							"domain": "",
+							"eid_last_seen": "",
+							"enabled": false,
+							"exists": false,
+							"extended_key_usage": null,
+							"id": "",
+							"infected": false,
+							"is_active": false,
+							"issue_count": "",
+							"last_seen": "",
+							"locations": [],
+							"network_status": "",
+							"operational_state": "",
+							"operator": "",
+							"os": "",
+							"os_distro_name": "",
+							"os_distro_revision": "",
+							"os_version_extra": "",
+							"overall": "",
+							"path": "/usr/bin/app",
+							"require_all": false,
+							"risk_level": "",
+							"running": true,
+							"score": 0,
+							"sensor_config": "",
+							"sha256": "abc123",
+							"state": "",
+							"thumbprint": "",
+							"total_score": 0,
+							"version": "",
+							"version_operator": ""
+						}]
+					},
+					"schema_version": 1
+				}]
+			}]
+		}`,
+			Expected: `{
+			"version": 4,
+			"terraform_version": "1.5.0",
+			"resources": [{
+				"type": "cloudflare_zero_trust_device_posture_rule",
+				"name": "name",
+				"instances": [{
+					"attributes": {
+						"id": "test-rule-id",
+						"account_id": "f037e56e89293a057740de681ac9abbe",
+						"name": "name",
+						"type": "application",
+						"input": {
+							"active_threats": null,
+							"certificate_id": null,
+							"check_disks": null,
+							"check_private_key": null,
+							"cn": null,
+							"compliance_status": null,
+							"connection_id": null,
+							"count_operator": null,
+							"domain": null,
+							"eid_last_seen": null,
+							"enabled": null,
+							"exists": null,
+							"extended_key_usage": null,
+							"id": null,
+							"infected": null,
+							"is_active": null,
+							"issue_count": null,
+							"last_seen": null,
+							"locations": null,
+							"network_status": null,
+							"operational_state": null,
+							"operator": null,
+							"os": null,
+							"os_distro_name": null,
+							"os_distro_revision": null,
+							"os_version_extra": null,
+							"overall": null,
+							"path": "/usr/bin/app",
+							"require_all": null,
+							"risk_level": null,
+							"score": null,
+							"sensor_config": null,
+							"sha256": "abc123",
+							"state": null,
+							"thumbprint": null,
+							"total_score": null,
+							"version": null,
+							"version_operator": null
+						}
+					},
+					"schema_version": 0
+				}]
+			}]
+		}`,
+		},
+		{
+			Name: "resource with int to float attributes",
+			Input: `{
+			"version": 4,
+			"terraform_version": "1.5.0",
+			"resources": [{
+				"type": "cloudflare_device_posture_rule",
+				"name": "name",
+				"instances": [{
+					"attributes": {
+						"id": "test-rule-id",
+						"account_id": "f037e56e89293a057740de681ac9abbe",
+						"name": "name",
+						"type": "sentinelone_s2s",
+						"input": [{
+							"active_threats": 5,
+							"certificate_id": "",
+							"check_disks": null,
+							"check_private_key": false,
+							"cn": "",
+							"compliance_status": "",
+							"connection_id": "",
+							"count_operator": "",
+							"domain": "",
+							"eid_last_seen": "",
+							"enabled": false,
+							"exists": false,
+							"extended_key_usage": null,
+							"id": "",
+							"infected": false,
+							"is_active": false,
+							"issue_count": "",
+							"last_seen": "",
+							"locations": [],
+							"network_status": "",
+							"operational_state": "",
+							"operator": "",
+							"os": "",
+							"os_distro_name": "",
+							"os_distro_revision": "",
+							"os_version_extra": "",
+							"overall": "",
+							"path": "",
+							"require_all": false,
+							"risk_level": "",
+							"running": false,
+							"score": 5,
+							"sensor_config": "",
+							"sha256": "",
+							"state": "",
+							"thumbprint": "",
+							"total_score": 5,
+							"version": "",
+							"version_operator": ""
+						}]
+					},
+					"schema_version": 1
+				}]
+			}]
+		}`,
+			Expected: `{
+			"version": 4,
+			"terraform_version": "1.5.0",
+			"resources": [{
+				"type": "cloudflare_zero_trust_device_posture_rule",
+				"name": "name",
+				"instances": [{
+					"attributes": {
+						"id": "test-rule-id",
+						"account_id": "f037e56e89293a057740de681ac9abbe",
+						"name": "name",
+						"type": "sentinelone_s2s",
+						"input": {
+							"active_threats": 5.0,
+							"certificate_id": null,
+							"check_disks": null,
+							"check_private_key": null,
+							"cn": null,
+							"compliance_status": null,
+							"connection_id": null,
+							"count_operator": null,
+							"domain": null,
+							"eid_last_seen": null,
+							"enabled": null,
+							"exists": null,
+							"extended_key_usage": null,
+							"id": null,
+							"infected": null,
+							"is_active": null,
+							"issue_count": null,
+							"last_seen": null,
+							"locations": null,
+							"network_status": null,
+							"operational_state": null,
+							"operator": null,
+							"os": null,
+							"os_distro_name": null,
+							"os_distro_revision": null,
+							"os_version_extra": null,
+							"overall": null,
+							"path": null,
+							"require_all": null,
+							"risk_level": null,
+							"score": 5.0,
+							"sensor_config": null,
+							"sha256": null,
+							"state": null,
+							"thumbprint": null,
+							"total_score": 5.0,
+							"version": null,
+							"version_operator": null
+						}
+					},
+					"schema_version": 0
+				}]
+			}]
+		}`,
+		},
+		{
+			Name: "comprehensive resource with all field types",
+			Input: `{
+			"version": 4,
+			"terraform_version": "1.5.0",
+			"resources": [{
+				"type": "cloudflare_device_posture_rule",
+				"name": "name",
+				"instances": [{
+					"attributes": {
+						"id": "test-rule-id",
+						"account_id": "f037e56e89293a057740de681ac9abbe",
+						"name": "name",
+						"description": "Tests all field types and transformations",
+						"type": "client_certificate_v2",
+						"schedule": "5m",
+						"expiration": "1h",
+						"match": [
+							{"platform": "windows"},
+							{"platform": "mac"},
+							{"platform": "linux"}
+						],
+						"input": [{
+							"id": "test-id-123",
+							"path": "/usr/bin/app",
+							"exists": true,
+							"thumbprint": "abc123def456",
+							"sha256": "sha256hash",
+							"running": true,
+							"require_all": true,
+							"check_disks": ["C:", "D:", "E:"],
+							"enabled": true,
+							"version": "1.0.0",
+							"os_version_extra": "build-123",
+							"operator": ">=",
+							"domain": "example.com",
+							"connection_id": "conn-123",
+							"compliance_status": "compliant",
+							"os_distro_name": "Ubuntu",
+							"os_distro_revision": "22.04",
+							"os": "linux",
+							"overall": "pass",
+							"sensor_config": "sensor-config-123",
+							"version_operator": ">=",
+							"last_seen": "2024-01-01T00:00:00Z",
+							"state": "active",
+							"count_operator": ">",
+							"issue_count": "5",
+							"certificate_id": "cert-123",
+							"cn": "device.example.com",
+							"active_threats": 1,
+							"operational_state": "active",
+							"network_status": "connected",
+							"infected": false,
+							"is_active": true,
+							"eid_last_seen": "2024-01-01T00:00:00Z",
+							"risk_level": "low",
+							"total_score": 85,
+							"check_private_key": true,
+							"extended_key_usage": ["clientAuth", "serverAuth"],
+							"score": 100,
+							"locations": [{
+								"paths": ["/etc/ssl/certs", "/usr/local/share/certs", "/opt/certs"],
+								"trust_stores": ["system", "user", "custom"]
+							}]
+						}]
+					},
+					"schema_version": 1
+				}]
+			}]
+		}`,
+			Expected: `{
+			"version": 4,
+			"terraform_version": "1.5.0",
+			"resources": [{
+				"type": "cloudflare_zero_trust_device_posture_rule",
+				"name": "name",
+				"instances": [{
+					"attributes": {
+						"id": "test-rule-id",
+						"account_id": "f037e56e89293a057740de681ac9abbe",
+						"name": "name",
+						"description": "Tests all field types and transformations",
+						"type": "client_certificate_v2",
+						"schedule": "5m",
+						"expiration": "1h",
+						"match": [
+							{"platform": "windows"},
+							{"platform": "mac"},
+							{"platform": "linux"}
+						],
+						"input": {
+							"id": "test-id-123",
+							"path": "/usr/bin/app",
+							"exists": true,
+							"thumbprint": "abc123def456",
+							"sha256": "sha256hash",
+							"require_all": true,
+							"check_disks": ["C:", "D:", "E:"],
+							"enabled": true,
+							"version": "1.0.0",
+							"os_version_extra": "build-123",
+							"operator": ">=",
+							"domain": "example.com",
+							"connection_id": "conn-123",
+							"compliance_status": "compliant",
+							"os_distro_name": "Ubuntu",
+							"os_distro_revision": "22.04",
+							"os": "linux",
+							"overall": "pass",
+							"sensor_config": "sensor-config-123",
+							"version_operator": ">=",
+							"last_seen": "2024-01-01T00:00:00Z",
+							"state": "active",
+							"count_operator": ">",
+							"issue_count": "5",
+							"certificate_id": "cert-123",
+							"cn": "device.example.com",
+							"active_threats": 1.0,
+							"operational_state": "active",
+							"network_status": "connected",
+							"infected": null,
+							"is_active": true,
+							"eid_last_seen": "2024-01-01T00:00:00Z",
+							"risk_level": "low",
+							"total_score": 85.0,
+							"check_private_key": true,
+							"extended_key_usage": ["clientAuth", "serverAuth"],
+							"score": 100.0,
+							"locations": {
+								"paths": ["/etc/ssl/certs", "/usr/local/share/certs", "/opt/certs"],
+								"trust_stores": ["system", "user", "custom"]
+							}
+						}
+					},
+					"schema_version": 0
+				}]
+			}]
+		}`,
+		},
+		{
+			Name: "resource with missing attributes",
+			Input: `{
+			"version": 4,
+			"terraform_version": "1.5.0",
+			"resources": [{
+				"type": "cloudflare_device_posture_rule",
+				"name": "name",
+				"instances": [{
+					"schema_version": 1
+				}]
+			}]
+		}`,
+			Expected: `{
+			"version": 4,
+			"terraform_version": "1.5.0",
+			"resources": [{
+				"type": "cloudflare_zero_trust_device_posture_rule",
+				"name": "name",
+				"instances": [{
+					"schema_version": 0
+				}]
+			}]
+		}`,
+		},
+		{
+			Name: "resource with empty array input",
+			Input: `{
+			"version": 4,
+			"terraform_version": "1.5.0",
+			"resources": [{
+				"type": "cloudflare_device_posture_rule",
+				"name": "name",
+				"instances": [{
+					"attributes": {
+						"id": "test-rule-id",
+						"account_id": "f037e56e89293a057740de681ac9abbe",
+						"name": "name",
+						"type": "serial_number",
+						"input": []
+					},
+					"schema_version": 1
+				}]
+			}]
+		}`,
+			Expected: `{
+			"version": 4,
+			"terraform_version": "1.5.0",
+			"resources": [{
+				"type": "cloudflare_zero_trust_device_posture_rule",
+				"name": "name",
+				"instances": [{
+					"attributes": {
+						"id": "test-rule-id",
+						"account_id": "f037e56e89293a057740de681ac9abbe",
+						"name": "name",
+						"type": "serial_number"
+					},
+					"schema_version": 0
+				}]
+			}]
+		}`,
+		},
+		{
+			Name: "resource with empty locations array",
+			Input: `{
+			"version": 4,
+			"terraform_version": "1.5.0",
+			"resources": [{
+				"type": "cloudflare_device_posture_rule",
+				"name": "name",
+				"instances": [{
+					"attributes": {
+						"id": "test-rule-id",
+						"account_id": "f037e56e89293a057740de681ac9abbe",
+						"name": "name",
+						"type": "client_certificate_v2",
+						"input": [{
+							"active_threats": 0,
+							"certificate_id": "",
+							"check_disks": null,
+							"check_private_key": true,
+							"cn": "device.example.com",
+							"compliance_status": "",
+							"connection_id": "",
+							"count_operator": "",
+							"domain": "",
+							"eid_last_seen": "",
+							"enabled": false,
+							"exists": false,
+							"extended_key_usage": null,
+							"id": "",
+							"infected": false,
+							"is_active": false,
+							"issue_count": "",
+							"last_seen": "",
+							"locations": [],
+							"network_status": "",
+							"operational_state": "",
+							"operator": "",
+							"os": "",
+							"os_distro_name": "",
+							"os_distro_revision": "",
+							"os_version_extra": "",
+							"overall": "",
+							"path": "",
+							"require_all": false,
+							"risk_level": "",
+							"running": false,
+							"score": 0,
+							"sensor_config": "",
+							"sha256": "",
+							"state": "",
+							"thumbprint": "",
+							"total_score": 0,
+							"version": "",
+							"version_operator": ""
+						}]
+					},
+					"schema_version": 1
+				}]
+			}]
+		}`,
+			Expected: `{
+			"version": 4,
+			"terraform_version": "1.5.0",
+			"resources": [{
+				"type": "cloudflare_zero_trust_device_posture_rule",
+				"name": "name",
+				"instances": [{
+					"attributes": {
+						"id": "test-rule-id",
+						"account_id": "f037e56e89293a057740de681ac9abbe",
+						"name": "name",
+						"type": "client_certificate_v2",
+						"input": {
+							"active_threats": null,
+							"certificate_id": null,
+							"check_disks": null,
+							"check_private_key": true,
+							"cn": "device.example.com",
+							"compliance_status": null,
+							"connection_id": null,
+							"count_operator": null,
+							"domain": null,
+							"eid_last_seen": null,
+							"enabled": null,
+							"exists": null,
+							"extended_key_usage": null,
+							"id": null,
+							"infected": null,
+							"is_active": null,
+							"issue_count": null,
+							"last_seen": null,
+							"locations": null,
+							"network_status": null,
+							"operational_state": null,
+							"operator": null,
+							"os": null,
+							"os_distro_name": null,
+							"os_distro_revision": null,
+							"os_version_extra": null,
+							"overall": null,
+							"path": null,
+							"require_all": null,
+							"risk_level": null,
+							"score": null,
+							"sensor_config": null,
+							"sha256": null,
+							"state": null,
+							"thumbprint": null,
+							"total_score": null,
+							"version": null,
+							"version_operator": null
+						}
+					},
+					"schema_version": 0
+				}]
+			}]
+		}`,
+		},
+	}
+
+	testhelpers.RunStateTransformTests(t, tests, migrator)
+}

--- a/internal/resources/zero_trust_dlp_custom_profile/v4_to_v5.go
+++ b/internal/resources/zero_trust_dlp_custom_profile/v4_to_v5.go
@@ -173,7 +173,7 @@ func (m *V4ToV5Migrator) transformPredefinedEntryBlocks(body *hclwrite.Body) {
 	}
 }
 
-func (m *V4ToV5Migrator) TransformState(ctx *transform.Context, stateJSON gjson.Result, resourcePath string) (string, error) {
+func (m *V4ToV5Migrator) TransformState(ctx *transform.Context, stateJSON gjson.Result, resourcePath, resourceName string) (string, error) {
 	result := stateJSON.String()
 
 	if stateJSON.Get("instances").Exists() {

--- a/internal/resources/zero_trust_dlp_custom_profile/v4_to_v5_test.go
+++ b/internal/resources/zero_trust_dlp_custom_profile/v4_to_v5_test.go
@@ -576,7 +576,7 @@ func TestV4ToV5Transformation(t *testing.T) {
 func TestPreprocessing(t *testing.T) {
 	migrator := &V4ToV5Migrator{}
 
-	// Test that preprocessing does nothing (we handle everything through HCL AST)
+	// Test that preprocessing does nothing (we handle everything through HCL CFGFile)
 	tests := []struct {
 		name  string
 		input string

--- a/internal/resources/zero_trust_gateway_policy/v4_to_v5.go
+++ b/internal/resources/zero_trust_gateway_policy/v4_to_v5.go
@@ -98,11 +98,11 @@ func (m *V4ToV5Migrator) processRuleSettingsBlock(ruleSettingsBlock *hclwrite.Bl
 	}
 }
 
-func (m *V4ToV5Migrator) TransformState(ctx *transform.Context, instance gjson.Result, resourcePath string) (string, error) {
+func (m *V4ToV5Migrator) TransformState(ctx *transform.Context, stateJSON gjson.Result, resourcePath, resourceName string) (string, error) {
 	// This function receives a single instance and needs to return the transformed instance JSON
-	result := instance.String()
+	result := stateJSON.String()
 	// Get attributes
-	attrs := instance.Get("attributes")
+	attrs := stateJSON.Get("attributes")
 	if !attrs.Exists() {
 		result, _ = sjson.Set(result, "schema_version", 0)
 		return result, nil

--- a/internal/resources/zero_trust_list/v4_to_v5.go
+++ b/internal/resources/zero_trust_list/v4_to_v5.go
@@ -68,12 +68,12 @@ func (m *V4ToV5Migrator) TransformConfig(ctx *transform.Context, block *hclwrite
 	}, nil
 }
 
-func (m *V4ToV5Migrator) TransformState(ctx *transform.Context, instance gjson.Result, resourcePath string) (string, error) {
+func (m *V4ToV5Migrator) TransformState(ctx *transform.Context, stateJSON gjson.Result, resourcePath, resourceName string) (string, error) {
 	// This function receives a single instance and needs to return the transformed instance JSON
-	result := instance.String()
+	result := stateJSON.String()
 
 	// Transform the instance attributes
-	attrs := instance.Get("attributes")
+	attrs := stateJSON.Get("attributes")
 	if attrs.Exists() {
 		var transformedItems []map[string]interface{}
 

--- a/internal/resources/zero_trust_tunnel_cloudflared/v4_to_v5.go
+++ b/internal/resources/zero_trust_tunnel_cloudflared/v4_to_v5.go
@@ -59,7 +59,7 @@ func (m *V4ToV5Migrator) TransformConfig(ctx *transform.Context, block *hclwrite
 	}, nil
 }
 
-func (m *V4ToV5Migrator) TransformState(ctx *transform.Context, instance gjson.Result, resourcePath string) (string, error) {
+func (m *V4ToV5Migrator) TransformState(ctx *transform.Context, instance gjson.Result, resourcePath, resourceName string) (string, error) {
 	result := instance.String()
 	attrs := instance.Get("attributes")
 

--- a/internal/resources/zero_trust_tunnel_cloudflared_route/v4_to_v5.go
+++ b/internal/resources/zero_trust_tunnel_cloudflared_route/v4_to_v5.go
@@ -58,21 +58,21 @@ func (m *V4ToV5Migrator) TransformConfig(ctx *transform.Context, block *hclwrite
 	}, nil
 }
 
-func (m *V4ToV5Migrator) TransformState(ctx *transform.Context, instance gjson.Result, resourcePath string) (string, error) {
-	result := instance.String()
+func (m *V4ToV5Migrator) TransformState(ctx *transform.Context, stateJSON gjson.Result, resourcePath, resourceName string) (string, error) {
+	result := stateJSON.String()
 
 	// Set schema_version to 0 for v5
 	result, _ = sjson.Set(result, "schema_version", 0)
 
 	// Update the type field if it exists (for unit tests that pass instance-level type)
-	if instance.Get("type").Exists() {
+	if stateJSON.Get("type").Exists() {
 		result, _ = sjson.Set(result, "type", "cloudflare_zero_trust_tunnel_cloudflared_route")
 	}
 
 	// Try to update the ID if API client is available
 	// In v4, the ID was the network CIDR (or a checksum of it)
 	// In v5, the ID is a UUID from the API
-	attrs := instance.Get("attributes")
+	attrs := stateJSON.Get("attributes")
 	if attrs.Exists() && ctx.APIClient != nil {
 		accountID := attrs.Get("account_id").String()
 		tunnelID := attrs.Get("tunnel_id").String()

--- a/internal/resources/zone_dnssec/v4_to_v5.go
+++ b/internal/resources/zone_dnssec/v4_to_v5.go
@@ -106,15 +106,15 @@ func (m *V4ToV5Migrator) TransformConfig(ctx *transform.Context, block *hclwrite
 // TransformState handles state file transformations.
 // This function receives a single resource instance and returns the transformed instance JSON.
 // Converts flags and key_tag from TypeInt (v4) to Float64 (v5).
-func (m *V4ToV5Migrator) TransformState(ctx *transform.Context, instance gjson.Result, resourcePath string) (string, error) {
-	result := instance.String()
+func (m *V4ToV5Migrator) TransformState(ctx *transform.Context, stateJSON gjson.Result, resourcePath, resourceName string) (string, error) {
+	result := stateJSON.String()
 
 	// Check if it's a valid zone_dnssec instance
-	if !instance.Exists() || !instance.Get("attributes").Exists() {
+	if !stateJSON.Exists() || !stateJSON.Get("attributes").Exists() {
 		return result, nil
 	}
 
-	attrs := instance.Get("attributes")
+	attrs := stateJSON.Get("attributes")
 	if !attrs.Get("zone_id").Exists() {
 		return result, nil
 	}

--- a/internal/testhelpers/config.go
+++ b/internal/testhelpers/config.go
@@ -35,10 +35,10 @@ func runConfigTransformTest(t *testing.T, tt ConfigTestCase, migrator transform.
 	ctx := &transform.Context{
 		Content:  []byte(processedContent),
 		Filename: "test.tf",
-		AST:      file,
+		CFGFile:  file,
 	}
 
-	// Step 4: Transform using HCL AST
+	// Step 4: Transform using HCL CFGFile
 	body := file.Body()
 	for _, block := range body.Blocks() {
 		if block.Type() == "resource" && len(block.Labels()) >= 2 {

--- a/internal/transform/state/fields.go
+++ b/internal/transform/state/fields.go
@@ -16,33 +16,35 @@ import (
 // Example - Adding required TTL field to DNS record state:
 //
 // Before state JSON:
-//   {
-//     "resources": [{
-//       "instances": [{
-//         "attributes": {
-//           "zone_id": "abc123",
-//           "name": "test",
-//           "type": "A",
-//           "content": "192.0.2.1"
-//         }
-//       }]
-//     }]
-//   }
+//
+//	{
+//	  "resources": [{
+//	    "instances": [{
+//	      "attributes": {
+//	        "zone_id": "abc123",
+//	        "name": "test",
+//	        "type": "A",
+//	        "content": "192.0.2.1"
+//	      }
+//	    }]
+//	  }]
+//	}
 //
 // After calling EnsureField(stateJSON, "resources.0.instances.0.attributes", instance, "ttl", 1):
-//   {
-//     "resources": [{
-//       "instances": [{
-//         "attributes": {
-//           "zone_id": "abc123",
-//           "name": "test",
-//           "type": "A",
-//           "content": "192.0.2.1",
-//           "ttl": 1
-//         }
-//       }]
-//     }]
-//   }
+//
+//	{
+//	  "resources": [{
+//	    "instances": [{
+//	      "attributes": {
+//	        "zone_id": "abc123",
+//	        "name": "test",
+//	        "type": "A",
+//	        "content": "192.0.2.1",
+//	        "ttl": 1
+//	      }
+//	    }]
+//	  }]
+//	}
 func EnsureField(stateJSON string, path string, instance gjson.Result, field string, defaultValue interface{}) string {
 	if !instance.Get(field).Exists() {
 		result, _ := sjson.Set(stateJSON, path+"."+field, defaultValue)
@@ -57,36 +59,38 @@ func EnsureField(stateJSON string, path string, instance gjson.Result, field str
 // Example - Renaming 'value' to 'content' in DNS record state:
 //
 // Before state JSON:
-//   {
-//     "resources": [{
-//       "instances": [{
-//         "attributes": {
-//           "zone_id": "abc123",
-//           "name": "test",
-//           "type": "A",
-//           "value": "192.0.2.1"  // Old field name
-//         }
-//       }]
-//     }]
-//   }
+//
+//	{
+//	  "resources": [{
+//	    "instances": [{
+//	      "attributes": {
+//	        "zone_id": "abc123",
+//	        "name": "test",
+//	        "type": "A",
+//	        "value": "192.0.2.1"  // Old field name
+//	      }
+//	    }]
+//	  }]
+//	}
 //
 // After calling RenameField(stateJSON, "resources.0.instances.0.attributes", instance, "value", "content"):
-//   {
-//     "resources": [{
-//       "instances": [{
-//         "attributes": {
-//           "zone_id": "abc123",
-//           "name": "test",
-//           "type": "A",
-//           "content": "192.0.2.1"  // New field name
-//         }
-//       }]
-//     }]
-//   }
+//
+//	{
+//	  "resources": [{
+//	    "instances": [{
+//	      "attributes": {
+//	        "zone_id": "abc123",
+//	        "name": "test",
+//	        "type": "A",
+//	        "content": "192.0.2.1"  // New field name
+//	      }
+//	    }]
+//	  }]
+//	}
 func RenameField(stateJSON string, path string, instance gjson.Result, oldName, newName string) string {
 	oldField := instance.Get(oldName)
 	newField := instance.Get(newName)
-	
+
 	if oldField.Exists() && !newField.Exists() {
 		// Copy old to new
 		stateJSON, _ = sjson.Set(stateJSON, path+"."+newName, oldField.Value())
@@ -96,7 +100,7 @@ func RenameField(stateJSON string, path string, instance gjson.Result, oldName, 
 		// If both exist, just remove the old one (new takes precedence)
 		stateJSON, _ = sjson.Delete(stateJSON, path+"."+oldName)
 	}
-	
+
 	return stateJSON
 }
 
@@ -105,35 +109,37 @@ func RenameField(stateJSON string, path string, instance gjson.Result, oldName, 
 // Example - Removing deprecated fields from DNS record state:
 //
 // Before state JSON:
-//   {
-//     "resources": [{
-//       "instances": [{
-//         "attributes": {
-//           "zone_id": "abc123",
-//           "name": "test",
-//           "type": "A",
-//           "content": "192.0.2.1",
-//           "hostname": "test.example.com",  // Deprecated
-//           "allow_overwrite": true,         // Deprecated
-//           "timeouts": {}                    // Deprecated
-//         }
-//       }]
-//     }]
-//   }
+//
+//	{
+//	  "resources": [{
+//	    "instances": [{
+//	      "attributes": {
+//	        "zone_id": "abc123",
+//	        "name": "test",
+//	        "type": "A",
+//	        "content": "192.0.2.1",
+//	        "hostname": "test.example.com",  // Deprecated
+//	        "allow_overwrite": true,         // Deprecated
+//	        "timeouts": {}                    // Deprecated
+//	      }
+//	    }]
+//	  }]
+//	}
 //
 // After calling RemoveFields(stateJSON, path, instance, "hostname", "allow_overwrite", "timeouts"):
-//   {
-//     "resources": [{
-//       "instances": [{
-//         "attributes": {
-//           "zone_id": "abc123",
-//           "name": "test",
-//           "type": "A",
-//           "content": "192.0.2.1"
-//         }
-//       }]
-//     }]
-//   }
+//
+//	{
+//	  "resources": [{
+//	    "instances": [{
+//	      "attributes": {
+//	        "zone_id": "abc123",
+//	        "name": "test",
+//	        "type": "A",
+//	        "content": "192.0.2.1"
+//	      }
+//	    }]
+//	  }]
+//	}
 func RemoveFields(stateJSON string, path string, instance gjson.Result, fields ...string) string {
 	for _, field := range fields {
 		if instance.Get(field).Exists() {
@@ -148,39 +154,41 @@ func RemoveFields(stateJSON string, path string, instance gjson.Result, fields .
 // Example - Cleaning up empty meta field:
 //
 // Before state JSON:
-//   {
-//     "resources": [{
-//       "instances": [{
-//         "attributes": {
-//           "zone_id": "abc123",
-//           "name": "test",
-//           "meta": {},  // Empty object
-//           "settings": []  // Empty array
-//         }
-//       }]
-//     }]
-//   }
+//
+//	{
+//	  "resources": [{
+//	    "instances": [{
+//	      "attributes": {
+//	        "zone_id": "abc123",
+//	        "name": "test",
+//	        "meta": {},  // Empty object
+//	        "settings": []  // Empty array
+//	      }
+//	    }]
+//	  }]
+//	}
 //
 // After calling CleanupEmptyField(stateJSON, "resources.0.instances.0.attributes.meta", metaField):
-//   {
-//     "resources": [{
-//       "instances": [{
-//         "attributes": {
-//           "zone_id": "abc123",
-//           "name": "test",
-//           "settings": []  // meta removed, settings still present
-//         }
-//       }]
-//     }]
-//   }
+//
+//	{
+//	  "resources": [{
+//	    "instances": [{
+//	      "attributes": {
+//	        "zone_id": "abc123",
+//	        "name": "test",
+//	        "settings": []  // meta removed, settings still present
+//	      }
+//	    }]
+//	  }]
+//	}
 func CleanupEmptyField(stateJSON string, path string, field gjson.Result) string {
 	if field.Exists() {
 		// Check various empty conditions
-		if field.String() == "{}" || 
-		   field.String() == "[]" ||
-		   field.String() == "" ||
-		   (field.IsObject() && len(field.Map()) == 0) ||
-		   (field.IsArray() && len(field.Array()) == 0) {
+		if field.String() == "{}" ||
+			field.String() == "[]" ||
+			field.String() == "" ||
+			(field.IsObject() && len(field.Map()) == 0) ||
+			(field.IsArray() && len(field.Array()) == 0) {
 			stateJSON, _ = sjson.Delete(stateJSON, path)
 		}
 	}
@@ -192,39 +200,41 @@ func CleanupEmptyField(stateJSON string, path string, field gjson.Result) string
 // Example - Removing settings object with all null values:
 //
 // Before state JSON:
-//   {
-//     "resources": [{
-//       "instances": [{
-//         "attributes": {
-//           "zone_id": "abc123",
-//           "name": "test",
-//           "settings": {
-//             "flatten_cname": null,
-//             "ipv4_only": null,
-//             "ipv6_only": null
-//           }
-//         }
-//       }]
-//     }]
-//   }
+//
+//	{
+//	  "resources": [{
+//	    "instances": [{
+//	      "attributes": {
+//	        "zone_id": "abc123",
+//	        "name": "test",
+//	        "settings": {
+//	          "flatten_cname": null,
+//	          "ipv4_only": null,
+//	          "ipv6_only": null
+//	        }
+//	      }
+//	    }]
+//	  }]
+//	}
 //
 // After calling RemoveObjectIfAllNull(stateJSON, path+".settings", settingsObj, []string{"flatten_cname", "ipv4_only", "ipv6_only"}):
-//   {
-//     "resources": [{
-//       "instances": [{
-//         "attributes": {
-//           "zone_id": "abc123",
-//           "name": "test"
-//           // settings removed because all fields were null
-//         }
-//       }]
-//     }]
-//   }
+//
+//	{
+//	  "resources": [{
+//	    "instances": [{
+//	      "attributes": {
+//	        "zone_id": "abc123",
+//	        "name": "test"
+//	        // settings removed because all fields were null
+//	      }
+//	    }]
+//	  }]
+//	}
 func RemoveObjectIfAllNull(stateJSON string, path string, obj gjson.Result, fields []string) string {
 	if !obj.Exists() {
 		return stateJSON
 	}
-	
+
 	allNull := true
 	for _, field := range fields {
 		val := obj.Get(field)
@@ -233,7 +243,7 @@ func RemoveObjectIfAllNull(stateJSON string, path string, obj gjson.Result, fiel
 			break
 		}
 	}
-	
+
 	if allNull {
 		stateJSON, _ = sjson.Delete(stateJSON, path)
 	}
@@ -246,40 +256,42 @@ func RemoveObjectIfAllNull(stateJSON string, path string, obj gjson.Result, fiel
 // Example - Adding timestamps to DNS record:
 //
 // Before state JSON:
-//   {
-//     "resources": [{
-//       "instances": [{
-//         "attributes": {
-//           "zone_id": "abc123",
-//           "name": "test",
-//           "type": "A",
-//           "content": "192.0.2.1"
-//         }
-//       }]
-//     }]
-//   }
+//
+//	{
+//	  "resources": [{
+//	    "instances": [{
+//	      "attributes": {
+//	        "zone_id": "abc123",
+//	        "name": "test",
+//	        "type": "A",
+//	        "content": "192.0.2.1"
+//	      }
+//	    }]
+//	  }]
+//	}
 //
 // After calling EnsureTimestamps(stateJSON, path, instance, "2024-01-01T00:00:00Z"):
-//   {
-//     "resources": [{
-//       "instances": [{
-//         "attributes": {
-//           "zone_id": "abc123",
-//           "name": "test",
-//           "type": "A",
-//           "content": "192.0.2.1",
-//           "created_on": "2024-01-01T00:00:00Z",
-//           "modified_on": "2024-01-01T00:00:00Z"
-//         }
-//       }]
-//     }]
-//   }
+//
+//	{
+//	  "resources": [{
+//	    "instances": [{
+//	      "attributes": {
+//	        "zone_id": "abc123",
+//	        "name": "test",
+//	        "type": "A",
+//	        "content": "192.0.2.1",
+//	        "created_on": "2024-01-01T00:00:00Z",
+//	        "modified_on": "2024-01-01T00:00:00Z"
+//	      }
+//	    }]
+//	  }]
+//	}
 func EnsureTimestamps(stateJSON string, path string, instance gjson.Result, defaultTime string) string {
 	createdOn := instance.Get("created_on")
 	if !createdOn.Exists() {
 		stateJSON, _ = sjson.Set(stateJSON, path+".created_on", defaultTime)
 	}
-	
+
 	modifiedOn := instance.Get("modified_on")
 	if !modifiedOn.Exists() {
 		if createdOn.Exists() {
@@ -288,7 +300,7 @@ func EnsureTimestamps(stateJSON string, path string, instance gjson.Result, defa
 			stateJSON, _ = sjson.Set(stateJSON, path+".modified_on", defaultTime)
 		}
 	}
-	
+
 	return stateJSON
 }
 
@@ -331,5 +343,43 @@ func ConvertGjsonToJSON(value gjson.Result) interface{} {
 		return nil
 	default:
 		return value.Value()
+	}
+}
+
+// isEmptyValue checks if a gjson.Result value is considered "empty" (default/zero)
+func IsEmptyValue(value gjson.Result) bool {
+	if !value.Exists() {
+		return true
+	}
+
+	switch value.Type {
+	case gjson.Null:
+		return true
+	case gjson.False:
+		return true
+	case gjson.Number:
+		return value.Num == 0
+	case gjson.String:
+		return value.Str == ""
+	case gjson.JSON:
+		// Check if it's an empty array or object
+		if value.IsArray() {
+			return len(value.Array()) == 0
+		}
+		if value.IsObject() {
+			// Empty object or object with all empty values
+			isEmpty := true
+			value.ForEach(func(_, v gjson.Result) bool {
+				if !IsEmptyValue(v) {
+					isEmpty = false
+					return false
+				}
+				return true
+			})
+			return isEmpty
+		}
+		return false
+	default:
+		return false
 	}
 }

--- a/internal/transform/transformer.go
+++ b/internal/transform/transformer.go
@@ -11,7 +11,8 @@ import (
 type Context struct {
 	Content       []byte
 	Filename      string
-	AST           *hclwrite.File
+	CFGFile       *hclwrite.File
+	CFGFiles      map[string]*hclwrite.File
 	StateJSON     string
 	Diagnostics   hcl.Diagnostics
 	Metadata      map[string]interface{}
@@ -37,7 +38,7 @@ type ResourceTransformer interface {
 	// - Split: return {Blocks: newBlocks, RemoveOriginal: true}
 	// - Remove: return {Blocks: nil, RemoveOriginal: true}
 	TransformConfig(ctx *Context, block *hclwrite.Block) (*TransformResult, error)
-	TransformState(ctx *Context, json gjson.Result, resourcePath string) (string, error)
+	TransformState(ctx *Context, stateJSON gjson.Result, resourcePath, resourceName string) (string, error)
 	GetResourceType() string
 	// Preprocess for string-level transformations before parsing
 	Preprocess(content string) string


### PR DESCRIPTION
A couple notes: 
* `name` attribute went from optional in V4 to required in V5. We will check the state during config transforms and use that value if it contains one, but otherwise we will not migrate the name attribute and the user will have to manually add the required name to their HCL. 
* The `input` attribute block is computed in V4 and defaults to empty strings. In V5 it defaults to null for attributes that are undefined in the HCL. For now we are going to migrate any empty values to null. If this causes issues it should be discovered in E2E testing. 