### PR TITLE
fix: add v4 to v5 integration tests for workers_kv, workers_kv_namespace, r2_bucket

### DIFF
--- a/integration/v4_to_v5/testdata/r2_bucket/expected/r2_bucket.tf
+++ b/integration/v4_to_v5/testdata/r2_bucket/expected/r2_bucket.tf
@@ -1,3 +1,6 @@
+# ============================================================================
+# Standard Variables (Auto-provided by test infrastructure)
+# ============================================================================
 variable "cloudflare_account_id" {
   description = "Cloudflare account ID"
   type        = string
@@ -8,40 +11,203 @@ variable "cloudflare_zone_id" {
   type        = string
 }
 
-# Test Case 1: Basic R2 bucket with required fields only
-resource "cloudflare_r2_bucket" "basic" {
-  account_id = var.cloudflare_account_id
-  name       = "test-bucket"
+# ============================================================================
+# Pattern Group 1: Locals for Common Values
+# ============================================================================
+locals {
+  common_account = var.cloudflare_account_id
+  name_prefix    = "test-integration"
+  locations = {
+    "wnam" = "WNAM"
+    "enam" = "ENAM"
+    "weur" = "WEUR"
+    "eeur" = "EEUR"
+    "apac" = "APAC"
+    "oc"   = "OC"
+  }
+  enable_feature = true
+  enable_test    = false
 }
 
-# Test Case 2: R2 bucket with location (uppercase - v4 style)
-resource "cloudflare_r2_bucket" "with_location_upper" {
+# ============================================================================
+# Pattern Group 2: Basic Resource Configurations
+# ============================================================================
+
+# Test Case 1: Minimal bucket with only required fields
+resource "cloudflare_r2_bucket" "minimal" {
+  account_id = var.cloudflare_account_id
+  name       = "minimal-bucket"
+}
+
+# Test Case 2: Bucket with all locations tested
+resource "cloudflare_r2_bucket" "location_wnam" {
   account_id = var.cloudflare_account_id
   name       = "bucket-wnam"
   location   = "WNAM"
 }
 
-# Test Case 3: R2 bucket with location (must be uppercase)
-resource "cloudflare_r2_bucket" "with_location_lower" {
+resource "cloudflare_r2_bucket" "location_enam" {
+  account_id = var.cloudflare_account_id
+  name       = "bucket-enam"
+  location   = "ENAM"
+}
+
+resource "cloudflare_r2_bucket" "location_weur" {
+  account_id = var.cloudflare_account_id
+  name       = "bucket-weur"
+  location   = "WEUR"
+}
+
+resource "cloudflare_r2_bucket" "location_eeur" {
   account_id = var.cloudflare_account_id
   name       = "bucket-eeur"
   location   = "EEUR"
 }
 
-# Test Case 4: R2 bucket with variable reference
-resource "cloudflare_r2_bucket" "with_variable" {
+resource "cloudflare_r2_bucket" "location_apac" {
   account_id = var.cloudflare_account_id
-  name       = "variable-bucket"
-}
-
-# Test Case 5: Multiple buckets with different configs
-resource "cloudflare_r2_bucket" "multi1" {
-  account_id = var.cloudflare_account_id
-  name       = "multi-bucket-1"
-}
-
-resource "cloudflare_r2_bucket" "multi2" {
-  account_id = var.cloudflare_account_id
-  name       = "multi-bucket-2"
+  name       = "bucket-apac"
   location   = "APAC"
+}
+
+resource "cloudflare_r2_bucket" "location_oc" {
+  account_id = var.cloudflare_account_id
+  name       = "bucket-oc"
+  location   = "OC"
+}
+
+# ============================================================================
+# Pattern Group 3: for_each with Maps
+# ============================================================================
+
+resource "cloudflare_r2_bucket" "map_example" {
+  for_each = {
+    "data" = {
+      name     = "data-bucket"
+      location = "WNAM"
+    }
+    "logs" = {
+      name     = "logs-bucket"
+      location = "ENAM"
+    }
+    "backups" = {
+      name     = "backups-bucket"
+      location = "WEUR"
+    }
+  }
+
+  account_id = var.cloudflare_account_id
+  name       = each.value.name
+  location   = each.value.location
+}
+
+# ============================================================================
+# Pattern Group 4: for_each with Sets
+# ============================================================================
+
+resource "cloudflare_r2_bucket" "set_example" {
+  for_each = toset([
+    "alpha",
+    "beta",
+    "gamma",
+    "delta",
+  ])
+
+  account_id = var.cloudflare_account_id
+  name       = "set-${each.value}-bucket"
+}
+
+# ============================================================================
+# Pattern Group 5: count-based Resources
+# ============================================================================
+
+resource "cloudflare_r2_bucket" "counted" {
+  count = 3
+
+  account_id = var.cloudflare_account_id
+  name       = "counted-bucket-${count.index}"
+  location   = count.index == 0 ? "WNAM" : count.index == 1 ? "EEUR" : "APAC"
+}
+
+# ============================================================================
+# Pattern Group 6: Conditional Creation
+# ============================================================================
+
+resource "cloudflare_r2_bucket" "conditional_enabled" {
+  count = local.enable_feature ? 1 : 0
+
+  account_id = var.cloudflare_account_id
+  name       = "conditional-enabled-bucket"
+  location   = "WNAM"
+}
+
+resource "cloudflare_r2_bucket" "conditional_disabled" {
+  count = local.enable_test ? 1 : 0
+
+  account_id = var.cloudflare_account_id
+  name       = "conditional-disabled-bucket"
+  location   = "EEUR"
+}
+
+# ============================================================================
+# Pattern Group 7: Terraform Functions
+# ============================================================================
+
+resource "cloudflare_r2_bucket" "with_functions" {
+  account_id = var.cloudflare_account_id
+  name       = join("-", [local.name_prefix, "function", "test"])
+  location   = lookup(local.locations, "wnam", "WNAM")
+}
+
+resource "cloudflare_r2_bucket" "with_interpolation" {
+  account_id = local.common_account
+  name       = "${local.name_prefix}-interpolated-bucket"
+  location   = local.locations["eeur"]
+}
+
+# ============================================================================
+# Pattern Group 8: Lifecycle Meta-Arguments
+# ============================================================================
+
+resource "cloudflare_r2_bucket" "with_lifecycle" {
+  account_id = var.cloudflare_account_id
+  name       = "lifecycle-test-bucket"
+  location   = "WNAM"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "cloudflare_r2_bucket" "with_prevent_destroy" {
+  account_id = var.cloudflare_account_id
+  name       = "prevent-destroy-bucket"
+  location   = "EEUR"
+
+  lifecycle {
+    prevent_destroy = false
+  }
+}
+
+# ============================================================================
+# Pattern Group 9: Edge Cases
+# ============================================================================
+
+# Special characters in bucket names (hyphens and numbers)
+resource "cloudflare_r2_bucket" "special_chars" {
+  account_id = var.cloudflare_account_id
+  name       = "bucket-with-dashes-and-numbers-123"
+}
+
+# Long bucket name (testing near max length - 63 chars max)
+resource "cloudflare_r2_bucket" "long_name" {
+  account_id = var.cloudflare_account_id
+  name       = "very-long-bucket-name-for-testing-migration-limits-max-len"
+}
+
+# Bucket name with all allowed characters (lowercase, numbers, hyphens)
+resource "cloudflare_r2_bucket" "all_chars" {
+  account_id = var.cloudflare_account_id
+  name       = "bucket-name-with-all-valid-chars-123-test"
+  location   = "WNAM"
 }

--- a/integration/v4_to_v5/testdata/r2_bucket/expected/terraform.tfstate
+++ b/integration/v4_to_v5/testdata/r2_bucket/expected/terraform.tfstate
@@ -8,15 +8,15 @@
     {
       "mode": "managed",
       "type": "cloudflare_r2_bucket",
-      "name": "basic",
+      "name": "minimal",
       "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
       "instances": [
         {
           "schema_version": 0,
           "attributes": {
-            "id": "test-bucket",
+            "id": "minimal-bucket",
             "account_id": "f037e56e89293a057740de681ac9abbe",
-            "name": "test-bucket",
+            "name": "minimal-bucket",
             "jurisdiction": "default",
             "storage_class": "Standard"
           }
@@ -26,7 +26,7 @@
     {
       "mode": "managed",
       "type": "cloudflare_r2_bucket",
-      "name": "with_location_upper",
+      "name": "location_wnam",
       "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
       "instances": [
         {
@@ -45,7 +45,45 @@
     {
       "mode": "managed",
       "type": "cloudflare_r2_bucket",
-      "name": "with_location_lower",
+      "name": "location_enam",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "bucket-enam",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "name": "bucket-enam",
+            "location": "ENAM",
+            "jurisdiction": "default",
+            "storage_class": "Standard"
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_r2_bucket",
+      "name": "location_weur",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "bucket-weur",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "name": "bucket-weur",
+            "location": "WEUR",
+            "jurisdiction": "default",
+            "storage_class": "Standard"
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_r2_bucket",
+      "name": "location_eeur",
       "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
       "instances": [
         {
@@ -54,7 +92,7 @@
             "id": "bucket-eeur",
             "account_id": "f037e56e89293a057740de681ac9abbe",
             "name": "bucket-eeur",
-            "location": "eeur",
+            "location": "EEUR",
             "jurisdiction": "default",
             "storage_class": "Standard"
           }
@@ -64,52 +102,326 @@
     {
       "mode": "managed",
       "type": "cloudflare_r2_bucket",
-      "name": "with_variable",
+      "name": "location_apac",
       "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
       "instances": [
         {
           "schema_version": 0,
           "attributes": {
-            "id": "variable-bucket",
+            "id": "bucket-apac",
             "account_id": "f037e56e89293a057740de681ac9abbe",
-            "name": "variable-bucket",
-            "jurisdiction": "default",
-            "storage_class": "Standard"
-          }
-        }
-      ]
-    },
-    {
-      "mode": "managed",
-      "type": "cloudflare_r2_bucket",
-      "name": "multi1",
-      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
-      "instances": [
-        {
-          "schema_version": 0,
-          "attributes": {
-            "id": "multi-bucket-1",
-            "account_id": "f037e56e89293a057740de681ac9abbe",
-            "name": "multi-bucket-1",
-            "jurisdiction": "default",
-            "storage_class": "Standard"
-          }
-        }
-      ]
-    },
-    {
-      "mode": "managed",
-      "type": "cloudflare_r2_bucket",
-      "name": "multi2",
-      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
-      "instances": [
-        {
-          "schema_version": 0,
-          "attributes": {
-            "id": "multi-bucket-2",
-            "account_id": "f037e56e89293a057740de681ac9abbe",
-            "name": "multi-bucket-2",
+            "name": "bucket-apac",
             "location": "APAC",
+            "jurisdiction": "default",
+            "storage_class": "Standard"
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_r2_bucket",
+      "name": "location_oc",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "bucket-oc",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "name": "bucket-oc",
+            "location": "OC",
+            "jurisdiction": "default",
+            "storage_class": "Standard"
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_r2_bucket",
+      "name": "map_example",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "index_key": "backups",
+          "schema_version": 0,
+          "attributes": {
+            "id": "backups-bucket",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "name": "backups-bucket",
+            "location": "WEUR",
+            "jurisdiction": "default",
+            "storage_class": "Standard"
+          }
+        },
+        {
+          "index_key": "data",
+          "schema_version": 0,
+          "attributes": {
+            "id": "data-bucket",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "name": "data-bucket",
+            "location": "WNAM",
+            "jurisdiction": "default",
+            "storage_class": "Standard"
+          }
+        },
+        {
+          "index_key": "logs",
+          "schema_version": 0,
+          "attributes": {
+            "id": "logs-bucket",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "name": "logs-bucket",
+            "location": "ENAM",
+            "jurisdiction": "default",
+            "storage_class": "Standard"
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_r2_bucket",
+      "name": "set_example",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "index_key": "alpha",
+          "schema_version": 0,
+          "attributes": {
+            "id": "set-alpha-bucket",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "name": "set-alpha-bucket",
+            "jurisdiction": "default",
+            "storage_class": "Standard"
+          }
+        },
+        {
+          "index_key": "beta",
+          "schema_version": 0,
+          "attributes": {
+            "id": "set-beta-bucket",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "name": "set-beta-bucket",
+            "jurisdiction": "default",
+            "storage_class": "Standard"
+          }
+        },
+        {
+          "index_key": "delta",
+          "schema_version": 0,
+          "attributes": {
+            "id": "set-delta-bucket",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "name": "set-delta-bucket",
+            "jurisdiction": "default",
+            "storage_class": "Standard"
+          }
+        },
+        {
+          "index_key": "gamma",
+          "schema_version": 0,
+          "attributes": {
+            "id": "set-gamma-bucket",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "name": "set-gamma-bucket",
+            "jurisdiction": "default",
+            "storage_class": "Standard"
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_r2_bucket",
+      "name": "counted",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "index": 0,
+          "schema_version": 0,
+          "attributes": {
+            "id": "counted-bucket-0",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "name": "counted-bucket-0",
+            "location": "WNAM",
+            "jurisdiction": "default",
+            "storage_class": "Standard"
+          }
+        },
+        {
+          "index": 1,
+          "schema_version": 0,
+          "attributes": {
+            "id": "counted-bucket-1",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "name": "counted-bucket-1",
+            "location": "EEUR",
+            "jurisdiction": "default",
+            "storage_class": "Standard"
+          }
+        },
+        {
+          "index": 2,
+          "schema_version": 0,
+          "attributes": {
+            "id": "counted-bucket-2",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "name": "counted-bucket-2",
+            "location": "APAC",
+            "jurisdiction": "default",
+            "storage_class": "Standard"
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_r2_bucket",
+      "name": "conditional_enabled",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "index": 0,
+          "schema_version": 0,
+          "attributes": {
+            "id": "conditional-enabled-bucket",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "name": "conditional-enabled-bucket",
+            "location": "WNAM",
+            "jurisdiction": "default",
+            "storage_class": "Standard"
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_r2_bucket",
+      "name": "with_functions",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "test-integration-function-test",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "name": "test-integration-function-test",
+            "location": "WNAM",
+            "jurisdiction": "default",
+            "storage_class": "Standard"
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_r2_bucket",
+      "name": "with_interpolation",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "test-integration-interpolated-bucket",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "name": "test-integration-interpolated-bucket",
+            "location": "EEUR",
+            "jurisdiction": "default",
+            "storage_class": "Standard"
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_r2_bucket",
+      "name": "with_lifecycle",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "lifecycle-test-bucket",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "name": "lifecycle-test-bucket",
+            "location": "WNAM",
+            "jurisdiction": "default",
+            "storage_class": "Standard"
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_r2_bucket",
+      "name": "with_prevent_destroy",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "prevent-destroy-bucket",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "name": "prevent-destroy-bucket",
+            "location": "EEUR",
+            "jurisdiction": "default",
+            "storage_class": "Standard"
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_r2_bucket",
+      "name": "all_chars",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "bucket-name-with-all-valid-chars-123-test",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "name": "bucket-name-with-all-valid-chars-123-test",
+            "location": "WNAM",
+            "jurisdiction": "default",
+            "storage_class": "Standard"
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_r2_bucket",
+      "name": "special_chars",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "bucket-with-dashes-and-numbers-123",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "name": "bucket-with-dashes-and-numbers-123",
+            "jurisdiction": "default",
+            "storage_class": "Standard"
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_r2_bucket",
+      "name": "long_name",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "very-long-bucket-name-for-testing-migration-limits-max-len",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "name": "very-long-bucket-name-for-testing-migration-limits-max-len",
             "jurisdiction": "default",
             "storage_class": "Standard"
           }

--- a/integration/v4_to_v5/testdata/r2_bucket/input/r2_bucket.tf
+++ b/integration/v4_to_v5/testdata/r2_bucket/input/r2_bucket.tf
@@ -1,3 +1,6 @@
+# ============================================================================
+# Standard Variables (Auto-provided by test infrastructure)
+# ============================================================================
 variable "cloudflare_account_id" {
   description = "Cloudflare account ID"
   type        = string
@@ -8,40 +11,203 @@ variable "cloudflare_zone_id" {
   type        = string
 }
 
-# Test Case 1: Basic R2 bucket with required fields only
-resource "cloudflare_r2_bucket" "basic" {
-  account_id = var.cloudflare_account_id
-  name       = "test-bucket"
+# ============================================================================
+# Pattern Group 1: Locals for Common Values
+# ============================================================================
+locals {
+  common_account = var.cloudflare_account_id
+  name_prefix    = "test-integration"
+  locations = {
+    "wnam" = "WNAM"
+    "enam" = "ENAM"
+    "weur" = "WEUR"
+    "eeur" = "EEUR"
+    "apac" = "APAC"
+    "oc"   = "OC"
+  }
+  enable_feature = true
+  enable_test    = false
 }
 
-# Test Case 2: R2 bucket with location (uppercase - v4 style)
-resource "cloudflare_r2_bucket" "with_location_upper" {
+# ============================================================================
+# Pattern Group 2: Basic Resource Configurations
+# ============================================================================
+
+# Test Case 1: Minimal bucket with only required fields
+resource "cloudflare_r2_bucket" "minimal" {
+  account_id = var.cloudflare_account_id
+  name       = "minimal-bucket"
+}
+
+# Test Case 2: Bucket with all locations tested
+resource "cloudflare_r2_bucket" "location_wnam" {
   account_id = var.cloudflare_account_id
   name       = "bucket-wnam"
   location   = "WNAM"
 }
 
-# Test Case 3: R2 bucket with location (must be uppercase)
-resource "cloudflare_r2_bucket" "with_location_lower" {
+resource "cloudflare_r2_bucket" "location_enam" {
+  account_id = var.cloudflare_account_id
+  name       = "bucket-enam"
+  location   = "ENAM"
+}
+
+resource "cloudflare_r2_bucket" "location_weur" {
+  account_id = var.cloudflare_account_id
+  name       = "bucket-weur"
+  location   = "WEUR"
+}
+
+resource "cloudflare_r2_bucket" "location_eeur" {
   account_id = var.cloudflare_account_id
   name       = "bucket-eeur"
   location   = "EEUR"
 }
 
-# Test Case 4: R2 bucket with variable reference
-resource "cloudflare_r2_bucket" "with_variable" {
+resource "cloudflare_r2_bucket" "location_apac" {
   account_id = var.cloudflare_account_id
-  name       = "variable-bucket"
-}
-
-# Test Case 5: Multiple buckets with different configs
-resource "cloudflare_r2_bucket" "multi1" {
-  account_id = var.cloudflare_account_id
-  name       = "multi-bucket-1"
-}
-
-resource "cloudflare_r2_bucket" "multi2" {
-  account_id = var.cloudflare_account_id
-  name       = "multi-bucket-2"
+  name       = "bucket-apac"
   location   = "APAC"
+}
+
+resource "cloudflare_r2_bucket" "location_oc" {
+  account_id = var.cloudflare_account_id
+  name       = "bucket-oc"
+  location   = "OC"
+}
+
+# ============================================================================
+# Pattern Group 3: for_each with Maps
+# ============================================================================
+
+resource "cloudflare_r2_bucket" "map_example" {
+  for_each = {
+    "data" = {
+      name     = "data-bucket"
+      location = "WNAM"
+    }
+    "logs" = {
+      name     = "logs-bucket"
+      location = "ENAM"
+    }
+    "backups" = {
+      name     = "backups-bucket"
+      location = "WEUR"
+    }
+  }
+
+  account_id = var.cloudflare_account_id
+  name       = each.value.name
+  location   = each.value.location
+}
+
+# ============================================================================
+# Pattern Group 4: for_each with Sets
+# ============================================================================
+
+resource "cloudflare_r2_bucket" "set_example" {
+  for_each = toset([
+    "alpha",
+    "beta",
+    "gamma",
+    "delta",
+  ])
+
+  account_id = var.cloudflare_account_id
+  name       = "set-${each.value}-bucket"
+}
+
+# ============================================================================
+# Pattern Group 5: count-based Resources
+# ============================================================================
+
+resource "cloudflare_r2_bucket" "counted" {
+  count = 3
+
+  account_id = var.cloudflare_account_id
+  name       = "counted-bucket-${count.index}"
+  location   = count.index == 0 ? "WNAM" : count.index == 1 ? "EEUR" : "APAC"
+}
+
+# ============================================================================
+# Pattern Group 6: Conditional Creation
+# ============================================================================
+
+resource "cloudflare_r2_bucket" "conditional_enabled" {
+  count = local.enable_feature ? 1 : 0
+
+  account_id = var.cloudflare_account_id
+  name       = "conditional-enabled-bucket"
+  location   = "WNAM"
+}
+
+resource "cloudflare_r2_bucket" "conditional_disabled" {
+  count = local.enable_test ? 1 : 0
+
+  account_id = var.cloudflare_account_id
+  name       = "conditional-disabled-bucket"
+  location   = "EEUR"
+}
+
+# ============================================================================
+# Pattern Group 7: Terraform Functions
+# ============================================================================
+
+resource "cloudflare_r2_bucket" "with_functions" {
+  account_id = var.cloudflare_account_id
+  name       = join("-", [local.name_prefix, "function", "test"])
+  location   = lookup(local.locations, "wnam", "WNAM")
+}
+
+resource "cloudflare_r2_bucket" "with_interpolation" {
+  account_id = local.common_account
+  name       = "${local.name_prefix}-interpolated-bucket"
+  location   = local.locations["eeur"]
+}
+
+# ============================================================================
+# Pattern Group 8: Lifecycle Meta-Arguments
+# ============================================================================
+
+resource "cloudflare_r2_bucket" "with_lifecycle" {
+  account_id = var.cloudflare_account_id
+  name       = "lifecycle-test-bucket"
+  location   = "WNAM"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "cloudflare_r2_bucket" "with_prevent_destroy" {
+  account_id = var.cloudflare_account_id
+  name       = "prevent-destroy-bucket"
+  location   = "EEUR"
+
+  lifecycle {
+    prevent_destroy = false
+  }
+}
+
+# ============================================================================
+# Pattern Group 9: Edge Cases
+# ============================================================================
+
+# Special characters in bucket names (hyphens and numbers)
+resource "cloudflare_r2_bucket" "special_chars" {
+  account_id = var.cloudflare_account_id
+  name       = "bucket-with-dashes-and-numbers-123"
+}
+
+# Long bucket name (testing near max length - 63 chars max)
+resource "cloudflare_r2_bucket" "long_name" {
+  account_id = var.cloudflare_account_id
+  name       = "very-long-bucket-name-for-testing-migration-limits-max-len"
+}
+
+# Bucket name with all allowed characters (lowercase, numbers, hyphens)
+resource "cloudflare_r2_bucket" "all_chars" {
+  account_id = var.cloudflare_account_id
+  name       = "bucket-name-with-all-valid-chars-123-test"
+  location   = "WNAM"
 }

--- a/integration/v4_to_v5/testdata/r2_bucket/input/terraform.tfstate
+++ b/integration/v4_to_v5/testdata/r2_bucket/input/terraform.tfstate
@@ -8,15 +8,15 @@
     {
       "mode": "managed",
       "type": "cloudflare_r2_bucket",
-      "name": "basic",
+      "name": "minimal",
       "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
       "instances": [
         {
           "schema_version": 0,
           "attributes": {
-            "id": "test-bucket",
+            "id": "minimal-bucket",
             "account_id": "f037e56e89293a057740de681ac9abbe",
-            "name": "test-bucket"
+            "name": "minimal-bucket"
           }
         }
       ]
@@ -24,7 +24,7 @@
     {
       "mode": "managed",
       "type": "cloudflare_r2_bucket",
-      "name": "with_location_upper",
+      "name": "location_wnam",
       "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
       "instances": [
         {
@@ -41,7 +41,41 @@
     {
       "mode": "managed",
       "type": "cloudflare_r2_bucket",
-      "name": "with_location_lower",
+      "name": "location_enam",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "bucket-enam",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "name": "bucket-enam",
+            "location": "ENAM"
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_r2_bucket",
+      "name": "location_weur",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "bucket-weur",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "name": "bucket-weur",
+            "location": "WEUR"
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_r2_bucket",
+      "name": "location_eeur",
       "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
       "instances": [
         {
@@ -50,7 +84,7 @@
             "id": "bucket-eeur",
             "account_id": "f037e56e89293a057740de681ac9abbe",
             "name": "bucket-eeur",
-            "location": "eeur"
+            "location": "EEUR"
           }
         }
       ]
@@ -58,48 +92,288 @@
     {
       "mode": "managed",
       "type": "cloudflare_r2_bucket",
-      "name": "with_variable",
+      "name": "location_apac",
       "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
       "instances": [
         {
           "schema_version": 0,
           "attributes": {
-            "id": "variable-bucket",
+            "id": "bucket-apac",
             "account_id": "f037e56e89293a057740de681ac9abbe",
-            "name": "variable-bucket"
-          }
-        }
-      ]
-    },
-    {
-      "mode": "managed",
-      "type": "cloudflare_r2_bucket",
-      "name": "multi1",
-      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
-      "instances": [
-        {
-          "schema_version": 0,
-          "attributes": {
-            "id": "multi-bucket-1",
-            "account_id": "f037e56e89293a057740de681ac9abbe",
-            "name": "multi-bucket-1"
-          }
-        }
-      ]
-    },
-    {
-      "mode": "managed",
-      "type": "cloudflare_r2_bucket",
-      "name": "multi2",
-      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
-      "instances": [
-        {
-          "schema_version": 0,
-          "attributes": {
-            "id": "multi-bucket-2",
-            "account_id": "f037e56e89293a057740de681ac9abbe",
-            "name": "multi-bucket-2",
+            "name": "bucket-apac",
             "location": "APAC"
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_r2_bucket",
+      "name": "location_oc",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "bucket-oc",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "name": "bucket-oc",
+            "location": "OC"
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_r2_bucket",
+      "name": "map_example",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "index_key": "backups",
+          "schema_version": 0,
+          "attributes": {
+            "id": "backups-bucket",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "name": "backups-bucket",
+            "location": "WEUR"
+          }
+        },
+        {
+          "index_key": "data",
+          "schema_version": 0,
+          "attributes": {
+            "id": "data-bucket",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "name": "data-bucket",
+            "location": "WNAM"
+          }
+        },
+        {
+          "index_key": "logs",
+          "schema_version": 0,
+          "attributes": {
+            "id": "logs-bucket",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "name": "logs-bucket",
+            "location": "ENAM"
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_r2_bucket",
+      "name": "set_example",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "index_key": "alpha",
+          "schema_version": 0,
+          "attributes": {
+            "id": "set-alpha-bucket",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "name": "set-alpha-bucket"
+          }
+        },
+        {
+          "index_key": "beta",
+          "schema_version": 0,
+          "attributes": {
+            "id": "set-beta-bucket",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "name": "set-beta-bucket"
+          }
+        },
+        {
+          "index_key": "delta",
+          "schema_version": 0,
+          "attributes": {
+            "id": "set-delta-bucket",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "name": "set-delta-bucket"
+          }
+        },
+        {
+          "index_key": "gamma",
+          "schema_version": 0,
+          "attributes": {
+            "id": "set-gamma-bucket",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "name": "set-gamma-bucket"
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_r2_bucket",
+      "name": "counted",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "index": 0,
+          "schema_version": 0,
+          "attributes": {
+            "id": "counted-bucket-0",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "name": "counted-bucket-0",
+            "location": "WNAM"
+          }
+        },
+        {
+          "index": 1,
+          "schema_version": 0,
+          "attributes": {
+            "id": "counted-bucket-1",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "name": "counted-bucket-1",
+            "location": "EEUR"
+          }
+        },
+        {
+          "index": 2,
+          "schema_version": 0,
+          "attributes": {
+            "id": "counted-bucket-2",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "name": "counted-bucket-2",
+            "location": "APAC"
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_r2_bucket",
+      "name": "conditional_enabled",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "index": 0,
+          "schema_version": 0,
+          "attributes": {
+            "id": "conditional-enabled-bucket",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "name": "conditional-enabled-bucket",
+            "location": "WNAM"
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_r2_bucket",
+      "name": "with_functions",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "test-integration-function-test",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "name": "test-integration-function-test",
+            "location": "WNAM"
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_r2_bucket",
+      "name": "with_interpolation",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "test-integration-interpolated-bucket",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "name": "test-integration-interpolated-bucket",
+            "location": "EEUR"
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_r2_bucket",
+      "name": "with_lifecycle",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "lifecycle-test-bucket",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "name": "lifecycle-test-bucket",
+            "location": "WNAM"
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_r2_bucket",
+      "name": "with_prevent_destroy",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "prevent-destroy-bucket",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "name": "prevent-destroy-bucket",
+            "location": "EEUR"
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_r2_bucket",
+      "name": "all_chars",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "bucket-name-with-all-valid-chars-123-test",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "name": "bucket-name-with-all-valid-chars-123-test",
+            "location": "WNAM"
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_r2_bucket",
+      "name": "special_chars",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "bucket-with-dashes-and-numbers-123",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "name": "bucket-with-dashes-and-numbers-123"
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_r2_bucket",
+      "name": "long_name",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "very-long-bucket-name-for-testing-migration-limits-max-len",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "name": "very-long-bucket-name-for-testing-migration-limits-max-len"
           }
         }
       ]

--- a/integration/v4_to_v5/testdata/workers_kv/expected/workers_kv.tf
+++ b/integration/v4_to_v5/testdata/workers_kv/expected/workers_kv.tf
@@ -8,16 +8,35 @@ variable "cloudflare_zone_id" {
   type        = string
 }
 
-# Reference the namespace created in workers_kv_namespace module
-# This creates a dependency and tests cross-resource references
-
-# First create the namespace (from workers_kv_namespace testdata)
-resource "cloudflare_workers_kv_namespace" "test_namespace" {
-  account_id = var.cloudflare_account_id
-  title      = "test-kv-namespace"
+# Locals for reusable values
+locals {
+  common_account   = var.cloudflare_account_id
+  namespace_prefix = "test-kv"
+  test_keys = [
+    "config_key_1",
+    "config_key_2",
+    "config_key_3"
+  ]
+  enable_optional = true
+  disable_test    = false
 }
 
-# Test Case 1: Basic Workers KV resource
+# Parent resource: KV Namespace for dependency testing
+resource "cloudflare_workers_kv_namespace" "test_namespace" {
+  account_id = local.common_account
+  title      = "${local.namespace_prefix}-namespace"
+}
+
+# Pattern Group 1: Basic Resources
+# Test Case 1: Minimal resource (only required fields)
+resource "cloudflare_workers_kv" "minimal" {
+  account_id   = var.cloudflare_account_id
+  namespace_id = cloudflare_workers_kv_namespace.test_namespace.id
+  value        = "minimal_value"
+  key_name     = "minimal_key"
+}
+
+# Test Case 2: Basic resource with cross-resource reference
 resource "cloudflare_workers_kv" "basic" {
   account_id   = var.cloudflare_account_id
   namespace_id = cloudflare_workers_kv_namespace.test_namespace.id
@@ -25,7 +44,7 @@ resource "cloudflare_workers_kv" "basic" {
   key_name     = "config_key"
 }
 
-# Test Case 2: KV with special characters
+# Test Case 3: KV with special characters in key
 resource "cloudflare_workers_kv" "special_chars" {
   account_id   = var.cloudflare_account_id
   namespace_id = cloudflare_workers_kv_namespace.test_namespace.id
@@ -33,10 +52,200 @@ resource "cloudflare_workers_kv" "special_chars" {
   key_name     = "api/token"
 }
 
-# Test Case 3: KV with empty value
+# Test Case 4: KV with empty value
 resource "cloudflare_workers_kv" "empty_value" {
   account_id   = var.cloudflare_account_id
   namespace_id = cloudflare_workers_kv_namespace.test_namespace.id
   value        = ""
   key_name     = "placeholder"
+}
+
+# Test Case 5: KV with special characters in value
+resource "cloudflare_workers_kv" "special_value" {
+  account_id   = var.cloudflare_account_id
+  namespace_id = cloudflare_workers_kv_namespace.test_namespace.id
+  value        = "Line 1\nLine 2\tTabbed\r\nWindows line"
+  key_name     = "special_value_key"
+}
+
+# Pattern Group 2: for_each with Maps (3-5 resources)
+resource "cloudflare_workers_kv" "map_example" {
+  for_each = {
+    "config1" = {
+      key   = "map_config_1"
+      value = "Config value 1"
+    }
+    "config2" = {
+      key   = "map_config_2"
+      value = "Config value 2"
+    }
+    "config3" = {
+      key   = "map_config_3"
+      value = "Config value 3"
+    }
+    "config4" = {
+      key   = "map_config_4"
+      value = "Config value 4"
+    }
+  }
+
+  account_id   = var.cloudflare_account_id
+  namespace_id = cloudflare_workers_kv_namespace.test_namespace.id
+  value        = each.value.value
+  key_name     = each.value.key
+}
+
+# Pattern Group 3: for_each with Sets (3-5 items)
+resource "cloudflare_workers_kv" "set_example" {
+  for_each = toset([
+    "alpha",
+    "beta",
+    "gamma",
+    "delta"
+  ])
+
+  account_id   = var.cloudflare_account_id
+  namespace_id = cloudflare_workers_kv_namespace.test_namespace.id
+  value        = "Value for ${each.value}"
+  key_name     = "set-${each.value}"
+}
+
+# Pattern Group 4: count-based Resources (at least 3)
+resource "cloudflare_workers_kv" "counted" {
+  count = 3
+
+  account_id   = var.cloudflare_account_id
+  namespace_id = cloudflare_workers_kv_namespace.test_namespace.id
+  value        = "This is count resource number ${count.index}"
+  key_name     = "counted-${count.index}"
+}
+
+# Pattern Group 5: Conditional Creation
+resource "cloudflare_workers_kv" "conditional_enabled" {
+  count = local.enable_optional ? 1 : 0
+
+  account_id   = var.cloudflare_account_id
+  namespace_id = cloudflare_workers_kv_namespace.test_namespace.id
+  value        = "This resource is conditionally created"
+  key_name     = "conditional_enabled_key"
+}
+
+resource "cloudflare_workers_kv" "conditional_disabled" {
+  count = local.disable_test ? 1 : 0
+
+  account_id   = var.cloudflare_account_id
+  namespace_id = cloudflare_workers_kv_namespace.test_namespace.id
+  value        = "This resource should NOT be created"
+  key_name     = "conditional_disabled_key"
+}
+
+# Pattern Group 6: Terraform Functions
+resource "cloudflare_workers_kv" "with_functions" {
+  account_id   = var.cloudflare_account_id
+  namespace_id = cloudflare_workers_kv_namespace.test_namespace.id
+
+
+  # String interpolation with account ID
+  value    = "Resource for account ${var.cloudflare_account_id}"
+  key_name = join("-", ["test", "function", "key"])
+}
+
+resource "cloudflare_workers_kv" "with_base64" {
+  account_id   = var.cloudflare_account_id
+  namespace_id = cloudflare_workers_kv_namespace.test_namespace.id
+
+  # base64encode() function
+  value    = base64encode("This is a base64 encoded value for testing")
+  key_name = "encoded_key"
+}
+
+# Pattern Group 7: Lifecycle Meta-Arguments
+resource "cloudflare_workers_kv" "with_lifecycle" {
+  account_id   = var.cloudflare_account_id
+  namespace_id = cloudflare_workers_kv_namespace.test_namespace.id
+  value        = "Testing lifecycle rules"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+  key_name = "lifecycle_test_key"
+}
+
+resource "cloudflare_workers_kv" "with_ignore_changes" {
+  account_id   = var.cloudflare_account_id
+  namespace_id = cloudflare_workers_kv_namespace.test_namespace.id
+  value        = "Value that might change"
+
+  lifecycle {
+    ignore_changes = [value]
+  }
+  key_name = "ignore_changes_key"
+}
+
+# Pattern Group 8: Edge Cases
+# Large value (approaching 25 MiB limit - using a smaller 1KB sample)
+resource "cloudflare_workers_kv" "large_value" {
+  account_id   = var.cloudflare_account_id
+  namespace_id = cloudflare_workers_kv_namespace.test_namespace.id
+  value        = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt."
+  key_name     = "large_value_key"
+}
+
+# Key with URL encoding special cases
+#resource "cloudflare_workers_kv" "url_encoded_key" {
+#  account_id   = var.cloudflare_account_id
+#  namespace_id = cloudflare_workers_kv_namespace.test_namespace.id
+#  key          = "path/to/resource?query=value&param=test"
+#  value        = "Value for URL-like key"
+#}
+
+# Key with Unicode characters
+resource "cloudflare_workers_kv" "unicode_key" {
+  account_id   = var.cloudflare_account_id
+  namespace_id = cloudflare_workers_kv_namespace.test_namespace.id
+  value        = "Unicode test value: 你好世界"
+  key_name     = "unicode_测试_key"
+}
+
+# Value with JSON
+resource "cloudflare_workers_kv" "json_value" {
+  account_id   = var.cloudflare_account_id
+  namespace_id = cloudflare_workers_kv_namespace.test_namespace.id
+  value = jsonencode({
+    name    = "test"
+    enabled = true
+    count   = 42
+    tags    = ["tag1", "tag2", "tag3"]
+  })
+  key_name = "json_data"
+}
+
+# Pattern Group 9: Multiple Resources with Dependencies
+resource "cloudflare_workers_kv_namespace" "secondary_namespace" {
+  account_id = var.cloudflare_account_id
+  title      = "${local.namespace_prefix}-secondary"
+}
+
+resource "cloudflare_workers_kv" "secondary_ns_kv1" {
+  account_id   = var.cloudflare_account_id
+  namespace_id = cloudflare_workers_kv_namespace.secondary_namespace.id
+  value        = "Value in secondary namespace 1"
+  key_name     = "secondary_key_1"
+}
+
+resource "cloudflare_workers_kv" "secondary_ns_kv2" {
+  account_id   = var.cloudflare_account_id
+  namespace_id = cloudflare_workers_kv_namespace.secondary_namespace.id
+  value        = "Value in secondary namespace 2"
+  key_name     = "secondary_key_2"
+}
+
+# Using local values in keys
+resource "cloudflare_workers_kv" "with_locals" {
+  count = length(local.test_keys)
+
+  account_id   = var.cloudflare_account_id
+  namespace_id = cloudflare_workers_kv_namespace.test_namespace.id
+  value        = "Value for ${local.test_keys[count.index]}"
+  key_name     = local.test_keys[count.index]
 }

--- a/integration/v4_to_v5/testdata/workers_kv/input/workers_kv.tf
+++ b/integration/v4_to_v5/testdata/workers_kv/input/workers_kv.tf
@@ -8,16 +8,35 @@ variable "cloudflare_zone_id" {
   type        = string
 }
 
-# Reference the namespace created in workers_kv_namespace module
-# This creates a dependency and tests cross-resource references
-
-# First create the namespace (from workers_kv_namespace testdata)
-resource "cloudflare_workers_kv_namespace" "test_namespace" {
-  account_id = var.cloudflare_account_id
-  title      = "test-kv-namespace"
+# Locals for reusable values
+locals {
+  common_account   = var.cloudflare_account_id
+  namespace_prefix = "test-kv"
+  test_keys = [
+    "config_key_1",
+    "config_key_2",
+    "config_key_3"
+  ]
+  enable_optional = true
+  disable_test    = false
 }
 
-# Test Case 1: Basic Workers KV resource
+# Parent resource: KV Namespace for dependency testing
+resource "cloudflare_workers_kv_namespace" "test_namespace" {
+  account_id = local.common_account
+  title      = "${local.namespace_prefix}-namespace"
+}
+
+# Pattern Group 1: Basic Resources
+# Test Case 1: Minimal resource (only required fields)
+resource "cloudflare_workers_kv" "minimal" {
+  account_id   = var.cloudflare_account_id
+  namespace_id = cloudflare_workers_kv_namespace.test_namespace.id
+  key          = "minimal_key"
+  value        = "minimal_value"
+}
+
+# Test Case 2: Basic resource with cross-resource reference
 resource "cloudflare_workers_kv" "basic" {
   account_id   = var.cloudflare_account_id
   namespace_id = cloudflare_workers_kv_namespace.test_namespace.id
@@ -25,7 +44,7 @@ resource "cloudflare_workers_kv" "basic" {
   value        = "config_value"
 }
 
-# Test Case 2: KV with special characters
+# Test Case 3: KV with special characters in key
 resource "cloudflare_workers_kv" "special_chars" {
   account_id   = var.cloudflare_account_id
   namespace_id = cloudflare_workers_kv_namespace.test_namespace.id
@@ -33,10 +52,201 @@ resource "cloudflare_workers_kv" "special_chars" {
   value        = "{\"api_key\": \"test123\", \"endpoint\": \"https://api.example.com\"}"
 }
 
-# Test Case 3: KV with empty value
+# Test Case 4: KV with empty value
 resource "cloudflare_workers_kv" "empty_value" {
   account_id   = var.cloudflare_account_id
   namespace_id = cloudflare_workers_kv_namespace.test_namespace.id
   key          = "placeholder"
   value        = ""
+}
+
+# Test Case 5: KV with special characters in value
+resource "cloudflare_workers_kv" "special_value" {
+  account_id   = var.cloudflare_account_id
+  namespace_id = cloudflare_workers_kv_namespace.test_namespace.id
+  key          = "special_value_key"
+  value        = "Line 1\nLine 2\tTabbed\r\nWindows line"
+}
+
+# Pattern Group 2: for_each with Maps (3-5 resources)
+resource "cloudflare_workers_kv" "map_example" {
+  for_each = {
+    "config1" = {
+      key   = "map_config_1"
+      value = "Config value 1"
+    }
+    "config2" = {
+      key   = "map_config_2"
+      value = "Config value 2"
+    }
+    "config3" = {
+      key   = "map_config_3"
+      value = "Config value 3"
+    }
+    "config4" = {
+      key   = "map_config_4"
+      value = "Config value 4"
+    }
+  }
+
+  account_id   = var.cloudflare_account_id
+  namespace_id = cloudflare_workers_kv_namespace.test_namespace.id
+  key          = each.value.key
+  value        = each.value.value
+}
+
+# Pattern Group 3: for_each with Sets (3-5 items)
+resource "cloudflare_workers_kv" "set_example" {
+  for_each = toset([
+    "alpha",
+    "beta",
+    "gamma",
+    "delta"
+  ])
+
+  account_id   = var.cloudflare_account_id
+  namespace_id = cloudflare_workers_kv_namespace.test_namespace.id
+  key          = "set-${each.value}"
+  value        = "Value for ${each.value}"
+}
+
+# Pattern Group 4: count-based Resources (at least 3)
+resource "cloudflare_workers_kv" "counted" {
+  count = 3
+
+  account_id   = var.cloudflare_account_id
+  namespace_id = cloudflare_workers_kv_namespace.test_namespace.id
+  key          = "counted-${count.index}"
+  value        = "This is count resource number ${count.index}"
+}
+
+# Pattern Group 5: Conditional Creation
+resource "cloudflare_workers_kv" "conditional_enabled" {
+  count = local.enable_optional ? 1 : 0
+
+  account_id   = var.cloudflare_account_id
+  namespace_id = cloudflare_workers_kv_namespace.test_namespace.id
+  key          = "conditional_enabled_key"
+  value        = "This resource is conditionally created"
+}
+
+resource "cloudflare_workers_kv" "conditional_disabled" {
+  count = local.disable_test ? 1 : 0
+
+  account_id   = var.cloudflare_account_id
+  namespace_id = cloudflare_workers_kv_namespace.test_namespace.id
+  key          = "conditional_disabled_key"
+  value        = "This resource should NOT be created"
+}
+
+# Pattern Group 6: Terraform Functions
+resource "cloudflare_workers_kv" "with_functions" {
+  account_id   = var.cloudflare_account_id
+  namespace_id = cloudflare_workers_kv_namespace.test_namespace.id
+
+  # join() function
+  key = join("-", ["test", "function", "key"])
+
+  # String interpolation with account ID
+  value = "Resource for account ${var.cloudflare_account_id}"
+}
+
+resource "cloudflare_workers_kv" "with_base64" {
+  account_id   = var.cloudflare_account_id
+  namespace_id = cloudflare_workers_kv_namespace.test_namespace.id
+  key          = "encoded_key"
+
+  # base64encode() function
+  value = base64encode("This is a base64 encoded value for testing")
+}
+
+# Pattern Group 7: Lifecycle Meta-Arguments
+resource "cloudflare_workers_kv" "with_lifecycle" {
+  account_id   = var.cloudflare_account_id
+  namespace_id = cloudflare_workers_kv_namespace.test_namespace.id
+  key          = "lifecycle_test_key"
+  value        = "Testing lifecycle rules"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "cloudflare_workers_kv" "with_ignore_changes" {
+  account_id   = var.cloudflare_account_id
+  namespace_id = cloudflare_workers_kv_namespace.test_namespace.id
+  key          = "ignore_changes_key"
+  value        = "Value that might change"
+
+  lifecycle {
+    ignore_changes = [value]
+  }
+}
+
+# Pattern Group 8: Edge Cases
+# Large value (approaching 25 MiB limit - using a smaller 1KB sample)
+resource "cloudflare_workers_kv" "large_value" {
+  account_id   = var.cloudflare_account_id
+  namespace_id = cloudflare_workers_kv_namespace.test_namespace.id
+  key          = "large_value_key"
+  value        = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt."
+}
+
+# Key with URL encoding special cases
+#resource "cloudflare_workers_kv" "url_encoded_key" {
+#  account_id   = var.cloudflare_account_id
+#  namespace_id = cloudflare_workers_kv_namespace.test_namespace.id
+#  key          = "path/to/resource?query=value&param=test"
+#  value        = "Value for URL-like key"
+#}
+
+# Key with Unicode characters
+resource "cloudflare_workers_kv" "unicode_key" {
+  account_id   = var.cloudflare_account_id
+  namespace_id = cloudflare_workers_kv_namespace.test_namespace.id
+  key          = "unicode_测试_key"
+  value        = "Unicode test value: 你好世界"
+}
+
+# Value with JSON
+resource "cloudflare_workers_kv" "json_value" {
+  account_id   = var.cloudflare_account_id
+  namespace_id = cloudflare_workers_kv_namespace.test_namespace.id
+  key          = "json_data"
+  value        = jsonencode({
+    name    = "test"
+    enabled = true
+    count   = 42
+    tags    = ["tag1", "tag2", "tag3"]
+  })
+}
+
+# Pattern Group 9: Multiple Resources with Dependencies
+resource "cloudflare_workers_kv_namespace" "secondary_namespace" {
+  account_id = var.cloudflare_account_id
+  title      = "${local.namespace_prefix}-secondary"
+}
+
+resource "cloudflare_workers_kv" "secondary_ns_kv1" {
+  account_id   = var.cloudflare_account_id
+  namespace_id = cloudflare_workers_kv_namespace.secondary_namespace.id
+  key          = "secondary_key_1"
+  value        = "Value in secondary namespace 1"
+}
+
+resource "cloudflare_workers_kv" "secondary_ns_kv2" {
+  account_id   = var.cloudflare_account_id
+  namespace_id = cloudflare_workers_kv_namespace.secondary_namespace.id
+  key          = "secondary_key_2"
+  value        = "Value in secondary namespace 2"
+}
+
+# Using local values in keys
+resource "cloudflare_workers_kv" "with_locals" {
+  count = length(local.test_keys)
+
+  account_id   = var.cloudflare_account_id
+  namespace_id = cloudflare_workers_kv_namespace.test_namespace.id
+  key          = local.test_keys[count.index]
+  value        = "Value for ${local.test_keys[count.index]}"
 }

--- a/integration/v4_to_v5/testdata/workers_kv_namespace/expected/terraform.tfstate
+++ b/integration/v4_to_v5/testdata/workers_kv_namespace/expected/terraform.tfstate
@@ -1,57 +1,334 @@
 {
-  "lineage": "a75366f2-b332-4347-9a6c-239a2f23a319",
+  "version": 4,
+  "terraform_version": "1.5.0",
+  "serial": 1,
+  "lineage": "workers-kv-namespace-comprehensive-test",
   "outputs": {},
   "resources": [
     {
+      "mode": "managed",
+      "type": "cloudflare_workers_kv_namespace",
+      "name": "map_example",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "each": "map",
       "instances": [
         {
+          "index_key": "cache",
+          "schema_version": 0,
           "attributes": {
             "account_id": "f037e56e89293a057740de681ac9abbe",
-            "id": "0f2ac2fd364ea7d3f44bdc5a556c527e",
-            "title": "test-namespace"
-          },
-          "schema_version": 0
+            "id": "map_cache_id_001",
+            "title": "test-integration-Cache Store"
+          }
+        },
+        {
+          "index_key": "config",
+          "schema_version": 0,
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "id": "map_config_id_002",
+            "title": "test-integration-Configuration Store"
+          }
+        },
+        {
+          "index_key": "session",
+          "schema_version": 0,
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "id": "map_session_id_003",
+            "title": "test-integration-Session Store"
+          }
         }
-      ],
-      "mode": "managed",
-      "name": "basic",
-      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
-      "type": "cloudflare_workers_kv_namespace"
+      ]
     },
     {
+      "mode": "managed",
+      "type": "cloudflare_workers_kv_namespace",
+      "name": "set_example",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "each": "set",
       "instances": [
         {
+          "index_key": "alpha",
+          "schema_version": 0,
           "attributes": {
             "account_id": "f037e56e89293a057740de681ac9abbe",
-            "id": "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6",
-            "title": "test-namespace-2024"
-          },
-          "schema_version": 0
+            "id": "set_alpha_id_004",
+            "title": "set-alpha-namespace"
+          }
+        },
+        {
+          "index_key": "beta",
+          "schema_version": 0,
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "id": "set_beta_id_005",
+            "title": "set-beta-namespace"
+          }
+        },
+        {
+          "index_key": "delta",
+          "schema_version": 0,
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "id": "set_delta_id_006",
+            "title": "set-delta-namespace"
+          }
+        },
+        {
+          "index_key": "gamma",
+          "schema_version": 0,
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "id": "set_gamma_id_007",
+            "title": "set-gamma-namespace"
+          }
         }
-      ],
+      ]
+    },
+    {
       "mode": "managed",
+      "type": "cloudflare_workers_kv_namespace",
+      "name": "counted",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "index_key": 0,
+          "schema_version": 0,
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "id": "counted_0_id_008",
+            "title": "counted-namespace-0"
+          }
+        },
+        {
+          "index_key": 1,
+          "schema_version": 0,
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "id": "counted_1_id_009",
+            "title": "counted-namespace-1"
+          }
+        },
+        {
+          "index_key": 2,
+          "schema_version": 0,
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "id": "counted_2_id_010",
+            "title": "counted-namespace-2"
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_workers_kv_namespace",
+      "name": "conditional_enabled",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "index_key": 0,
+          "schema_version": 0,
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "id": "conditional_enabled_id_011",
+            "title": "conditional-enabled-namespace"
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_workers_kv_namespace",
+      "name": "with_join",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "id": "with_join_id_012",
+            "title": "workers-kv-joined"
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_workers_kv_namespace",
+      "name": "with_format",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "id": "with_format_id_013",
+            "title": "formatted-namespace-001"
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_workers_kv_namespace",
+      "name": "with_interpolation",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "id": "with_interpolation_id_014",
+            "title": "namespace-for-account-f037e56e89293a057740de681ac9abbe"
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_workers_kv_namespace",
+      "name": "with_lifecycle",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "id": "with_lifecycle_id_015",
+            "title": "lifecycle-test-namespace"
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_workers_kv_namespace",
+      "name": "with_prevent_destroy",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "id": "with_prevent_destroy_id_016",
+            "title": "prevent-destroy-namespace"
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_workers_kv_namespace",
+      "name": "minimal",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "id": "minimal_id_017",
+            "title": "minimal"
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_workers_kv_namespace",
       "name": "special_chars",
       "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
-      "type": "cloudflare_workers_kv_namespace"
-    },
-    {
       "instances": [
         {
+          "schema_version": 0,
           "attributes": {
             "account_id": "f037e56e89293a057740de681ac9abbe",
-            "id": "b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7",
-            "title": "My Workers KV Namespace"
-          },
-          "schema_version": 0
+            "id": "special_chars_id_018",
+            "title": "test_namespace-with.special-chars!2024"
+          }
         }
-      ],
+      ]
+    },
+    {
       "mode": "managed",
+      "type": "cloudflare_workers_kv_namespace",
       "name": "with_spaces",
       "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
-      "type": "cloudflare_workers_kv_namespace"
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "id": "with_spaces_id_019",
+            "title": "My Workers KV Namespace With Spaces"
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_workers_kv_namespace",
+      "name": "long_title",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "id": "long_title_id_020",
+            "title": "very-long-namespace-title-that-tests-maximum-length-handling-in-migration-process-2024"
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_workers_kv_namespace",
+      "name": "unicode",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "id": "unicode_id_021",
+            "title": "namespace-with-émojis-🚀-and-spëcial-chàrs"
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_workers_kv_namespace",
+      "name": "from_locals",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "id": "from_locals_id_022",
+            "title": "test-integration-from-locals"
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_workers_kv_namespace",
+      "name": "variable_driven",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "id": "variable_driven_id_023",
+            "title": "namespace-zone-id-placeholder"
+          }
+        }
+      ]
     }
-  ],
-  "serial": 1,
-  "terraform_version": "1.0.0",
-  "version": 4
+  ]
 }

--- a/integration/v4_to_v5/testdata/workers_kv_namespace/expected/workers_kv_namespace.tf
+++ b/integration/v4_to_v5/testdata/workers_kv_namespace/expected/workers_kv_namespace.tf
@@ -1,3 +1,7 @@
+# Comprehensive Integration Tests for workers_kv_namespace v4 to v5 Migration
+# Covers all mandatory patterns from subtask 08
+
+# Pattern Group 1: Variables & Locals (Lines 1-25)
 variable "cloudflare_account_id" {
   description = "Cloudflare account ID"
   type        = string
@@ -8,20 +12,170 @@ variable "cloudflare_zone_id" {
   type        = string
 }
 
-# Test Case 1: Basic Workers KV Namespace
-resource "cloudflare_workers_kv_namespace" "basic" {
-  account_id = var.cloudflare_account_id
-  title      = "test-namespace"
+locals {
+  common_account = var.cloudflare_account_id
+  name_prefix    = "test-integration"
+  tags           = ["test", "migration", "v4_to_v5"]
+  environments   = ["dev", "staging", "prod"]
 }
 
-# Test Case 2: Namespace with special characters
+# Pattern Group 2: for_each with Maps (3 instances)
+resource "cloudflare_workers_kv_namespace" "map_example" {
+  for_each = {
+    "cache" = {
+      title = "Cache Store"
+    }
+    "session" = {
+      title = "Session Store"
+    }
+    "config" = {
+      title = "Configuration Store"
+    }
+  }
+
+  account_id = local.common_account
+  title      = "${local.name_prefix}-${each.value.title}"
+}
+
+# Pattern Group 3: for_each with Sets (4 instances)
+resource "cloudflare_workers_kv_namespace" "set_example" {
+  for_each = toset([
+    "alpha",
+    "beta",
+    "gamma",
+    "delta"
+  ])
+
+  account_id = var.cloudflare_account_id
+  title      = "set-${each.value}-namespace"
+}
+
+# Pattern Group 4: count-based Resources (3 instances)
+resource "cloudflare_workers_kv_namespace" "counted" {
+  count = 3
+
+  account_id = var.cloudflare_account_id
+  title      = "counted-namespace-${count.index}"
+}
+
+# Pattern Group 5: Conditional Creation (1 instance created, 1 not created)
+locals {
+  enable_feature = true
+  enable_test    = false
+}
+
+resource "cloudflare_workers_kv_namespace" "conditional_enabled" {
+  count = local.enable_feature ? 1 : 0
+
+  account_id = var.cloudflare_account_id
+  title      = "conditional-enabled-namespace"
+}
+
+resource "cloudflare_workers_kv_namespace" "conditional_disabled" {
+  count = local.enable_test ? 1 : 0
+
+  account_id = var.cloudflare_account_id
+  title      = "conditional-disabled-namespace"
+}
+
+# Pattern Group 6: Terraform Functions (3 instances)
+resource "cloudflare_workers_kv_namespace" "with_join" {
+  account_id = var.cloudflare_account_id
+  title      = join("-", ["workers", "kv", "joined"])
+}
+
+resource "cloudflare_workers_kv_namespace" "with_format" {
+  account_id = var.cloudflare_account_id
+  title      = "formatted-namespace-001"
+}
+
+resource "cloudflare_workers_kv_namespace" "with_interpolation" {
+  account_id = var.cloudflare_account_id
+  title      = "namespace-for-account-${var.cloudflare_account_id}"
+}
+
+# Pattern Group 7: Lifecycle Meta-Arguments (2 instances)
+resource "cloudflare_workers_kv_namespace" "with_lifecycle" {
+  account_id = var.cloudflare_account_id
+  title      = "lifecycle-test-namespace"
+
+  lifecycle {
+    create_before_destroy = true
+    ignore_changes        = [title]
+  }
+}
+
+resource "cloudflare_workers_kv_namespace" "with_prevent_destroy" {
+  account_id = var.cloudflare_account_id
+  title      = "prevent-destroy-namespace"
+
+  lifecycle {
+    prevent_destroy = false
+  }
+}
+
+# Pattern Group 8: Edge Cases
+
+# Minimal resource (only required fields)
+resource "cloudflare_workers_kv_namespace" "minimal" {
+  account_id = var.cloudflare_account_id
+  title      = "minimal"
+}
+
+# Resource with special characters in title
 resource "cloudflare_workers_kv_namespace" "special_chars" {
   account_id = var.cloudflare_account_id
-  title      = "test-namespace-2024"
+  title      = "test_namespace-with.special-chars!2024"
 }
 
-# Test Case 3: Namespace with spaces
+# Resource with spaces in title
 resource "cloudflare_workers_kv_namespace" "with_spaces" {
   account_id = var.cloudflare_account_id
-  title      = "My Workers KV Namespace"
+  title      = "My Workers KV Namespace With Spaces"
 }
+
+# Resource with very long title
+resource "cloudflare_workers_kv_namespace" "long_title" {
+  account_id = var.cloudflare_account_id
+  title      = "very-long-namespace-title-that-tests-maximum-length-handling-in-migration-process-2024"
+}
+
+# Resource with unicode characters
+resource "cloudflare_workers_kv_namespace" "unicode" {
+  account_id = var.cloudflare_account_id
+  title      = "namespace-with-émojis-🚀-and-spëcial-chàrs"
+}
+
+# Pattern Group 9: Production-like Patterns
+
+# Using locals for common values
+resource "cloudflare_workers_kv_namespace" "from_locals" {
+  account_id = local.common_account
+  title      = "${local.name_prefix}-from-locals"
+}
+
+# Variable-driven configuration
+resource "cloudflare_workers_kv_namespace" "variable_driven" {
+  account_id = var.cloudflare_account_id
+  title      = "namespace-${var.cloudflare_zone_id}"
+}
+
+# Total instances: 25
+# - map_example: 3 instances (cache, session, config)
+# - set_example: 4 instances (alpha, beta, gamma, delta)
+# - counted: 3 instances (0, 1, 2)
+# - conditional_enabled: 1 instance
+# - conditional_disabled: 0 instances (not created)
+# - with_join: 1 instance
+# - with_format: 1 instance
+# - with_interpolation: 1 instance
+# - with_lifecycle: 1 instance
+# - with_prevent_destroy: 1 instance
+# - minimal: 1 instance
+# - special_chars: 1 instance
+# - with_spaces: 1 instance
+# - long_title: 1 instance
+# - unicode: 1 instance
+# - from_locals: 1 instance
+# - variable_driven: 1 instance
+# Total: 23 instances (excluding conditional_disabled which has count = 0)

--- a/integration/v4_to_v5/testdata/workers_kv_namespace/input/terraform.tfstate
+++ b/integration/v4_to_v5/testdata/workers_kv_namespace/input/terraform.tfstate
@@ -1,22 +1,235 @@
 {
   "version": 4,
-  "terraform_version": "1.0.0",
+  "terraform_version": "1.5.0",
   "serial": 1,
-  "lineage": "a75366f2-b332-4347-9a6c-239a2f23a319",
+  "lineage": "workers-kv-namespace-comprehensive-test",
   "outputs": {},
   "resources": [
     {
       "mode": "managed",
       "type": "cloudflare_workers_kv_namespace",
-      "name": "basic",
+      "name": "map_example",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "each": "map",
+      "instances": [
+        {
+          "index_key": "cache",
+          "schema_version": 0,
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "id": "map_cache_id_001",
+            "title": "test-integration-Cache Store"
+          }
+        },
+        {
+          "index_key": "config",
+          "schema_version": 0,
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "id": "map_config_id_002",
+            "title": "test-integration-Configuration Store"
+          }
+        },
+        {
+          "index_key": "session",
+          "schema_version": 0,
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "id": "map_session_id_003",
+            "title": "test-integration-Session Store"
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_workers_kv_namespace",
+      "name": "set_example",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "each": "set",
+      "instances": [
+        {
+          "index_key": "alpha",
+          "schema_version": 0,
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "id": "set_alpha_id_004",
+            "title": "set-alpha-namespace"
+          }
+        },
+        {
+          "index_key": "beta",
+          "schema_version": 0,
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "id": "set_beta_id_005",
+            "title": "set-beta-namespace"
+          }
+        },
+        {
+          "index_key": "delta",
+          "schema_version": 0,
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "id": "set_delta_id_006",
+            "title": "set-delta-namespace"
+          }
+        },
+        {
+          "index_key": "gamma",
+          "schema_version": 0,
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "id": "set_gamma_id_007",
+            "title": "set-gamma-namespace"
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_workers_kv_namespace",
+      "name": "counted",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "index_key": 0,
+          "schema_version": 0,
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "id": "counted_0_id_008",
+            "title": "counted-namespace-0"
+          }
+        },
+        {
+          "index_key": 1,
+          "schema_version": 0,
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "id": "counted_1_id_009",
+            "title": "counted-namespace-1"
+          }
+        },
+        {
+          "index_key": 2,
+          "schema_version": 0,
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "id": "counted_2_id_010",
+            "title": "counted-namespace-2"
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_workers_kv_namespace",
+      "name": "conditional_enabled",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "index_key": 0,
+          "schema_version": 0,
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "id": "conditional_enabled_id_011",
+            "title": "conditional-enabled-namespace"
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_workers_kv_namespace",
+      "name": "with_join",
       "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
       "instances": [
         {
           "schema_version": 0,
           "attributes": {
             "account_id": "f037e56e89293a057740de681ac9abbe",
-            "id": "0f2ac2fd364ea7d3f44bdc5a556c527e",
-            "title": "test-namespace"
+            "id": "with_join_id_012",
+            "title": "workers-kv-joined"
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_workers_kv_namespace",
+      "name": "with_format",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "id": "with_format_id_013",
+            "title": "formatted-namespace-001"
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_workers_kv_namespace",
+      "name": "with_interpolation",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "id": "with_interpolation_id_014",
+            "title": "namespace-for-account-f037e56e89293a057740de681ac9abbe"
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_workers_kv_namespace",
+      "name": "with_lifecycle",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "id": "with_lifecycle_id_015",
+            "title": "lifecycle-test-namespace"
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_workers_kv_namespace",
+      "name": "with_prevent_destroy",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "id": "with_prevent_destroy_id_016",
+            "title": "prevent-destroy-namespace"
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_workers_kv_namespace",
+      "name": "minimal",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "id": "minimal_id_017",
+            "title": "minimal"
           }
         }
       ]
@@ -31,8 +244,8 @@
           "schema_version": 0,
           "attributes": {
             "account_id": "f037e56e89293a057740de681ac9abbe",
-            "id": "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6",
-            "title": "test-namespace-2024"
+            "id": "special_chars_id_018",
+            "title": "test_namespace-with.special-chars!2024"
           }
         }
       ]
@@ -47,8 +260,72 @@
           "schema_version": 0,
           "attributes": {
             "account_id": "f037e56e89293a057740de681ac9abbe",
-            "id": "b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7",
-            "title": "My Workers KV Namespace"
+            "id": "with_spaces_id_019",
+            "title": "My Workers KV Namespace With Spaces"
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_workers_kv_namespace",
+      "name": "long_title",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "id": "long_title_id_020",
+            "title": "very-long-namespace-title-that-tests-maximum-length-handling-in-migration-process-2024"
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_workers_kv_namespace",
+      "name": "unicode",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "id": "unicode_id_021",
+            "title": "namespace-with-émojis-🚀-and-spëcial-chàrs"
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_workers_kv_namespace",
+      "name": "from_locals",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "id": "from_locals_id_022",
+            "title": "test-integration-from-locals"
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_workers_kv_namespace",
+      "name": "variable_driven",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "id": "variable_driven_id_023",
+            "title": "namespace-zone-id-placeholder"
           }
         }
       ]

--- a/integration/v4_to_v5/testdata/workers_kv_namespace/input/workers_kv_namespace.tf
+++ b/integration/v4_to_v5/testdata/workers_kv_namespace/input/workers_kv_namespace.tf
@@ -1,3 +1,7 @@
+# Comprehensive Integration Tests for workers_kv_namespace v4 to v5 Migration
+# Covers all mandatory patterns from subtask 08
+
+# Pattern Group 1: Variables & Locals (Lines 1-25)
 variable "cloudflare_account_id" {
   description = "Cloudflare account ID"
   type        = string
@@ -8,20 +12,170 @@ variable "cloudflare_zone_id" {
   type        = string
 }
 
-# Test Case 1: Basic Workers KV Namespace
-resource "cloudflare_workers_kv_namespace" "basic" {
-  account_id = var.cloudflare_account_id
-  title      = "test-namespace"
+locals {
+  common_account = var.cloudflare_account_id
+  name_prefix    = "test-integration"
+  tags           = ["test", "migration", "v4_to_v5"]
+  environments   = ["dev", "staging", "prod"]
 }
 
-# Test Case 2: Namespace with special characters
+# Pattern Group 2: for_each with Maps (3 instances)
+resource "cloudflare_workers_kv_namespace" "map_example" {
+  for_each = {
+    "cache" = {
+      title = "Cache Store"
+    }
+    "session" = {
+      title = "Session Store"
+    }
+    "config" = {
+      title = "Configuration Store"
+    }
+  }
+
+  account_id = local.common_account
+  title      = "${local.name_prefix}-${each.value.title}"
+}
+
+# Pattern Group 3: for_each with Sets (4 instances)
+resource "cloudflare_workers_kv_namespace" "set_example" {
+  for_each = toset([
+    "alpha",
+    "beta",
+    "gamma",
+    "delta"
+  ])
+
+  account_id = var.cloudflare_account_id
+  title      = "set-${each.value}-namespace"
+}
+
+# Pattern Group 4: count-based Resources (3 instances)
+resource "cloudflare_workers_kv_namespace" "counted" {
+  count = 3
+
+  account_id = var.cloudflare_account_id
+  title      = "counted-namespace-${count.index}"
+}
+
+# Pattern Group 5: Conditional Creation (1 instance created, 1 not created)
+locals {
+  enable_feature = true
+  enable_test    = false
+}
+
+resource "cloudflare_workers_kv_namespace" "conditional_enabled" {
+  count = local.enable_feature ? 1 : 0
+
+  account_id = var.cloudflare_account_id
+  title      = "conditional-enabled-namespace"
+}
+
+resource "cloudflare_workers_kv_namespace" "conditional_disabled" {
+  count = local.enable_test ? 1 : 0
+
+  account_id = var.cloudflare_account_id
+  title      = "conditional-disabled-namespace"
+}
+
+# Pattern Group 6: Terraform Functions (3 instances)
+resource "cloudflare_workers_kv_namespace" "with_join" {
+  account_id = var.cloudflare_account_id
+  title      = join("-", ["workers", "kv", "joined"])
+}
+
+resource "cloudflare_workers_kv_namespace" "with_format" {
+  account_id = var.cloudflare_account_id
+  title      = "formatted-namespace-001"
+}
+
+resource "cloudflare_workers_kv_namespace" "with_interpolation" {
+  account_id = var.cloudflare_account_id
+  title      = "namespace-for-account-${var.cloudflare_account_id}"
+}
+
+# Pattern Group 7: Lifecycle Meta-Arguments (2 instances)
+resource "cloudflare_workers_kv_namespace" "with_lifecycle" {
+  account_id = var.cloudflare_account_id
+  title      = "lifecycle-test-namespace"
+
+  lifecycle {
+    create_before_destroy = true
+    ignore_changes        = [title]
+  }
+}
+
+resource "cloudflare_workers_kv_namespace" "with_prevent_destroy" {
+  account_id = var.cloudflare_account_id
+  title      = "prevent-destroy-namespace"
+
+  lifecycle {
+    prevent_destroy = false
+  }
+}
+
+# Pattern Group 8: Edge Cases
+
+# Minimal resource (only required fields)
+resource "cloudflare_workers_kv_namespace" "minimal" {
+  account_id = var.cloudflare_account_id
+  title      = "minimal"
+}
+
+# Resource with special characters in title
 resource "cloudflare_workers_kv_namespace" "special_chars" {
   account_id = var.cloudflare_account_id
-  title      = "test-namespace-2024"
+  title      = "test_namespace-with.special-chars!2024"
 }
 
-# Test Case 3: Namespace with spaces
+# Resource with spaces in title
 resource "cloudflare_workers_kv_namespace" "with_spaces" {
   account_id = var.cloudflare_account_id
-  title      = "My Workers KV Namespace"
+  title      = "My Workers KV Namespace With Spaces"
 }
+
+# Resource with very long title
+resource "cloudflare_workers_kv_namespace" "long_title" {
+  account_id = var.cloudflare_account_id
+  title      = "very-long-namespace-title-that-tests-maximum-length-handling-in-migration-process-2024"
+}
+
+# Resource with unicode characters
+resource "cloudflare_workers_kv_namespace" "unicode" {
+  account_id = var.cloudflare_account_id
+  title      = "namespace-with-émojis-🚀-and-spëcial-chàrs"
+}
+
+# Pattern Group 9: Production-like Patterns
+
+# Using locals for common values
+resource "cloudflare_workers_kv_namespace" "from_locals" {
+  account_id = local.common_account
+  title      = "${local.name_prefix}-from-locals"
+}
+
+# Variable-driven configuration
+resource "cloudflare_workers_kv_namespace" "variable_driven" {
+  account_id = var.cloudflare_account_id
+  title      = "namespace-${var.cloudflare_zone_id}"
+}
+
+# Total instances: 25
+# - map_example: 3 instances (cache, session, config)
+# - set_example: 4 instances (alpha, beta, gamma, delta)
+# - counted: 3 instances (0, 1, 2)
+# - conditional_enabled: 1 instance
+# - conditional_disabled: 0 instances (not created)
+# - with_join: 1 instance
+# - with_format: 1 instance
+# - with_interpolation: 1 instance
+# - with_lifecycle: 1 instance
+# - with_prevent_destroy: 1 instance
+# - minimal: 1 instance
+# - special_chars: 1 instance
+# - with_spaces: 1 instance
+# - long_title: 1 instance
+# - unicode: 1 instance
+# - from_locals: 1 instance
+# - variable_driven: 1 instance
+# Total: 23 instances (excluding conditional_disabled which has count = 0)


### PR DESCRIPTION
  Summary

  Add comprehensive v4 to v5 integration test data for Workers KV, Workers KV Namespace, and R2 Bucket resource migrations. This significantly expands test coverage by adding realistic, production-like
  test fixtures with multiple resource instances and complete configuration scenarios.

  Changes

  - workers_kv: Enhanced integration test data with comprehensive resource configurations
  - workers_kv_namespace: Added complete input and expected output test fixtures for v4 to v5 migration validation
  - r2_bucket: Expanded test data to include multiple resource instances and various configuration patterns