### PR TITLE
feat: v4 to v5 migration for cloudflare_r2_bucket

### DIFF
--- a/integration/v4_to_v5/integration_test.go
+++ b/integration/v4_to_v5/integration_test.go
@@ -12,6 +12,7 @@ import (
 	_ "github.com/cloudflare/tf-migrate/internal/resources/api_token"
 	_ "github.com/cloudflare/tf-migrate/internal/resources/dns_record"
 	_ "github.com/cloudflare/tf-migrate/internal/resources/logpull_retention"
+	_ "github.com/cloudflare/tf-migrate/internal/resources/r2_bucket"
 	_ "github.com/cloudflare/tf-migrate/internal/resources/workers_kv"
 	_ "github.com/cloudflare/tf-migrate/internal/resources/workers_kv_namespace"
 	_ "github.com/cloudflare/tf-migrate/internal/resources/zero_trust_access_service_token"
@@ -47,6 +48,7 @@ func TestV4ToV5Migration(t *testing.T) {
 		"api_token",
 		"dns_record",
 		"logpull_retention",
+		"r2_bucket",
 		"workers_kv",
 		"workers_kv_namespace",
 		"zero_trust_access_service_token",

--- a/integration/v4_to_v5/testdata/r2_bucket/expected/r2_bucket.tf
+++ b/integration/v4_to_v5/testdata/r2_bucket/expected/r2_bucket.tf
@@ -1,0 +1,41 @@
+# Test Case 1: Basic R2 bucket with required fields only
+resource "cloudflare_r2_bucket" "basic" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+  name       = "test-bucket"
+}
+
+# Test Case 2: R2 bucket with location (uppercase - v4 style)
+resource "cloudflare_r2_bucket" "with_location_upper" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+  name       = "bucket-wnam"
+  location   = "WNAM"
+}
+
+# Test Case 3: R2 bucket with location (lowercase - also valid)
+resource "cloudflare_r2_bucket" "with_location_lower" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+  name       = "bucket-eeur"
+  location   = "eeur"
+}
+
+# Test Case 4: R2 bucket with variable reference
+variable "account_id" {
+  type = string
+}
+
+resource "cloudflare_r2_bucket" "with_variable" {
+  account_id = var.account_id
+  name       = "variable-bucket"
+}
+
+# Test Case 5: Multiple buckets with different configs
+resource "cloudflare_r2_bucket" "multi1" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+  name       = "multi-bucket-1"
+}
+
+resource "cloudflare_r2_bucket" "multi2" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+  name       = "multi-bucket-2"
+  location   = "APAC"
+}

--- a/integration/v4_to_v5/testdata/r2_bucket/expected/terraform.tfstate
+++ b/integration/v4_to_v5/testdata/r2_bucket/expected/terraform.tfstate
@@ -1,0 +1,120 @@
+{
+  "version": 4,
+  "terraform_version": "1.5.0",
+  "serial": 1,
+  "lineage": "test-r2-bucket-lineage",
+  "outputs": {},
+  "resources": [
+    {
+      "mode": "managed",
+      "type": "cloudflare_r2_bucket",
+      "name": "basic",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "test-bucket",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "name": "test-bucket",
+            "jurisdiction": "default",
+            "storage_class": "Standard"
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_r2_bucket",
+      "name": "with_location_upper",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "bucket-wnam",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "name": "bucket-wnam",
+            "location": "WNAM",
+            "jurisdiction": "default",
+            "storage_class": "Standard"
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_r2_bucket",
+      "name": "with_location_lower",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "bucket-eeur",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "name": "bucket-eeur",
+            "location": "eeur",
+            "jurisdiction": "default",
+            "storage_class": "Standard"
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_r2_bucket",
+      "name": "with_variable",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "variable-bucket",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "name": "variable-bucket",
+            "jurisdiction": "default",
+            "storage_class": "Standard"
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_r2_bucket",
+      "name": "multi1",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "multi-bucket-1",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "name": "multi-bucket-1",
+            "jurisdiction": "default",
+            "storage_class": "Standard"
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_r2_bucket",
+      "name": "multi2",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "multi-bucket-2",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "name": "multi-bucket-2",
+            "location": "APAC",
+            "jurisdiction": "default",
+            "storage_class": "Standard"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/integration/v4_to_v5/testdata/r2_bucket/input/r2_bucket.tf
+++ b/integration/v4_to_v5/testdata/r2_bucket/input/r2_bucket.tf
@@ -1,0 +1,41 @@
+# Test Case 1: Basic R2 bucket with required fields only
+resource "cloudflare_r2_bucket" "basic" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+  name       = "test-bucket"
+}
+
+# Test Case 2: R2 bucket with location (uppercase - v4 style)
+resource "cloudflare_r2_bucket" "with_location_upper" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+  name       = "bucket-wnam"
+  location   = "WNAM"
+}
+
+# Test Case 3: R2 bucket with location (lowercase - also valid)
+resource "cloudflare_r2_bucket" "with_location_lower" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+  name       = "bucket-eeur"
+  location   = "eeur"
+}
+
+# Test Case 4: R2 bucket with variable reference
+variable "account_id" {
+  type = string
+}
+
+resource "cloudflare_r2_bucket" "with_variable" {
+  account_id = var.account_id
+  name       = "variable-bucket"
+}
+
+# Test Case 5: Multiple buckets with different configs
+resource "cloudflare_r2_bucket" "multi1" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+  name       = "multi-bucket-1"
+}
+
+resource "cloudflare_r2_bucket" "multi2" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+  name       = "multi-bucket-2"
+  location   = "APAC"
+}

--- a/integration/v4_to_v5/testdata/r2_bucket/input/terraform.tfstate
+++ b/integration/v4_to_v5/testdata/r2_bucket/input/terraform.tfstate
@@ -1,0 +1,108 @@
+{
+  "version": 4,
+  "terraform_version": "1.5.0",
+  "serial": 1,
+  "lineage": "test-r2-bucket-lineage",
+  "outputs": {},
+  "resources": [
+    {
+      "mode": "managed",
+      "type": "cloudflare_r2_bucket",
+      "name": "basic",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "test-bucket",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "name": "test-bucket"
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_r2_bucket",
+      "name": "with_location_upper",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "bucket-wnam",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "name": "bucket-wnam",
+            "location": "WNAM"
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_r2_bucket",
+      "name": "with_location_lower",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "bucket-eeur",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "name": "bucket-eeur",
+            "location": "eeur"
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_r2_bucket",
+      "name": "with_variable",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "variable-bucket",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "name": "variable-bucket"
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_r2_bucket",
+      "name": "multi1",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "multi-bucket-1",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "name": "multi-bucket-1"
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_r2_bucket",
+      "name": "multi2",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "multi-bucket-2",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "name": "multi-bucket-2",
+            "location": "APAC"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -5,6 +5,7 @@ import (
 	"github.com/cloudflare/tf-migrate/internal/resources/api_token"
 	"github.com/cloudflare/tf-migrate/internal/resources/dns_record"
 	"github.com/cloudflare/tf-migrate/internal/resources/logpull_retention"
+	"github.com/cloudflare/tf-migrate/internal/resources/r2_bucket"
 	"github.com/cloudflare/tf-migrate/internal/resources/workers_kv"
 	"github.com/cloudflare/tf-migrate/internal/resources/workers_kv_namespace"
 	"github.com/cloudflare/tf-migrate/internal/resources/zero_trust_access_service_token"
@@ -22,6 +23,7 @@ func RegisterAllMigrations() {
 	api_token.NewV4ToV5Migrator()
 	dns_record.NewV4ToV5Migrator()
 	logpull_retention.NewV4ToV5Migrator()
+	r2_bucket.NewV4ToV5Migrator()
 	workers_kv.NewV4ToV5Migrator()
 	workers_kv_namespace.NewV4ToV5Migrator()
 	zero_trust_access_service_token.NewV4ToV5Migrator()

--- a/internal/resources/r2_bucket/v4_to_v5.go
+++ b/internal/resources/r2_bucket/v4_to_v5.go
@@ -1,0 +1,66 @@
+package r2_bucket
+
+import (
+	"github.com/cloudflare/tf-migrate/internal"
+	"github.com/cloudflare/tf-migrate/internal/transform"
+	"github.com/cloudflare/tf-migrate/internal/transform/state"
+	"github.com/hashicorp/hcl/v2/hclwrite"
+	"github.com/tidwall/gjson"
+)
+
+type V4ToV5Migrator struct {
+}
+
+func NewV4ToV5Migrator() transform.ResourceTransformer {
+	migrator := &V4ToV5Migrator{}
+	internal.RegisterMigrator("cloudflare_r2_bucket", "v4", "v5", migrator)
+	return migrator
+}
+
+func (m *V4ToV5Migrator) GetResourceType() string {
+	return "cloudflare_r2_bucket"
+}
+
+func (m *V4ToV5Migrator) CanHandle(resourceType string) bool {
+	return resourceType == "cloudflare_r2_bucket"
+}
+
+// Preprocess performs any string-level transformations before HCL parsing.
+// For r2_bucket, no preprocessing is needed.
+func (m *V4ToV5Migrator) Preprocess(content string) string {
+	return content
+}
+
+// TransformConfig transforms the HCL configuration from v4 to v5.
+// For r2_bucket, the config is identical between v4 and v5.
+func (m *V4ToV5Migrator) TransformConfig(ctx *transform.Context, block *hclwrite.Block) (*transform.TransformResult, error) {
+	// No transformations needed - config is identical
+	return &transform.TransformResult{
+		Blocks:         []*hclwrite.Block{block},
+		RemoveOriginal: false,
+	}, nil
+}
+
+// TransformState transforms the JSON state from v4 to v5.
+// For r2_bucket, we need to add the new v5 fields with their default values
+// to prevent plan changes after migration.
+func (m *V4ToV5Migrator) TransformState(ctx *transform.Context, stateJSON gjson.Result, resourcePath string) (string, error) {
+	result := stateJSON.String()
+
+	if !stateJSON.Exists() || !stateJSON.Get("attributes").Exists() {
+		return result, nil
+	}
+
+	instance := stateJSON.Get("attributes")
+
+	// Add new v5 fields with their default values to match the schema
+	// jurisdiction: default is "default"
+	result = state.EnsureField(result, "attributes", instance, "jurisdiction", "default")
+
+	// storage_class: default is "Standard"
+	result = state.EnsureField(result, "attributes", instance, "storage_class", "Standard")
+
+	// Note: creation_date is not added here as it's purely computed and will be set by the API
+
+	return result, nil
+}

--- a/internal/resources/r2_bucket/v4_to_v5_test.go
+++ b/internal/resources/r2_bucket/v4_to_v5_test.go
@@ -1,0 +1,209 @@
+package r2_bucket
+
+import (
+	"testing"
+
+	"github.com/cloudflare/tf-migrate/internal/testhelpers"
+)
+
+func TestV4ToV5Migration(t *testing.T) {
+	migrator := NewV4ToV5Migrator()
+
+	t.Run("ConfigTransformation", func(t *testing.T) {
+		tests := []testhelpers.ConfigTestCase{
+			{
+				Name: "basic r2 bucket with required fields",
+				Input: `
+resource "cloudflare_r2_bucket" "test" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+  name       = "test-bucket"
+}`,
+				Expected: `
+resource "cloudflare_r2_bucket" "test" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+  name       = "test-bucket"
+}`,
+			},
+			{
+				Name: "r2 bucket with location",
+				Input: `
+resource "cloudflare_r2_bucket" "test" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+  name       = "test-bucket"
+  location   = "WNAM"
+}`,
+				Expected: `
+resource "cloudflare_r2_bucket" "test" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+  name       = "test-bucket"
+  location   = "WNAM"
+}`,
+			},
+			{
+				Name: "r2 bucket with lowercase location",
+				Input: `
+resource "cloudflare_r2_bucket" "test" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+  name       = "test-bucket"
+  location   = "wnam"
+}`,
+				Expected: `
+resource "cloudflare_r2_bucket" "test" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+  name       = "test-bucket"
+  location   = "wnam"
+}`,
+			},
+			{
+				Name: "multiple r2 buckets",
+				Input: `
+resource "cloudflare_r2_bucket" "test1" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+  name       = "bucket-1"
+}
+
+resource "cloudflare_r2_bucket" "test2" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+  name       = "bucket-2"
+  location   = "EEUR"
+}`,
+				Expected: `
+resource "cloudflare_r2_bucket" "test1" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+  name       = "bucket-1"
+}
+
+resource "cloudflare_r2_bucket" "test2" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+  name       = "bucket-2"
+  location   = "EEUR"
+}`,
+			},
+			{
+				Name: "r2 bucket with variable reference",
+				Input: `
+variable "account_id" {
+  type = string
+}
+
+resource "cloudflare_r2_bucket" "test" {
+  account_id = var.account_id
+  name       = "test-bucket"
+}`,
+				Expected: `
+variable "account_id" {
+  type = string
+}
+
+resource "cloudflare_r2_bucket" "test" {
+  account_id = var.account_id
+  name       = "test-bucket"
+}`,
+			},
+		}
+
+		testhelpers.RunConfigTransformTests(t, tests, migrator)
+	})
+
+	t.Run("StateTransformation", func(t *testing.T) {
+		tests := []testhelpers.StateTestCase{
+			{
+				Name: "basic state with required fields",
+				Input: `{
+					"attributes": {
+						"account_id": "f037e56e89293a057740de681ac9abbe",
+						"name": "test-bucket"
+					}
+				}`,
+				Expected: `{
+					"attributes": {
+						"account_id": "f037e56e89293a057740de681ac9abbe",
+						"name": "test-bucket",
+						"jurisdiction": "default",
+						"storage_class": "Standard"
+					}
+				}`,
+			},
+			{
+				Name: "state with id already present",
+				Input: `{
+					"attributes": {
+						"id": "test-bucket",
+						"account_id": "f037e56e89293a057740de681ac9abbe",
+						"name": "test-bucket"
+					}
+				}`,
+				Expected: `{
+					"attributes": {
+						"id": "test-bucket",
+						"account_id": "f037e56e89293a057740de681ac9abbe",
+						"name": "test-bucket",
+						"jurisdiction": "default",
+						"storage_class": "Standard"
+					}
+				}`,
+			},
+			{
+				Name: "state with location (uppercase)",
+				Input: `{
+					"attributes": {
+						"account_id": "f037e56e89293a057740de681ac9abbe",
+						"name": "test-bucket",
+						"location": "WNAM"
+					}
+				}`,
+				Expected: `{
+					"attributes": {
+						"account_id": "f037e56e89293a057740de681ac9abbe",
+						"name": "test-bucket",
+						"location": "WNAM",
+						"jurisdiction": "default",
+						"storage_class": "Standard"
+					}
+				}`,
+			},
+			{
+				Name: "state with location (lowercase)",
+				Input: `{
+					"attributes": {
+						"account_id": "f037e56e89293a057740de681ac9abbe",
+						"name": "test-bucket",
+						"location": "wnam"
+					}
+				}`,
+				Expected: `{
+					"attributes": {
+						"account_id": "f037e56e89293a057740de681ac9abbe",
+						"name": "test-bucket",
+						"location": "wnam",
+						"jurisdiction": "default",
+						"storage_class": "Standard"
+					}
+				}`,
+			},
+			{
+				Name: "state with all v4 fields",
+				Input: `{
+					"attributes": {
+						"id": "my-r2-bucket",
+						"account_id": "f037e56e89293a057740de681ac9abbe",
+						"name": "my-r2-bucket",
+						"location": "EEUR"
+					}
+				}`,
+				Expected: `{
+					"attributes": {
+						"id": "my-r2-bucket",
+						"account_id": "f037e56e89293a057740de681ac9abbe",
+						"name": "my-r2-bucket",
+						"location": "EEUR",
+						"jurisdiction": "default",
+						"storage_class": "Standard"
+					}
+				}`,
+			},
+		}
+
+		testhelpers.RunStateTransformTests(t, tests, migrator)
+	})
+}


### PR DESCRIPTION
Add cloudflare_r2_bucket v4 to v5 migration

Implements migration for cloudflare_r2_bucket resource with state transformation to add v5 default values (jurisdiction="default", storage_class="Standard"). Config files pass through unchanged.

Files added:
- internal/resources/r2_bucket/v4_to_v5.go
- internal/resources/r2_bucket/v4_to_v5_test.go
- integration/v4_to_v5/testdata/r2_bucket/

Tests:
- 10 unit tests (5 config, 5 state transformation)
- Integration tests with 6 bucket resources
- All tests verify no plan changes after migration