### PR TITLE
add notification_policy_webhooks migration

### DIFF
--- a/integration/v4_to_v5/integration_test.go
+++ b/integration/v4_to_v5/integration_test.go
@@ -12,12 +12,13 @@ import (
 	_ "github.com/cloudflare/tf-migrate/internal/resources/api_token"
 	_ "github.com/cloudflare/tf-migrate/internal/resources/dns_record"
 	_ "github.com/cloudflare/tf-migrate/internal/resources/logpull_retention"
+	_ "github.com/cloudflare/tf-migrate/internal/resources/notification_policy_webhooks"
 	_ "github.com/cloudflare/tf-migrate/internal/resources/r2_bucket"
 	_ "github.com/cloudflare/tf-migrate/internal/resources/workers_kv"
 	_ "github.com/cloudflare/tf-migrate/internal/resources/workers_kv_namespace"
 	_ "github.com/cloudflare/tf-migrate/internal/resources/zero_trust_access_service_token"
-	_ "github.com/cloudflare/tf-migrate/internal/resources/zero_trust_gateway_policy"
 	_ "github.com/cloudflare/tf-migrate/internal/resources/zero_trust_dlp_custom_profile"
+	_ "github.com/cloudflare/tf-migrate/internal/resources/zero_trust_gateway_policy"
 	_ "github.com/cloudflare/tf-migrate/internal/resources/zero_trust_list"
 	_ "github.com/cloudflare/tf-migrate/internal/resources/zone_dnssec"
 )
@@ -49,6 +50,7 @@ func TestV4ToV5Migration(t *testing.T) {
 		"api_token",
 		"dns_record",
 		"logpull_retention",
+		"notification_policy_webhooks",
 		"r2_bucket",
 		"workers_kv",
 		"workers_kv_namespace",

--- a/integration/v4_to_v5/testdata/notification_policy_webhooks/expected/notification_policy_webhooks.tf
+++ b/integration/v4_to_v5/testdata/notification_policy_webhooks/expected/notification_policy_webhooks.tf
@@ -1,0 +1,28 @@
+# Test Case 1: Basic webhook with minimal fields
+resource "cloudflare_notification_policy_webhooks" "basic_webhook" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+  name       = "basic-webhook"
+  url        = "https://example.com/webhook"
+}
+
+# Test Case 2: Full webhook with all fields
+resource "cloudflare_notification_policy_webhooks" "full_webhook" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+  name       = "production-webhook"
+  url        = "https://alerts.example.com/notify"
+  secret     = "webhook-secret-token-12345"
+}
+
+# Test Case 3: Multiple webhooks
+resource "cloudflare_notification_policy_webhooks" "primary" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+  name       = "primary-webhook"
+  url        = "https://primary.example.com/webhook"
+}
+
+resource "cloudflare_notification_policy_webhooks" "backup" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+  name       = "backup-webhook"
+  url        = "https://backup.example.com/webhook"
+  secret     = "backup-secret"
+}

--- a/integration/v4_to_v5/testdata/notification_policy_webhooks/expected/terraform.tfstate
+++ b/integration/v4_to_v5/testdata/notification_policy_webhooks/expected/terraform.tfstate
@@ -1,0 +1,97 @@
+{
+  "version": 4,
+  "terraform_version": "1.0.0",
+  "serial": 1,
+  "lineage": "a75366f2-b332-4347-9a6c-239a2f23a319",
+  "outputs": {},
+  "resources": [
+    {
+      "mode": "managed",
+      "type": "cloudflare_notification_policy_webhooks",
+      "name": "basic_webhook",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "f174e90a-fafe-4643-bbbc-4a0ed4fc8415",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "name": "basic-webhook",
+            "url": "https://example.com/webhook",
+            "secret": null,
+            "type": "generic",
+            "created_at": "2023-01-01T12:00:00Z",
+            "last_success": null,
+            "last_failure": null
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_notification_policy_webhooks",
+      "name": "full_webhook",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "a284b91d-5fa5-4532-abcd-3b1ed5fc9527",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "name": "production-webhook",
+            "url": "https://alerts.example.com/notify",
+            "secret": "webhook-secret-token-12345",
+            "type": "generic",
+            "created_at": "2023-01-01T12:00:00Z",
+            "last_success": "2023-01-15T14:30:00Z",
+            "last_failure": null
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_notification_policy_webhooks",
+      "name": "primary",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "c8e5d92e-6fb6-5643-bcde-4c2fe6ga0638",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "name": "primary-webhook",
+            "url": "https://primary.example.com/webhook",
+            "secret": null,
+            "type": "generic",
+            "created_at": "2023-01-01T12:00:00Z",
+            "last_success": null,
+            "last_failure": null
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_notification_policy_webhooks",
+      "name": "backup",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "d9f6ea3f-7gc7-6754-cdef-5d3gf7hb1749",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "name": "backup-webhook",
+            "url": "https://backup.example.com/webhook",
+            "secret": "backup-secret",
+            "type": "generic",
+            "created_at": "2023-01-01T12:00:00Z",
+            "last_success": null,
+            "last_failure": null
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/integration/v4_to_v5/testdata/notification_policy_webhooks/input/notification_policy_webhooks.tf
+++ b/integration/v4_to_v5/testdata/notification_policy_webhooks/input/notification_policy_webhooks.tf
@@ -1,0 +1,28 @@
+# Test Case 1: Basic webhook with minimal fields
+resource "cloudflare_notification_policy_webhooks" "basic_webhook" {
+    account_id = "f037e56e89293a057740de681ac9abbe"
+    name       = "basic-webhook"
+    url        = "https://example.com/webhook"
+}
+
+# Test Case 2: Full webhook with all fields
+resource "cloudflare_notification_policy_webhooks" "full_webhook" {
+    account_id = "f037e56e89293a057740de681ac9abbe"
+    name       = "production-webhook"
+    url        = "https://alerts.example.com/notify"
+    secret     = "webhook-secret-token-12345"
+}
+
+# Test Case 3: Multiple webhooks
+resource "cloudflare_notification_policy_webhooks" "primary" {
+    account_id = "f037e56e89293a057740de681ac9abbe"
+    name       = "primary-webhook"
+    url        = "https://primary.example.com/webhook"
+}
+
+resource "cloudflare_notification_policy_webhooks" "backup" {
+    account_id = "f037e56e89293a057740de681ac9abbe"
+    name       = "backup-webhook"
+    url        = "https://backup.example.com/webhook"
+    secret     = "backup-secret"
+}

--- a/integration/v4_to_v5/testdata/notification_policy_webhooks/input/terraform.tfstate
+++ b/integration/v4_to_v5/testdata/notification_policy_webhooks/input/terraform.tfstate
@@ -1,0 +1,97 @@
+{
+  "version": 4,
+  "terraform_version": "1.0.0",
+  "serial": 1,
+  "lineage": "a75366f2-b332-4347-9a6c-239a2f23a319",
+  "outputs": {},
+  "resources": [
+    {
+      "mode": "managed",
+      "type": "cloudflare_notification_policy_webhooks",
+      "name": "basic_webhook",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "f174e90a-fafe-4643-bbbc-4a0ed4fc8415",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "name": "basic-webhook",
+            "url": "https://example.com/webhook",
+            "secret": null,
+            "type": "generic",
+            "created_at": "2023-01-01T12:00:00Z",
+            "last_success": null,
+            "last_failure": null
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_notification_policy_webhooks",
+      "name": "full_webhook",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "a284b91d-5fa5-4532-abcd-3b1ed5fc9527",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "name": "production-webhook",
+            "url": "https://alerts.example.com/notify",
+            "secret": "webhook-secret-token-12345",
+            "type": "generic",
+            "created_at": "2023-01-01T12:00:00Z",
+            "last_success": "2023-01-15T14:30:00Z",
+            "last_failure": null
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_notification_policy_webhooks",
+      "name": "primary",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "c8e5d92e-6fb6-5643-bcde-4c2fe6ga0638",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "name": "primary-webhook",
+            "url": "https://primary.example.com/webhook",
+            "secret": null,
+            "type": "generic",
+            "created_at": "2023-01-01T12:00:00Z",
+            "last_success": null,
+            "last_failure": null
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_notification_policy_webhooks",
+      "name": "backup",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "d9f6ea3f-7gc7-6754-cdef-5d3gf7hb1749",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "name": "backup-webhook",
+            "url": "https://backup.example.com/webhook",
+            "secret": "backup-secret",
+            "type": "generic",
+            "created_at": "2023-01-01T12:00:00Z",
+            "last_success": null,
+            "last_failure": null
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -5,6 +5,7 @@ import (
 	"github.com/cloudflare/tf-migrate/internal/resources/api_token"
 	"github.com/cloudflare/tf-migrate/internal/resources/dns_record"
 	"github.com/cloudflare/tf-migrate/internal/resources/logpull_retention"
+	"github.com/cloudflare/tf-migrate/internal/resources/notification_policy_webhooks"
 	"github.com/cloudflare/tf-migrate/internal/resources/r2_bucket"
 	"github.com/cloudflare/tf-migrate/internal/resources/workers_kv"
 	"github.com/cloudflare/tf-migrate/internal/resources/workers_kv_namespace"
@@ -24,6 +25,7 @@ func RegisterAllMigrations() {
 	dns_record.NewV4ToV5Migrator()
 	zone_dnssec.NewV4ToV5Migrator()
 	logpull_retention.NewV4ToV5Migrator()
+	notification_policy_webhooks.NewV4ToV5Migrator()
 	r2_bucket.NewV4ToV5Migrator()
 	workers_kv.NewV4ToV5Migrator()
 	workers_kv_namespace.NewV4ToV5Migrator()

--- a/internal/resources/notification_policy_webhooks/v4_to_v5.go
+++ b/internal/resources/notification_policy_webhooks/v4_to_v5.go
@@ -1,0 +1,56 @@
+package notification_policy_webhooks
+
+import (
+	"github.com/cloudflare/tf-migrate/internal"
+	"github.com/cloudflare/tf-migrate/internal/transform"
+	"github.com/hashicorp/hcl/v2/hclwrite"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+type V4ToV5Migrator struct {
+}
+
+func NewV4ToV5Migrator() transform.ResourceTransformer {
+	migrator := &V4ToV5Migrator{}
+	internal.RegisterMigrator("cloudflare_notification_policy_webhooks", "v4", "v5", migrator)
+	return migrator
+}
+
+func (m *V4ToV5Migrator) GetResourceType() string {
+	return "cloudflare_notification_policy_webhooks"
+}
+
+func (m *V4ToV5Migrator) CanHandle(resourceType string) bool {
+	return resourceType == "cloudflare_notification_policy_webhooks"
+}
+
+func (m *V4ToV5Migrator) Preprocess(content string) string {
+	return content
+}
+
+func (m *V4ToV5Migrator) TransformConfig(ctx *transform.Context, block *hclwrite.Block) (*transform.TransformResult, error) {
+	// No transformations needed - all fields remain the same
+	// Note: We assume all v4 configs have the url field since it was optional in v4
+	// but is required in v5. If url is missing, the v5 provider will catch it during validation.
+	return &transform.TransformResult{
+		Blocks:         []*hclwrite.Block{block},
+		RemoveOriginal: false,
+	}, nil
+}
+
+func (m *V4ToV5Migrator) TransformState(ctx *transform.Context, stateJSON gjson.Result, resourcePath string) (string, error) {
+	result := stateJSON.String()
+
+	if !stateJSON.Exists() {
+		return result, nil
+	}
+
+	// Set schema_version to 0 for v5
+	// Note: We assume all v4 states have the url field. While it was optional in v4,
+	// the Cloudflare API requires it, so all real resources should have it.
+	// If url is missing, the v5 provider will catch it during the next apply.
+	result, _ = sjson.Set(result, "schema_version", 0)
+
+	return result, nil
+}

--- a/internal/resources/notification_policy_webhooks/v4_to_v5_test.go
+++ b/internal/resources/notification_policy_webhooks/v4_to_v5_test.go
@@ -1,0 +1,147 @@
+package notification_policy_webhooks
+
+import (
+	"testing"
+
+	"github.com/cloudflare/tf-migrate/internal/testhelpers"
+)
+
+func TestV4ToV5Migration(t *testing.T) {
+	migrator := NewV4ToV5Migrator()
+
+	t.Run("ConfigTransformation", func(t *testing.T) {
+		tests := []testhelpers.ConfigTestCase{
+			{
+				Name: "minimal config with url",
+				Input: `
+resource "cloudflare_notification_policy_webhooks" "example" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+  name       = "test-webhook"
+  url        = "https://example.com/webhook"
+}`,
+				Expected: `
+resource "cloudflare_notification_policy_webhooks" "example" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+  name       = "test-webhook"
+  url        = "https://example.com/webhook"
+}`,
+			},
+			{
+				Name: "full config with all fields",
+				Input: `
+resource "cloudflare_notification_policy_webhooks" "example" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+  name       = "production-webhook"
+  url        = "https://alerts.example.com/notify"
+  secret     = "webhook-secret-token"
+}`,
+				Expected: `
+resource "cloudflare_notification_policy_webhooks" "example" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+  name       = "production-webhook"
+  url        = "https://alerts.example.com/notify"
+  secret     = "webhook-secret-token"
+}`,
+			},
+			{
+				Name: "multiple resources",
+				Input: `
+resource "cloudflare_notification_policy_webhooks" "primary" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+  name       = "primary-webhook"
+  url        = "https://primary.example.com/webhook"
+}
+
+resource "cloudflare_notification_policy_webhooks" "backup" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+  name       = "backup-webhook"
+  url        = "https://backup.example.com/webhook"
+  secret     = "backup-secret"
+}`,
+				Expected: `
+resource "cloudflare_notification_policy_webhooks" "primary" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+  name       = "primary-webhook"
+  url        = "https://primary.example.com/webhook"
+}
+
+resource "cloudflare_notification_policy_webhooks" "backup" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+  name       = "backup-webhook"
+  url        = "https://backup.example.com/webhook"
+  secret     = "backup-secret"
+}`,
+			},
+		}
+
+		testhelpers.RunConfigTransformTests(t, tests, migrator)
+	})
+
+	// Note: No error cases for config transformation since we assume all v4 configs
+	// have the url field. If missing, the v5 provider will validate during apply.
+
+	t.Run("StateTransformation", func(t *testing.T) {
+		tests := []testhelpers.StateTestCase{
+			{
+				Name: "minimal state with url",
+				Input: `{
+					"schema_version": 1,
+					"attributes": {
+						"id": "f174e90a-fafe-4643-bbbc-4a0ed4fc8415",
+						"account_id": "f037e56e89293a057740de681ac9abbe",
+						"name": "test-webhook",
+						"url": "https://example.com/webhook",
+						"type": "generic"
+					}
+				}`,
+				Expected: `{
+					"schema_version": 0,
+					"attributes": {
+						"id": "f174e90a-fafe-4643-bbbc-4a0ed4fc8415",
+						"account_id": "f037e56e89293a057740de681ac9abbe",
+						"name": "test-webhook",
+						"url": "https://example.com/webhook",
+						"type": "generic"
+					}
+				}`,
+			},
+			{
+				Name: "full state with all fields",
+				Input: `{
+					"schema_version": 1,
+					"attributes": {
+						"id": "f174e90a-fafe-4643-bbbc-4a0ed4fc8415",
+						"account_id": "f037e56e89293a057740de681ac9abbe",
+						"name": "prod-webhook",
+						"url": "https://alerts.example.com/notify",
+						"secret": "webhook-secret",
+						"type": "generic",
+						"created_at": "2023-01-01T12:00:00Z",
+						"last_success": "2023-01-15T14:30:00Z",
+						"last_failure": null
+					}
+				}`,
+				Expected: `{
+					"schema_version": 0,
+					"attributes": {
+						"id": "f174e90a-fafe-4643-bbbc-4a0ed4fc8415",
+						"account_id": "f037e56e89293a057740de681ac9abbe",
+						"name": "prod-webhook",
+						"url": "https://alerts.example.com/notify",
+						"secret": "webhook-secret",
+						"type": "generic",
+						"created_at": "2023-01-01T12:00:00Z",
+						"last_success": "2023-01-15T14:30:00Z",
+						"last_failure": null
+					}
+				}`,
+			},
+		}
+
+		testhelpers.RunStateTransformTests(t, tests, migrator)
+	})
+
+	// Note: No error cases for state transformation since we assume all v4 states
+	// have the url field. While it was optional in v4 schema, the Cloudflare API
+	// requires it, so all real resources should have it.
+}


### PR DESCRIPTION
Adds `cloudflare_notification_policy_webhooks` for v4 to v5 migration. No changes were needed for this migration other than adding a schema_version.

_Note:_ It is technically possible for the URL to not be set for webhooks as it is not required in v4, but it is in v5. This has been noted as a scenario we will not be able to get into, as it is disallowed by the API.