### PR TITLE
add comprehensive tests for notification_policy_webhooks

### DIFF
--- a/integration/v4_to_v5/testdata/notification_policy_webhooks/expected/terraform.tfstate
+++ b/integration/v4_to_v5/testdata/notification_policy_webhooks/expected/terraform.tfstate
@@ -17,7 +17,7 @@
             "id": "f174e90a-fafe-4643-bbbc-4a0ed4fc8415",
             "account_id": "f037e56e89293a057740de681ac9abbe",
             "name": "basic-webhook",
-            "url": "https://example.com/webhook",
+            "url": "https://e2e-webhook-endpoint.terraform-testing-a09.workers.dev/basic",
             "secret": null,
             "type": "generic",
             "created_at": "2023-01-01T12:00:00Z",
@@ -39,7 +39,7 @@
             "id": "a284b91d-5fa5-4532-abcd-3b1ed5fc9527",
             "account_id": "f037e56e89293a057740de681ac9abbe",
             "name": "production-webhook",
-            "url": "https://alerts.example.com/notify",
+            "url": "https://e2e-webhook-endpoint.terraform-testing-a09.workers.dev/full",
             "secret": "webhook-secret-token-12345",
             "type": "generic",
             "created_at": "2023-01-01T12:00:00Z",
@@ -52,19 +52,118 @@
     {
       "mode": "managed",
       "type": "cloudflare_notification_policy_webhooks",
-      "name": "primary",
+      "name": "map_example",
       "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
       "instances": [
         {
+          "index_key": "alerts",
           "schema_version": 0,
           "attributes": {
-            "id": "c8e5d92e-6fb6-5643-bcde-4c2fe6ga0638",
+            "id": "map-alerts-webhook-id",
             "account_id": "f037e56e89293a057740de681ac9abbe",
-            "name": "primary-webhook",
-            "url": "https://primary.example.com/webhook",
+            "name": "alerts-webhook",
+            "url": "https://e2e-webhook-endpoint.terraform-testing-a09.workers.dev/alerts",
+            "secret": "alerts-secret-123",
+            "type": "generic",
+            "created_at": "2023-01-02T10:00:00Z",
+            "last_success": "2023-01-20T08:00:00Z",
+            "last_failure": null
+          }
+        },
+        {
+          "index_key": "monitoring",
+          "schema_version": 0,
+          "attributes": {
+            "id": "map-monitoring-webhook-id",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "name": "monitoring-webhook",
+            "url": "https://e2e-webhook-endpoint.terraform-testing-a09.workers.dev/monitoring",
+            "secret": "monitoring-secret-456",
+            "type": "generic",
+            "created_at": "2023-01-02T10:00:00Z",
+            "last_success": null,
+            "last_failure": "2023-01-18T12:00:00Z"
+          }
+        },
+        {
+          "index_key": "security",
+          "schema_version": 0,
+          "attributes": {
+            "id": "map-security-webhook-id",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "name": "security-webhook",
+            "url": "https://e2e-webhook-endpoint.terraform-testing-a09.workers.dev/security",
+            "secret": "security-secret-789",
+            "type": "generic",
+            "created_at": "2023-01-02T10:00:00Z",
+            "last_success": "2023-01-21T09:30:00Z",
+            "last_failure": null
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_notification_policy_webhooks",
+      "name": "set_example",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "index_key": "alpha",
+          "schema_version": 0,
+          "attributes": {
+            "id": "set-alpha-webhook-id",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "name": "set-alpha",
+            "url": "https://e2e-webhook-endpoint.terraform-testing-a09.workers.dev/set-alpha",
             "secret": null,
             "type": "generic",
-            "created_at": "2023-01-01T12:00:00Z",
+            "created_at": "2023-01-03T11:00:00Z",
+            "last_success": null,
+            "last_failure": null
+          }
+        },
+        {
+          "index_key": "beta",
+          "schema_version": 0,
+          "attributes": {
+            "id": "set-beta-webhook-id",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "name": "set-beta",
+            "url": "https://e2e-webhook-endpoint.terraform-testing-a09.workers.dev/set-beta",
+            "secret": null,
+            "type": "generic",
+            "created_at": "2023-01-03T11:00:00Z",
+            "last_success": null,
+            "last_failure": null
+          }
+        },
+        {
+          "index_key": "delta",
+          "schema_version": 0,
+          "attributes": {
+            "id": "set-delta-webhook-id",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "name": "set-delta",
+            "url": "https://e2e-webhook-endpoint.terraform-testing-a09.workers.dev/set-delta",
+            "secret": null,
+            "type": "generic",
+            "created_at": "2023-01-03T11:00:00Z",
+            "last_success": null,
+            "last_failure": null
+          }
+        },
+        {
+          "index_key": "gamma",
+          "schema_version": 0,
+          "attributes": {
+            "id": "set-gamma-webhook-id",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "name": "set-gamma",
+            "url": "https://e2e-webhook-endpoint.terraform-testing-a09.workers.dev/set-gamma",
+            "secret": null,
+            "type": "generic",
+            "created_at": "2023-01-03T11:00:00Z",
             "last_success": null,
             "last_failure": null
           }
@@ -74,19 +173,205 @@
     {
       "mode": "managed",
       "type": "cloudflare_notification_policy_webhooks",
-      "name": "backup",
+      "name": "counted",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "index_key": 0,
+          "schema_version": 0,
+          "attributes": {
+            "id": "counted-0-webhook-id",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "name": "webhook-0",
+            "url": "https://e2e-webhook-endpoint.terraform-testing-a09.workers.dev/counted-0",
+            "secret": null,
+            "type": "generic",
+            "created_at": "2023-01-04T12:00:00Z",
+            "last_success": null,
+            "last_failure": null
+          }
+        },
+        {
+          "index_key": 1,
+          "schema_version": 0,
+          "attributes": {
+            "id": "counted-1-webhook-id",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "name": "webhook-1",
+            "url": "https://e2e-webhook-endpoint.terraform-testing-a09.workers.dev/counted-1",
+            "secret": null,
+            "type": "generic",
+            "created_at": "2023-01-04T12:00:00Z",
+            "last_success": null,
+            "last_failure": null
+          }
+        },
+        {
+          "index_key": 2,
+          "schema_version": 0,
+          "attributes": {
+            "id": "counted-2-webhook-id",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "name": "webhook-2",
+            "url": "https://e2e-webhook-endpoint.terraform-testing-a09.workers.dev/counted-2",
+            "secret": null,
+            "type": "generic",
+            "created_at": "2023-01-04T12:00:00Z",
+            "last_success": null,
+            "last_failure": null
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_notification_policy_webhooks",
+      "name": "conditional_enabled",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "index_key": 0,
+          "schema_version": 0,
+          "attributes": {
+            "id": "conditional-enabled-webhook-id",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "name": "conditional-enabled",
+            "url": "https://e2e-webhook-endpoint.terraform-testing-a09.workers.dev/conditional-enabled",
+            "secret": null,
+            "type": "generic",
+            "created_at": "2023-01-05T13:00:00Z",
+            "last_success": null,
+            "last_failure": null
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_notification_policy_webhooks",
+      "name": "with_functions",
       "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
       "instances": [
         {
           "schema_version": 0,
           "attributes": {
-            "id": "d9f6ea3f-7gc7-6754-cdef-5d3gf7hb1749",
+            "id": "functions-webhook-id",
             "account_id": "f037e56e89293a057740de681ac9abbe",
-            "name": "backup-webhook",
-            "url": "https://backup.example.com/webhook",
-            "secret": "backup-secret",
+            "name": "test-integration-function-example",
+            "url": "https://e2e-webhook-endpoint.terraform-testing-a09.workers.dev/function-test",
+            "secret": "function-test-secret",
             "type": "generic",
-            "created_at": "2023-01-01T12:00:00Z",
+            "created_at": "2023-01-06T14:00:00Z",
+            "last_success": null,
+            "last_failure": null
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_notification_policy_webhooks",
+      "name": "with_lifecycle",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "lifecycle-webhook-id",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "name": "lifecycle-test",
+            "url": "https://e2e-webhook-endpoint.terraform-testing-a09.workers.dev/lifecycle",
+            "secret": null,
+            "type": "generic",
+            "created_at": "2023-01-07T15:00:00Z",
+            "last_success": null,
+            "last_failure": null
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_notification_policy_webhooks",
+      "name": "with_prevent_destroy",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "prevent-destroy-webhook-id",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "name": "prevent-destroy-test",
+            "url": "https://e2e-webhook-endpoint.terraform-testing-a09.workers.dev/prevent-destroy",
+            "secret": null,
+            "type": "generic",
+            "created_at": "2023-01-07T15:30:00Z",
+            "last_success": null,
+            "last_failure": null
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_notification_policy_webhooks",
+      "name": "minimal",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "minimal-webhook-id",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "name": "minimal",
+            "url": "https://e2e-webhook-endpoint.terraform-testing-a09.workers.dev/minimal",
+            "secret": null,
+            "type": "generic",
+            "created_at": "2023-01-08T16:00:00Z",
+            "last_success": null,
+            "last_failure": null
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_notification_policy_webhooks",
+      "name": "maximal",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "maximal-webhook-id",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "name": "maximal-webhook-with-all-fields",
+            "url": "https://e2e-webhook-endpoint.terraform-testing-a09.workers.dev/maximal?param=value&test=123",
+            "secret": "maximal-secret-token-with-special-chars-!@#$",
+            "type": "generic",
+            "created_at": "2023-01-09T17:00:00Z",
+            "last_success": "2023-01-25T10:00:00Z",
+            "last_failure": "2023-01-22T14:00:00Z"
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_notification_policy_webhooks",
+      "name": "special_chars",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "special-chars-webhook-id",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "name": "special-chars-test",
+            "url": "https://e2e-webhook-endpoint.terraform-testing-a09.workers.dev/path?query=value&param=test",
+            "secret": null,
+            "type": "generic",
+            "created_at": "2023-01-10T18:00:00Z",
             "last_success": null,
             "last_failure": null
           }

--- a/integration/v4_to_v5/testdata/notification_policy_webhooks/input/notification_policy_webhooks.tf
+++ b/integration/v4_to_v5/testdata/notification_policy_webhooks/input/notification_policy_webhooks.tf
@@ -1,3 +1,6 @@
+# ========================================
+# Variables
+# ========================================
 variable "cloudflare_account_id" {
   description = "Cloudflare account ID"
   type        = string
@@ -12,31 +15,162 @@ variable "cloudflare_zone_id" {
 # Worker URL: https://e2e-webhook-endpoint.terraform-testing-a09.workers.dev/
 # This worker responds with 200 OK to all requests for webhook validation
 
+# ========================================
+# Locals
+# ========================================
+locals {
+  common_account = var.cloudflare_account_id
+  name_prefix    = "test-integration"
+  webhook_base_url = "https://e2e-webhook-endpoint.terraform-testing-a09.workers.dev"
+  enable_backup    = true
+  enable_test      = false
+}
+
+# ========================================
+# Basic Resources
+# ========================================
+
 # Test Case 1: Basic webhook with minimal fields
 resource "cloudflare_notification_policy_webhooks" "basic_webhook" {
-    account_id = var.cloudflare_account_id
-    name       = "basic-webhook"
-    url        = "https://e2e-webhook-endpoint.terraform-testing-a09.workers.dev/basic"
+  account_id = var.cloudflare_account_id
+  name       = "basic-webhook"
+  url        = "https://e2e-webhook-endpoint.terraform-testing-a09.workers.dev/basic"
 }
 
 # Test Case 2: Full webhook with all fields
 resource "cloudflare_notification_policy_webhooks" "full_webhook" {
-    account_id = var.cloudflare_account_id
-    name       = "production-webhook"
-    url        = "https://e2e-webhook-endpoint.terraform-testing-a09.workers.dev/full"
-    secret     = "webhook-secret-token-12345"
+  account_id = var.cloudflare_account_id
+  name       = "production-webhook"
+  url        = "https://e2e-webhook-endpoint.terraform-testing-a09.workers.dev/full"
+  secret     = "webhook-secret-token-12345"
 }
 
-# Test Case 3: Multiple webhooks
-resource "cloudflare_notification_policy_webhooks" "primary" {
-    account_id = var.cloudflare_account_id
-    name       = "primary-webhook"
-    url        = "https://e2e-webhook-endpoint.terraform-testing-a09.workers.dev/primary"
+# ========================================
+# for_each with Maps Pattern (3 resources)
+# ========================================
+resource "cloudflare_notification_policy_webhooks" "map_example" {
+  for_each = {
+    "alerts" = {
+      name   = "alerts-webhook"
+      secret = "alerts-secret-123"
+    }
+    "monitoring" = {
+      name   = "monitoring-webhook"
+      secret = "monitoring-secret-456"
+    }
+    "security" = {
+      name   = "security-webhook"
+      secret = "security-secret-789"
+    }
+  }
+
+  account_id = local.common_account
+  name       = each.value.name
+  url        = "${local.webhook_base_url}/${each.key}"
+  secret     = each.value.secret
 }
 
-resource "cloudflare_notification_policy_webhooks" "backup" {
-    account_id = var.cloudflare_account_id
-    name       = "backup-webhook"
-    url        = "https://e2e-webhook-endpoint.terraform-testing-a09.workers.dev/backup"
-    secret     = "backup-secret"
+# ========================================
+# for_each with Sets Pattern (4 resources)
+# ========================================
+resource "cloudflare_notification_policy_webhooks" "set_example" {
+  for_each = toset([
+    "alpha",
+    "beta",
+    "gamma",
+    "delta"
+  ])
+
+  account_id = var.cloudflare_account_id
+  name       = "set-${each.value}"
+  url        = "${local.webhook_base_url}/set-${each.value}"
+}
+
+# ========================================
+# count-based Resources (3 resources)
+# ========================================
+resource "cloudflare_notification_policy_webhooks" "counted" {
+  count = 3
+
+  account_id = var.cloudflare_account_id
+  name       = "webhook-${count.index}"
+  url        = "${local.webhook_base_url}/counted-${count.index}"
+}
+
+# ========================================
+# Conditional Creation
+# ========================================
+resource "cloudflare_notification_policy_webhooks" "conditional_enabled" {
+  count = local.enable_backup ? 1 : 0
+
+  account_id = var.cloudflare_account_id
+  name       = "conditional-enabled"
+  url        = "${local.webhook_base_url}/conditional-enabled"
+}
+
+resource "cloudflare_notification_policy_webhooks" "conditional_disabled" {
+  count = local.enable_test ? 1 : 0
+
+  account_id = var.cloudflare_account_id
+  name       = "conditional-disabled"
+  url        = "${local.webhook_base_url}/conditional-disabled"
+}
+
+# ========================================
+# Terraform Functions
+# ========================================
+resource "cloudflare_notification_policy_webhooks" "with_functions" {
+  account_id = local.common_account
+  name       = join("-", [local.name_prefix, "function", "example"])
+  url        = "${local.webhook_base_url}/function-test"
+  secret     = "function-test-secret"
+}
+
+# ========================================
+# Lifecycle Meta-Arguments
+# ========================================
+resource "cloudflare_notification_policy_webhooks" "with_lifecycle" {
+  account_id = var.cloudflare_account_id
+  name       = "lifecycle-test"
+  url        = "${local.webhook_base_url}/lifecycle"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "cloudflare_notification_policy_webhooks" "with_prevent_destroy" {
+  account_id = var.cloudflare_account_id
+  name       = "prevent-destroy-test"
+  url        = "${local.webhook_base_url}/prevent-destroy"
+
+  lifecycle {
+    prevent_destroy = false
+  }
+}
+
+# ========================================
+# Edge Cases
+# ========================================
+
+# Minimal resource (only required fields)
+resource "cloudflare_notification_policy_webhooks" "minimal" {
+  account_id = var.cloudflare_account_id
+  name       = "minimal"
+  url        = "${local.webhook_base_url}/minimal"
+}
+
+# Maximal resource (all fields populated)
+resource "cloudflare_notification_policy_webhooks" "maximal" {
+  account_id = var.cloudflare_account_id
+  name       = "maximal-webhook-with-all-fields"
+  url        = "${local.webhook_base_url}/maximal?param=value&test=123"
+  secret     = "maximal-secret-token-with-special-chars-!@#$"
+}
+
+# URL with special characters
+resource "cloudflare_notification_policy_webhooks" "special_chars" {
+  account_id = var.cloudflare_account_id
+  name       = "special-chars-test"
+  url        = "${local.webhook_base_url}/path?query=value&param=test"
 }

--- a/integration/v4_to_v5/testdata/notification_policy_webhooks/input/terraform.tfstate
+++ b/integration/v4_to_v5/testdata/notification_policy_webhooks/input/terraform.tfstate
@@ -17,7 +17,7 @@
             "id": "f174e90a-fafe-4643-bbbc-4a0ed4fc8415",
             "account_id": "f037e56e89293a057740de681ac9abbe",
             "name": "basic-webhook",
-            "url": "https://example.com/webhook",
+            "url": "https://e2e-webhook-endpoint.terraform-testing-a09.workers.dev/basic",
             "secret": null,
             "type": "generic",
             "created_at": "2023-01-01T12:00:00Z",
@@ -39,7 +39,7 @@
             "id": "a284b91d-5fa5-4532-abcd-3b1ed5fc9527",
             "account_id": "f037e56e89293a057740de681ac9abbe",
             "name": "production-webhook",
-            "url": "https://alerts.example.com/notify",
+            "url": "https://e2e-webhook-endpoint.terraform-testing-a09.workers.dev/full",
             "secret": "webhook-secret-token-12345",
             "type": "generic",
             "created_at": "2023-01-01T12:00:00Z",
@@ -52,19 +52,118 @@
     {
       "mode": "managed",
       "type": "cloudflare_notification_policy_webhooks",
-      "name": "primary",
+      "name": "map_example",
       "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
       "instances": [
         {
+          "index_key": "alerts",
           "schema_version": 0,
           "attributes": {
-            "id": "c8e5d92e-6fb6-5643-bcde-4c2fe6ga0638",
+            "id": "map-alerts-webhook-id",
             "account_id": "f037e56e89293a057740de681ac9abbe",
-            "name": "primary-webhook",
-            "url": "https://primary.example.com/webhook",
+            "name": "alerts-webhook",
+            "url": "https://e2e-webhook-endpoint.terraform-testing-a09.workers.dev/alerts",
+            "secret": "alerts-secret-123",
+            "type": "generic",
+            "created_at": "2023-01-02T10:00:00Z",
+            "last_success": "2023-01-20T08:00:00Z",
+            "last_failure": null
+          }
+        },
+        {
+          "index_key": "monitoring",
+          "schema_version": 0,
+          "attributes": {
+            "id": "map-monitoring-webhook-id",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "name": "monitoring-webhook",
+            "url": "https://e2e-webhook-endpoint.terraform-testing-a09.workers.dev/monitoring",
+            "secret": "monitoring-secret-456",
+            "type": "generic",
+            "created_at": "2023-01-02T10:00:00Z",
+            "last_success": null,
+            "last_failure": "2023-01-18T12:00:00Z"
+          }
+        },
+        {
+          "index_key": "security",
+          "schema_version": 0,
+          "attributes": {
+            "id": "map-security-webhook-id",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "name": "security-webhook",
+            "url": "https://e2e-webhook-endpoint.terraform-testing-a09.workers.dev/security",
+            "secret": "security-secret-789",
+            "type": "generic",
+            "created_at": "2023-01-02T10:00:00Z",
+            "last_success": "2023-01-21T09:30:00Z",
+            "last_failure": null
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_notification_policy_webhooks",
+      "name": "set_example",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "index_key": "alpha",
+          "schema_version": 0,
+          "attributes": {
+            "id": "set-alpha-webhook-id",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "name": "set-alpha",
+            "url": "https://e2e-webhook-endpoint.terraform-testing-a09.workers.dev/set-alpha",
             "secret": null,
             "type": "generic",
-            "created_at": "2023-01-01T12:00:00Z",
+            "created_at": "2023-01-03T11:00:00Z",
+            "last_success": null,
+            "last_failure": null
+          }
+        },
+        {
+          "index_key": "beta",
+          "schema_version": 0,
+          "attributes": {
+            "id": "set-beta-webhook-id",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "name": "set-beta",
+            "url": "https://e2e-webhook-endpoint.terraform-testing-a09.workers.dev/set-beta",
+            "secret": null,
+            "type": "generic",
+            "created_at": "2023-01-03T11:00:00Z",
+            "last_success": null,
+            "last_failure": null
+          }
+        },
+        {
+          "index_key": "delta",
+          "schema_version": 0,
+          "attributes": {
+            "id": "set-delta-webhook-id",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "name": "set-delta",
+            "url": "https://e2e-webhook-endpoint.terraform-testing-a09.workers.dev/set-delta",
+            "secret": null,
+            "type": "generic",
+            "created_at": "2023-01-03T11:00:00Z",
+            "last_success": null,
+            "last_failure": null
+          }
+        },
+        {
+          "index_key": "gamma",
+          "schema_version": 0,
+          "attributes": {
+            "id": "set-gamma-webhook-id",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "name": "set-gamma",
+            "url": "https://e2e-webhook-endpoint.terraform-testing-a09.workers.dev/set-gamma",
+            "secret": null,
+            "type": "generic",
+            "created_at": "2023-01-03T11:00:00Z",
             "last_success": null,
             "last_failure": null
           }
@@ -74,19 +173,205 @@
     {
       "mode": "managed",
       "type": "cloudflare_notification_policy_webhooks",
-      "name": "backup",
+      "name": "counted",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "index_key": 0,
+          "schema_version": 0,
+          "attributes": {
+            "id": "counted-0-webhook-id",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "name": "webhook-0",
+            "url": "https://e2e-webhook-endpoint.terraform-testing-a09.workers.dev/counted-0",
+            "secret": null,
+            "type": "generic",
+            "created_at": "2023-01-04T12:00:00Z",
+            "last_success": null,
+            "last_failure": null
+          }
+        },
+        {
+          "index_key": 1,
+          "schema_version": 0,
+          "attributes": {
+            "id": "counted-1-webhook-id",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "name": "webhook-1",
+            "url": "https://e2e-webhook-endpoint.terraform-testing-a09.workers.dev/counted-1",
+            "secret": null,
+            "type": "generic",
+            "created_at": "2023-01-04T12:00:00Z",
+            "last_success": null,
+            "last_failure": null
+          }
+        },
+        {
+          "index_key": 2,
+          "schema_version": 0,
+          "attributes": {
+            "id": "counted-2-webhook-id",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "name": "webhook-2",
+            "url": "https://e2e-webhook-endpoint.terraform-testing-a09.workers.dev/counted-2",
+            "secret": null,
+            "type": "generic",
+            "created_at": "2023-01-04T12:00:00Z",
+            "last_success": null,
+            "last_failure": null
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_notification_policy_webhooks",
+      "name": "conditional_enabled",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "index_key": 0,
+          "schema_version": 0,
+          "attributes": {
+            "id": "conditional-enabled-webhook-id",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "name": "conditional-enabled",
+            "url": "https://e2e-webhook-endpoint.terraform-testing-a09.workers.dev/conditional-enabled",
+            "secret": null,
+            "type": "generic",
+            "created_at": "2023-01-05T13:00:00Z",
+            "last_success": null,
+            "last_failure": null
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_notification_policy_webhooks",
+      "name": "with_functions",
       "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
       "instances": [
         {
           "schema_version": 0,
           "attributes": {
-            "id": "d9f6ea3f-7gc7-6754-cdef-5d3gf7hb1749",
+            "id": "functions-webhook-id",
             "account_id": "f037e56e89293a057740de681ac9abbe",
-            "name": "backup-webhook",
-            "url": "https://backup.example.com/webhook",
-            "secret": "backup-secret",
+            "name": "test-integration-function-example",
+            "url": "https://e2e-webhook-endpoint.terraform-testing-a09.workers.dev/function-test",
+            "secret": "function-test-secret",
             "type": "generic",
-            "created_at": "2023-01-01T12:00:00Z",
+            "created_at": "2023-01-06T14:00:00Z",
+            "last_success": null,
+            "last_failure": null
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_notification_policy_webhooks",
+      "name": "with_lifecycle",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "lifecycle-webhook-id",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "name": "lifecycle-test",
+            "url": "https://e2e-webhook-endpoint.terraform-testing-a09.workers.dev/lifecycle",
+            "secret": null,
+            "type": "generic",
+            "created_at": "2023-01-07T15:00:00Z",
+            "last_success": null,
+            "last_failure": null
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_notification_policy_webhooks",
+      "name": "with_prevent_destroy",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "prevent-destroy-webhook-id",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "name": "prevent-destroy-test",
+            "url": "https://e2e-webhook-endpoint.terraform-testing-a09.workers.dev/prevent-destroy",
+            "secret": null,
+            "type": "generic",
+            "created_at": "2023-01-07T15:30:00Z",
+            "last_success": null,
+            "last_failure": null
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_notification_policy_webhooks",
+      "name": "minimal",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "minimal-webhook-id",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "name": "minimal",
+            "url": "https://e2e-webhook-endpoint.terraform-testing-a09.workers.dev/minimal",
+            "secret": null,
+            "type": "generic",
+            "created_at": "2023-01-08T16:00:00Z",
+            "last_success": null,
+            "last_failure": null
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_notification_policy_webhooks",
+      "name": "maximal",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "maximal-webhook-id",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "name": "maximal-webhook-with-all-fields",
+            "url": "https://e2e-webhook-endpoint.terraform-testing-a09.workers.dev/maximal?param=value&test=123",
+            "secret": "maximal-secret-token-with-special-chars-!@#$",
+            "type": "generic",
+            "created_at": "2023-01-09T17:00:00Z",
+            "last_success": "2023-01-25T10:00:00Z",
+            "last_failure": "2023-01-22T14:00:00Z"
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_notification_policy_webhooks",
+      "name": "special_chars",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "special-chars-webhook-id",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "name": "special-chars-test",
+            "url": "https://e2e-webhook-endpoint.terraform-testing-a09.workers.dev/path?query=value&param=test",
+            "secret": null,
+            "type": "generic",
+            "created_at": "2023-01-10T18:00:00Z",
             "last_success": null,
             "last_failure": null
           }


### PR DESCRIPTION
Added comprehensive tests for e2e/integration tests for `notification_policy_webhooks` resource.

Test run:
```
Running terraform plan in v5/...
✓ Terraform plan shows no changes (expected)
Running terraform apply in v5/...
✓ Terraform apply successful
```