### PR TITLE
feat(logpull_retention): add comprehensive tests for v4 to v5 migration

### DIFF
--- a/integration/v4_to_v5/testdata/logpull_retention/expected/logpull_retention.tf
+++ b/integration/v4_to_v5/testdata/logpull_retention/expected/logpull_retention.tf
@@ -1,3 +1,10 @@
+# Integration Test for cloudflare_logpull_retention v4 → v5 Migration
+# This file tests ALL Terraform patterns as required by subtask 08
+
+# ============================================================================
+# Pattern Group 1: Variables & Locals (Required by Subtask 08)
+# ============================================================================
+
 variable "cloudflare_account_id" {
   description = "Cloudflare account ID"
   type        = string
@@ -8,14 +15,204 @@ variable "cloudflare_zone_id" {
   type        = string
 }
 
-# Test Case 1: Basic logpull retention enabled
-resource "cloudflare_logpull_retention" "enabled_zone" {
+locals {
+  common_zone    = var.cloudflare_zone_id
+  name_prefix    = "test-integration"
+  tags           = ["test", "migration", "v4_to_v5"]
+  enable_feature = true
+  enable_test    = false
+  zone_count     = 3
+}
+
+# ============================================================================
+# Pattern Group 2: for_each with Maps (3-5 resources)
+# ============================================================================
+
+resource "cloudflare_logpull_retention" "map_example" {
+  for_each = {
+    "zone1" = {
+      zone_id = var.cloudflare_zone_id
+      enabled = true
+    }
+    "zone2" = {
+      zone_id = var.cloudflare_zone_id
+      enabled = false
+    }
+    "zone3" = {
+      zone_id = var.cloudflare_zone_id
+      enabled = true
+    }
+    "zone4" = {
+      zone_id = var.cloudflare_zone_id
+      enabled = false
+    }
+  }
+
+  zone_id = each.value.zone_id
+  flag    = each.value.enabled
+}
+
+# ============================================================================
+# Pattern Group 3: for_each with Sets (3-5 items)
+# ============================================================================
+
+resource "cloudflare_logpull_retention" "set_example" {
+  for_each = toset([
+    "alpha",
+    "beta",
+    "gamma",
+    "delta"
+  ])
+
+  zone_id = var.cloudflare_zone_id
+  flag    = each.key == "alpha" || each.key == "gamma" ? true : false
+}
+
+# ============================================================================
+# Pattern Group 4: count-based Resources (at least 3)
+# ============================================================================
+
+resource "cloudflare_logpull_retention" "counted" {
+  count = 3
+
+  zone_id = var.cloudflare_zone_id
+  flag    = count.index % 2 == 0 ? true : false
+}
+
+# ============================================================================
+# Pattern Group 5: Conditional Creation
+# ============================================================================
+
+resource "cloudflare_logpull_retention" "conditional_enabled" {
+  count = local.enable_feature ? 1 : 0
+
   zone_id = var.cloudflare_zone_id
   flag    = true
 }
 
-# Test Case 2: Logpull retention disabled
-resource "cloudflare_logpull_retention" "disabled_zone" {
+resource "cloudflare_logpull_retention" "conditional_disabled" {
+  count = local.enable_test ? 1 : 0
+
   zone_id = var.cloudflare_zone_id
   flag    = false
 }
+
+# ============================================================================
+# Pattern Group 6: Terraform Functions
+# ============================================================================
+
+resource "cloudflare_logpull_retention" "with_functions" {
+  zone_id = var.cloudflare_zone_id
+  flag    = true
+}
+
+resource "cloudflare_logpull_retention" "with_interpolation" {
+  zone_id = "${var.cloudflare_zone_id}" # String interpolation
+  flag    = false
+}
+
+# ============================================================================
+# Pattern Group 7: Lifecycle Meta-Arguments
+# ============================================================================
+
+resource "cloudflare_logpull_retention" "with_lifecycle" {
+  zone_id = var.cloudflare_zone_id
+
+  lifecycle {
+    create_before_destroy = true
+  }
+  flag = true
+}
+
+resource "cloudflare_logpull_retention" "with_ignore_changes" {
+  zone_id = local.common_zone
+
+  lifecycle {
+    ignore_changes = [flag]
+  }
+  flag = false
+}
+
+resource "cloudflare_logpull_retention" "with_prevent_destroy" {
+  zone_id = var.cloudflare_zone_id
+
+  lifecycle {
+    prevent_destroy = false # Set to false for testing
+  }
+  flag = true
+}
+
+# ============================================================================
+# Pattern Group 8: Edge Cases
+# ============================================================================
+
+# Minimal resource (only required fields)
+resource "cloudflare_logpull_retention" "minimal" {
+  zone_id = var.cloudflare_zone_id
+  flag    = true
+}
+
+# Using locals reference
+resource "cloudflare_logpull_retention" "with_local" {
+  zone_id = local.common_zone
+  flag    = local.enable_feature
+}
+
+# Complex conditional expression
+resource "cloudflare_logpull_retention" "complex_conditional" {
+  zone_id = var.cloudflare_zone_id
+  flag    = local.enable_feature && !local.enable_test ? true : false
+}
+
+# ============================================================================
+# Pattern Group 9: Additional Real-World Patterns
+# ============================================================================
+
+# Testing enabled=true explicitly
+resource "cloudflare_logpull_retention" "enabled_explicit" {
+  zone_id = var.cloudflare_zone_id
+  flag    = true
+}
+
+# Testing enabled=false explicitly
+resource "cloudflare_logpull_retention" "disabled_explicit" {
+  zone_id = var.cloudflare_zone_id
+  flag    = false
+}
+
+# Using ternary operator
+resource "cloudflare_logpull_retention" "ternary_true" {
+  zone_id = var.cloudflare_zone_id
+  flag    = 1 == 1 ? true : false
+}
+
+resource "cloudflare_logpull_retention" "ternary_false" {
+  zone_id = var.cloudflare_zone_id
+  flag    = 1 == 2 ? true : false
+}
+
+# ============================================================================
+# Summary:
+# - Total resource declarations: 18
+# - Total instances created:
+#   - map_example: 4 instances
+#   - set_example: 4 instances
+#   - counted: 3 instances
+#   - conditional_enabled: 1 instance
+#   - conditional_disabled: 0 instances (count = 0)
+#   - Others: 11 instances
+#   TOTAL: 4 + 4 + 3 + 1 + 0 + 11 = 23 instances
+#
+# Patterns covered:
+# ✓ Variables (cloudflare_account_id, cloudflare_zone_id)
+# ✓ Locals (common_zone, enable_feature, enable_test)
+# ✓ for_each with maps (4 resources)
+# ✓ for_each with sets using toset() (4 resources)
+# ✓ count-based resources (3 resources)
+# ✓ Conditional creation with ternary operator
+# ✓ String interpolation
+# ✓ Lifecycle meta-arguments (create_before_destroy, ignore_changes, prevent_destroy)
+# ✓ Terraform functions (toset())
+# ✓ Edge cases (minimal config, complex conditionals)
+# ✓ Boolean values (both true and false)
+# ============================================================================

--- a/integration/v4_to_v5/testdata/logpull_retention/expected/terraform.tfstate
+++ b/integration/v4_to_v5/testdata/logpull_retention/expected/terraform.tfstate
@@ -3,18 +3,160 @@
   "outputs": {},
   "resources": [
     {
+      "each": "map",
       "instances": [
         {
           "attributes": {
             "flag": true,
-            "id": "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6",
+            "id": "map-zone1-id-a1b2c3d4",
+            "zone_id": "d56084adb405e0b7e32c52321bf07be6"
+          },
+          "index_key": "zone1",
+          "schema_version": 0
+        },
+        {
+          "attributes": {
+            "flag": false,
+            "id": "map-zone2-id-e5f6g7h8",
+            "zone_id": "d56084adb405e0b7e32c52321bf07be6"
+          },
+          "index_key": "zone2",
+          "schema_version": 0
+        },
+        {
+          "attributes": {
+            "flag": true,
+            "id": "map-zone3-id-i9j0k1l2",
+            "zone_id": "d56084adb405e0b7e32c52321bf07be6"
+          },
+          "index_key": "zone3",
+          "schema_version": 0
+        },
+        {
+          "attributes": {
+            "flag": false,
+            "id": "map-zone4-id-m3n4o5p6",
+            "zone_id": "d56084adb405e0b7e32c52321bf07be6"
+          },
+          "index_key": "zone4",
+          "schema_version": 0
+        }
+      ],
+      "mode": "managed",
+      "name": "map_example",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_logpull_retention"
+    },
+    {
+      "each": "set",
+      "instances": [
+        {
+          "attributes": {
+            "flag": true,
+            "id": "set-alpha-id-q7r8s9t0",
+            "zone_id": "d56084adb405e0b7e32c52321bf07be6"
+          },
+          "index_key": "alpha",
+          "schema_version": 0
+        },
+        {
+          "attributes": {
+            "flag": false,
+            "id": "set-beta-id-u1v2w3x4",
+            "zone_id": "d56084adb405e0b7e32c52321bf07be6"
+          },
+          "index_key": "beta",
+          "schema_version": 0
+        },
+        {
+          "attributes": {
+            "flag": true,
+            "id": "set-gamma-id-y5z6a7b8",
+            "zone_id": "d56084adb405e0b7e32c52321bf07be6"
+          },
+          "index_key": "gamma",
+          "schema_version": 0
+        },
+        {
+          "attributes": {
+            "flag": false,
+            "id": "set-delta-id-c9d0e1f2",
+            "zone_id": "d56084adb405e0b7e32c52321bf07be6"
+          },
+          "index_key": "delta",
+          "schema_version": 0
+        }
+      ],
+      "mode": "managed",
+      "name": "set_example",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_logpull_retention"
+    },
+    {
+      "instances": [
+        {
+          "attributes": {
+            "flag": true,
+            "id": "counted-0-id-g3h4i5j6",
+            "zone_id": "d56084adb405e0b7e32c52321bf07be6"
+          },
+          "index_key": 0,
+          "schema_version": 0
+        },
+        {
+          "attributes": {
+            "flag": false,
+            "id": "counted-1-id-k7l8m9n0",
+            "zone_id": "d56084adb405e0b7e32c52321bf07be6"
+          },
+          "index_key": 1,
+          "schema_version": 0
+        },
+        {
+          "attributes": {
+            "flag": true,
+            "id": "counted-2-id-o1p2q3r4",
+            "zone_id": "d56084adb405e0b7e32c52321bf07be6"
+          },
+          "index_key": 2,
+          "schema_version": 0
+        }
+      ],
+      "mode": "managed",
+      "name": "counted",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_logpull_retention"
+    },
+    {
+      "instances": [
+        {
+          "attributes": {
+            "flag": true,
+            "id": "conditional-enabled-id-s5t6u7v8",
+            "zone_id": "d56084adb405e0b7e32c52321bf07be6"
+          },
+          "index_key": 0,
+          "schema_version": 0
+        }
+      ],
+      "mode": "managed",
+      "name": "conditional_enabled",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_logpull_retention"
+    },
+    {
+      "instances": [
+        {
+          "attributes": {
+            "flag": true,
+            "id": "with-functions-id-w9x0y1z2",
             "zone_id": "d56084adb405e0b7e32c52321bf07be6"
           },
           "schema_version": 0
         }
       ],
       "mode": "managed",
-      "name": "enabled_zone",
+      "name": "with_functions",
       "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
       "type": "cloudflare_logpull_retention"
     },
@@ -23,14 +165,174 @@
         {
           "attributes": {
             "flag": false,
-            "id": "z9y8x7w6v5u4t3s2r1q0p9o8n7m6l5k4",
-            "zone_id": "023e105f4ecef8ad9ca31a8372d0c353"
+            "id": "with-interpolation-id-a3b4c5d6",
+            "zone_id": "d56084adb405e0b7e32c52321bf07be6"
           },
           "schema_version": 0
         }
       ],
       "mode": "managed",
-      "name": "disabled_zone",
+      "name": "with_interpolation",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_logpull_retention"
+    },
+    {
+      "instances": [
+        {
+          "attributes": {
+            "flag": true,
+            "id": "with-lifecycle-id-e7f8g9h0",
+            "zone_id": "d56084adb405e0b7e32c52321bf07be6"
+          },
+          "schema_version": 0
+        }
+      ],
+      "mode": "managed",
+      "name": "with_lifecycle",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_logpull_retention"
+    },
+    {
+      "instances": [
+        {
+          "attributes": {
+            "flag": false,
+            "id": "with-ignore-changes-id-i1j2k3l4",
+            "zone_id": "d56084adb405e0b7e32c52321bf07be6"
+          },
+          "schema_version": 0
+        }
+      ],
+      "mode": "managed",
+      "name": "with_ignore_changes",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_logpull_retention"
+    },
+    {
+      "instances": [
+        {
+          "attributes": {
+            "flag": true,
+            "id": "with-prevent-destroy-id-m5n6o7p8",
+            "zone_id": "d56084adb405e0b7e32c52321bf07be6"
+          },
+          "schema_version": 0
+        }
+      ],
+      "mode": "managed",
+      "name": "with_prevent_destroy",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_logpull_retention"
+    },
+    {
+      "instances": [
+        {
+          "attributes": {
+            "flag": true,
+            "id": "minimal-id-q9r0s1t2",
+            "zone_id": "d56084adb405e0b7e32c52321bf07be6"
+          },
+          "schema_version": 0
+        }
+      ],
+      "mode": "managed",
+      "name": "minimal",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_logpull_retention"
+    },
+    {
+      "instances": [
+        {
+          "attributes": {
+            "flag": true,
+            "id": "with-local-id-u3v4w5x6",
+            "zone_id": "d56084adb405e0b7e32c52321bf07be6"
+          },
+          "schema_version": 0
+        }
+      ],
+      "mode": "managed",
+      "name": "with_local",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_logpull_retention"
+    },
+    {
+      "instances": [
+        {
+          "attributes": {
+            "flag": true,
+            "id": "complex-conditional-id-y7z8a9b0",
+            "zone_id": "d56084adb405e0b7e32c52321bf07be6"
+          },
+          "schema_version": 0
+        }
+      ],
+      "mode": "managed",
+      "name": "complex_conditional",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_logpull_retention"
+    },
+    {
+      "instances": [
+        {
+          "attributes": {
+            "flag": true,
+            "id": "enabled-explicit-id-c1d2e3f4",
+            "zone_id": "d56084adb405e0b7e32c52321bf07be6"
+          },
+          "schema_version": 0
+        }
+      ],
+      "mode": "managed",
+      "name": "enabled_explicit",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_logpull_retention"
+    },
+    {
+      "instances": [
+        {
+          "attributes": {
+            "flag": false,
+            "id": "disabled-explicit-id-g5h6i7j8",
+            "zone_id": "d56084adb405e0b7e32c52321bf07be6"
+          },
+          "schema_version": 0
+        }
+      ],
+      "mode": "managed",
+      "name": "disabled_explicit",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_logpull_retention"
+    },
+    {
+      "instances": [
+        {
+          "attributes": {
+            "flag": true,
+            "id": "ternary-true-id-k9l0m1n2",
+            "zone_id": "d56084adb405e0b7e32c52321bf07be6"
+          },
+          "schema_version": 0
+        }
+      ],
+      "mode": "managed",
+      "name": "ternary_true",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_logpull_retention"
+    },
+    {
+      "instances": [
+        {
+          "attributes": {
+            "flag": false,
+            "id": "ternary-false-id-o3p4q5r6",
+            "zone_id": "d56084adb405e0b7e32c52321bf07be6"
+          },
+          "schema_version": 0
+        }
+      ],
+      "mode": "managed",
+      "name": "ternary_false",
       "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
       "type": "cloudflare_logpull_retention"
     }

--- a/integration/v4_to_v5/testdata/logpull_retention/input/logpull_retention.tf
+++ b/integration/v4_to_v5/testdata/logpull_retention/input/logpull_retention.tf
@@ -1,3 +1,10 @@
+# Integration Test for cloudflare_logpull_retention v4 → v5 Migration
+# This file tests ALL Terraform patterns as required by subtask 08
+
+# ============================================================================
+# Pattern Group 1: Variables & Locals (Required by Subtask 08)
+# ============================================================================
+
 variable "cloudflare_account_id" {
   description = "Cloudflare account ID"
   type        = string
@@ -8,14 +15,204 @@ variable "cloudflare_zone_id" {
   type        = string
 }
 
-# Test Case 1: Basic logpull retention enabled
-resource "cloudflare_logpull_retention" "enabled_zone" {
+locals {
+  common_zone     = var.cloudflare_zone_id
+  name_prefix     = "test-integration"
+  tags            = ["test", "migration", "v4_to_v5"]
+  enable_feature  = true
+  enable_test     = false
+  zone_count      = 3
+}
+
+# ============================================================================
+# Pattern Group 2: for_each with Maps (3-5 resources)
+# ============================================================================
+
+resource "cloudflare_logpull_retention" "map_example" {
+  for_each = {
+    "zone1" = {
+      zone_id = var.cloudflare_zone_id
+      enabled = true
+    }
+    "zone2" = {
+      zone_id = var.cloudflare_zone_id
+      enabled = false
+    }
+    "zone3" = {
+      zone_id = var.cloudflare_zone_id
+      enabled = true
+    }
+    "zone4" = {
+      zone_id = var.cloudflare_zone_id
+      enabled = false
+    }
+  }
+
+  zone_id = each.value.zone_id
+  enabled = each.value.enabled
+}
+
+# ============================================================================
+# Pattern Group 3: for_each with Sets (3-5 items)
+# ============================================================================
+
+resource "cloudflare_logpull_retention" "set_example" {
+  for_each = toset([
+    "alpha",
+    "beta",
+    "gamma",
+    "delta"
+  ])
+
+  zone_id = var.cloudflare_zone_id
+  enabled = each.key == "alpha" || each.key == "gamma" ? true : false
+}
+
+# ============================================================================
+# Pattern Group 4: count-based Resources (at least 3)
+# ============================================================================
+
+resource "cloudflare_logpull_retention" "counted" {
+  count = 3
+
+  zone_id = var.cloudflare_zone_id
+  enabled = count.index % 2 == 0 ? true : false  # Alternating true/false
+}
+
+# ============================================================================
+# Pattern Group 5: Conditional Creation
+# ============================================================================
+
+resource "cloudflare_logpull_retention" "conditional_enabled" {
+  count = local.enable_feature ? 1 : 0
+
   zone_id = var.cloudflare_zone_id
   enabled = true
 }
 
-# Test Case 2: Logpull retention disabled
-resource "cloudflare_logpull_retention" "disabled_zone" {
+resource "cloudflare_logpull_retention" "conditional_disabled" {
+  count = local.enable_test ? 1 : 0
+
+  zone_id = var.cloudflare_zone_id
+  enabled = false  # Won't be created (local.enable_test = false)
+}
+
+# ============================================================================
+# Pattern Group 6: Terraform Functions
+# ============================================================================
+
+resource "cloudflare_logpull_retention" "with_functions" {
+  zone_id = var.cloudflare_zone_id
+  enabled = true
+}
+
+resource "cloudflare_logpull_retention" "with_interpolation" {
+  zone_id = "${var.cloudflare_zone_id}"  # String interpolation
+  enabled = false
+}
+
+# ============================================================================
+# Pattern Group 7: Lifecycle Meta-Arguments
+# ============================================================================
+
+resource "cloudflare_logpull_retention" "with_lifecycle" {
+  zone_id = var.cloudflare_zone_id
+  enabled = true
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "cloudflare_logpull_retention" "with_ignore_changes" {
+  zone_id = local.common_zone
+  enabled = false
+
+  lifecycle {
+    ignore_changes = [enabled]
+  }
+}
+
+resource "cloudflare_logpull_retention" "with_prevent_destroy" {
+  zone_id = var.cloudflare_zone_id
+  enabled = true
+
+  lifecycle {
+    prevent_destroy = false  # Set to false for testing
+  }
+}
+
+# ============================================================================
+# Pattern Group 8: Edge Cases
+# ============================================================================
+
+# Minimal resource (only required fields)
+resource "cloudflare_logpull_retention" "minimal" {
+  zone_id = var.cloudflare_zone_id
+  enabled = true
+}
+
+# Using locals reference
+resource "cloudflare_logpull_retention" "with_local" {
+  zone_id = local.common_zone
+  enabled = local.enable_feature
+}
+
+# Complex conditional expression
+resource "cloudflare_logpull_retention" "complex_conditional" {
+  zone_id = var.cloudflare_zone_id
+  enabled = local.enable_feature && !local.enable_test ? true : false
+}
+
+# ============================================================================
+# Pattern Group 9: Additional Real-World Patterns
+# ============================================================================
+
+# Testing enabled=true explicitly
+resource "cloudflare_logpull_retention" "enabled_explicit" {
+  zone_id = var.cloudflare_zone_id
+  enabled = true
+}
+
+# Testing enabled=false explicitly
+resource "cloudflare_logpull_retention" "disabled_explicit" {
   zone_id = var.cloudflare_zone_id
   enabled = false
 }
+
+# Using ternary operator
+resource "cloudflare_logpull_retention" "ternary_true" {
+  zone_id = var.cloudflare_zone_id
+  enabled = 1 == 1 ? true : false
+}
+
+resource "cloudflare_logpull_retention" "ternary_false" {
+  zone_id = var.cloudflare_zone_id
+  enabled = 1 == 2 ? true : false
+}
+
+# ============================================================================
+# Summary:
+# - Total resource declarations: 18
+# - Total instances created:
+#   - map_example: 4 instances
+#   - set_example: 4 instances
+#   - counted: 3 instances
+#   - conditional_enabled: 1 instance
+#   - conditional_disabled: 0 instances (count = 0)
+#   - Others: 11 instances
+#   TOTAL: 4 + 4 + 3 + 1 + 0 + 11 = 23 instances
+#
+# Patterns covered:
+# ✓ Variables (cloudflare_account_id, cloudflare_zone_id)
+# ✓ Locals (common_zone, enable_feature, enable_test)
+# ✓ for_each with maps (4 resources)
+# ✓ for_each with sets using toset() (4 resources)
+# ✓ count-based resources (3 resources)
+# ✓ Conditional creation with ternary operator
+# ✓ String interpolation
+# ✓ Lifecycle meta-arguments (create_before_destroy, ignore_changes, prevent_destroy)
+# ✓ Terraform functions (toset())
+# ✓ Edge cases (minimal config, complex conditionals)
+# ✓ Boolean values (both true and false)
+# ============================================================================

--- a/integration/v4_to_v5/testdata/logpull_retention/input/terraform.tfstate
+++ b/integration/v4_to_v5/testdata/logpull_retention/input/terraform.tfstate
@@ -8,14 +8,43 @@
     {
       "mode": "managed",
       "type": "cloudflare_logpull_retention",
-      "name": "enabled_zone",
+      "name": "map_example",
       "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "each": "map",
       "instances": [
         {
+          "index_key": "zone1",
           "schema_version": 0,
           "attributes": {
             "enabled": true,
-            "id": "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6",
+            "id": "map-zone1-id-a1b2c3d4",
+            "zone_id": "d56084adb405e0b7e32c52321bf07be6"
+          }
+        },
+        {
+          "index_key": "zone2",
+          "schema_version": 0,
+          "attributes": {
+            "enabled": false,
+            "id": "map-zone2-id-e5f6g7h8",
+            "zone_id": "d56084adb405e0b7e32c52321bf07be6"
+          }
+        },
+        {
+          "index_key": "zone3",
+          "schema_version": 0,
+          "attributes": {
+            "enabled": true,
+            "id": "map-zone3-id-i9j0k1l2",
+            "zone_id": "d56084adb405e0b7e32c52321bf07be6"
+          }
+        },
+        {
+          "index_key": "zone4",
+          "schema_version": 0,
+          "attributes": {
+            "enabled": false,
+            "id": "map-zone4-id-m3n4o5p6",
             "zone_id": "d56084adb405e0b7e32c52321bf07be6"
           }
         }
@@ -24,15 +53,288 @@
     {
       "mode": "managed",
       "type": "cloudflare_logpull_retention",
-      "name": "disabled_zone",
+      "name": "set_example",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "each": "set",
+      "instances": [
+        {
+          "index_key": "alpha",
+          "schema_version": 0,
+          "attributes": {
+            "enabled": true,
+            "id": "set-alpha-id-q7r8s9t0",
+            "zone_id": "d56084adb405e0b7e32c52321bf07be6"
+          }
+        },
+        {
+          "index_key": "beta",
+          "schema_version": 0,
+          "attributes": {
+            "enabled": false,
+            "id": "set-beta-id-u1v2w3x4",
+            "zone_id": "d56084adb405e0b7e32c52321bf07be6"
+          }
+        },
+        {
+          "index_key": "gamma",
+          "schema_version": 0,
+          "attributes": {
+            "enabled": true,
+            "id": "set-gamma-id-y5z6a7b8",
+            "zone_id": "d56084adb405e0b7e32c52321bf07be6"
+          }
+        },
+        {
+          "index_key": "delta",
+          "schema_version": 0,
+          "attributes": {
+            "enabled": false,
+            "id": "set-delta-id-c9d0e1f2",
+            "zone_id": "d56084adb405e0b7e32c52321bf07be6"
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_logpull_retention",
+      "name": "counted",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "index_key": 0,
+          "schema_version": 0,
+          "attributes": {
+            "enabled": true,
+            "id": "counted-0-id-g3h4i5j6",
+            "zone_id": "d56084adb405e0b7e32c52321bf07be6"
+          }
+        },
+        {
+          "index_key": 1,
+          "schema_version": 0,
+          "attributes": {
+            "enabled": false,
+            "id": "counted-1-id-k7l8m9n0",
+            "zone_id": "d56084adb405e0b7e32c52321bf07be6"
+          }
+        },
+        {
+          "index_key": 2,
+          "schema_version": 0,
+          "attributes": {
+            "enabled": true,
+            "id": "counted-2-id-o1p2q3r4",
+            "zone_id": "d56084adb405e0b7e32c52321bf07be6"
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_logpull_retention",
+      "name": "conditional_enabled",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "index_key": 0,
+          "schema_version": 0,
+          "attributes": {
+            "enabled": true,
+            "id": "conditional-enabled-id-s5t6u7v8",
+            "zone_id": "d56084adb405e0b7e32c52321bf07be6"
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_logpull_retention",
+      "name": "with_functions",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "enabled": true,
+            "id": "with-functions-id-w9x0y1z2",
+            "zone_id": "d56084adb405e0b7e32c52321bf07be6"
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_logpull_retention",
+      "name": "with_interpolation",
       "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
       "instances": [
         {
           "schema_version": 0,
           "attributes": {
             "enabled": false,
-            "id": "z9y8x7w6v5u4t3s2r1q0p9o8n7m6l5k4",
-            "zone_id": "023e105f4ecef8ad9ca31a8372d0c353"
+            "id": "with-interpolation-id-a3b4c5d6",
+            "zone_id": "d56084adb405e0b7e32c52321bf07be6"
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_logpull_retention",
+      "name": "with_lifecycle",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "enabled": true,
+            "id": "with-lifecycle-id-e7f8g9h0",
+            "zone_id": "d56084adb405e0b7e32c52321bf07be6"
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_logpull_retention",
+      "name": "with_ignore_changes",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "enabled": false,
+            "id": "with-ignore-changes-id-i1j2k3l4",
+            "zone_id": "d56084adb405e0b7e32c52321bf07be6"
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_logpull_retention",
+      "name": "with_prevent_destroy",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "enabled": true,
+            "id": "with-prevent-destroy-id-m5n6o7p8",
+            "zone_id": "d56084adb405e0b7e32c52321bf07be6"
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_logpull_retention",
+      "name": "minimal",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "enabled": true,
+            "id": "minimal-id-q9r0s1t2",
+            "zone_id": "d56084adb405e0b7e32c52321bf07be6"
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_logpull_retention",
+      "name": "with_local",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "enabled": true,
+            "id": "with-local-id-u3v4w5x6",
+            "zone_id": "d56084adb405e0b7e32c52321bf07be6"
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_logpull_retention",
+      "name": "complex_conditional",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "enabled": true,
+            "id": "complex-conditional-id-y7z8a9b0",
+            "zone_id": "d56084adb405e0b7e32c52321bf07be6"
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_logpull_retention",
+      "name": "enabled_explicit",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "enabled": true,
+            "id": "enabled-explicit-id-c1d2e3f4",
+            "zone_id": "d56084adb405e0b7e32c52321bf07be6"
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_logpull_retention",
+      "name": "disabled_explicit",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "enabled": false,
+            "id": "disabled-explicit-id-g5h6i7j8",
+            "zone_id": "d56084adb405e0b7e32c52321bf07be6"
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_logpull_retention",
+      "name": "ternary_true",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "enabled": true,
+            "id": "ternary-true-id-k9l0m1n2",
+            "zone_id": "d56084adb405e0b7e32c52321bf07be6"
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_logpull_retention",
+      "name": "ternary_false",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "enabled": false,
+            "id": "ternary-false-id-o3p4q5r6",
+            "zone_id": "d56084adb405e0b7e32c52321bf07be6"
           }
         }
       ]


### PR DESCRIPTION
Added comprehensive tests for e2e/integration tests for `logpull_retention` resource.

Additional Changes:
- added a helper to handle any renamed blocks in the lifecycle block.

Test run:
```
Running terraform plan in v5/...
⚠ Terraform plan shows changes
  Plan: 15 to add, 0 to change, 15 to destroy.

Detailed changes:

  # module.logpull_retention.cloudflare_logpull_retention.complex_conditional must be replaced

  # module.logpull_retention.cloudflare_logpull_retention.conditional_enabled[0] must be replaced

  # module.logpull_retention.cloudflare_logpull_retention.counted[0] must be replaced

  # module.logpull_retention.cloudflare_logpull_retention.counted[2] must be replaced

  # module.logpull_retention.cloudflare_logpull_retention.enabled_explicit must be replaced

  # module.logpull_retention.cloudflare_logpull_retention.map_example["zone1"] must be replaced

  # module.logpull_retention.cloudflare_logpull_retention.map_example["zone3"] must be replaced

  # module.logpull_retention.cloudflare_logpull_retention.minimal must be replaced

  # module.logpull_retention.cloudflare_logpull_retention.set_example["alpha"] must be replaced

  # module.logpull_retention.cloudflare_logpull_retention.set_example["gamma"] must be replaced

  # module.logpull_retention.cloudflare_logpull_retention.ternary_true must be replaced

  # module.logpull_retention.cloudflare_logpull_retention.with_functions must be replaced

  # module.logpull_retention.cloudflare_logpull_retention.with_lifecycle must be replaced

  # module.logpull_retention.cloudflare_logpull_retention.with_local must be replaced

  # module.logpull_retention.cloudflare_logpull_retention.with_prevent_destroy must be replaced


This may indicate the migration is not idempotent
```