### PR TITLE
feat(zone, zones): support data source migrations

### DIFF
--- a/integration/v4_to_v5/testdata/zone_datasource/expected/terraform.tfstate
+++ b/integration/v4_to_v5/testdata/zone_datasource/expected/terraform.tfstate
@@ -1,0 +1,50 @@
+{
+  "version": 4,
+  "terraform_version": "1.5.0",
+  "serial": 1,
+  "lineage": "test-lineage",
+  "resources": [
+    {
+      "mode": "data",
+      "type": "cloudflare_zone",
+      "name": "by_id",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "zone_id": "abc123def456",
+            "account_id": "account123",
+            "name": "example.com",
+            "status": "active",
+            "paused": false,
+            "plan": "free",
+            "name_servers": ["ns1.cloudflare.com", "ns2.cloudflare.com"],
+            "vanity_name_servers": []
+          }
+        }
+      ]
+    },
+    {
+      "mode": "data",
+      "type": "cloudflare_zone",
+      "name": "by_name",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "zone_id": "zone456",
+            "account_id": "account123",
+            "name": "example.com",
+            "status": "active",
+            "paused": false,
+            "plan": "pro",
+            "name_servers": ["ns1.cloudflare.com", "ns2.cloudflare.com"],
+            "vanity_name_servers": ["ns1.example.com", "ns2.example.com"]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/integration/v4_to_v5/testdata/zone_datasource/expected/zone.tf
+++ b/integration/v4_to_v5/testdata/zone_datasource/expected/zone.tf
@@ -1,58 +1,92 @@
+variable "cloudflare_account_id" {
+  description = "Cloudflare account ID"
+  type        = string
+}
+
+variable "cloudflare_zone_id" {
+  description = "Cloudflare zone ID"
+  type        = string
+}
+
+# Test variables for variable/local reference preservation tests
+# For E2E: These will use values from the first zone lookup to ensure they work
+variable "account_id" {
+  type    = string
+  default = ""
+}
+
+variable "zone_name" {
+  type    = string
+  default = ""
+}
+
+locals {
+  # For E2E: Use empty string, will be overridden by direct reference to by_id
+  zone_domain   = ""
+  cf_account_id = ""
+}
+
 # Zone datasource v4 test fixtures
 # Testing all lookup scenarios
 
 # Scenario 1: zone_id lookup (no changes)
 data "cloudflare_zone" "by_id" {
-  zone_id = "abc123def456"
+  zone_id = var.cloudflare_zone_id
 }
 
 # Scenario 2: name only lookup
+# Uses the zone name from by_id lookup so it works with any zone
 data "cloudflare_zone" "by_name" {
   filter = {
-    name = "example.com"
+    name = data.cloudflare_zone.by_id.name
   }
 }
 
-# Scenario 3: account_id only lookup
+# Scenario 3: account_id + name lookup
+# Note: v4 provider requires name or zone_id, so we include name for E2E testing
 data "cloudflare_zone" "by_account" {
   filter = {
+    name = data.cloudflare_zone.by_id.name
     account = {
-      id = "account789"
+      id = var.cloudflare_account_id
     }
   }
 }
 
-# Scenario 4: name + account_id lookup
+# Scenario 4: name + account_id lookup (same as scenario 3 but different instance)
 data "cloudflare_zone" "by_name_and_account" {
   filter = {
-    name = "example.org"
+    name = data.cloudflare_zone.by_id.name
     account = {
-      id = "account456"
+      id = var.cloudflare_account_id
     }
   }
 }
 
-# Scenario 5: with variable references
+# Scenario 5: with variable references (tests that var refs are preserved)
+# For E2E: Uses the zone name from by_id so it actually works
 data "cloudflare_zone" "with_variables" {
   filter = {
-    name = var.zone_name
+    name = coalesce(var.zone_name, data.cloudflare_zone.by_id.name)
     account = {
-      id = var.account_id
+      id = coalesce(var.account_id, var.cloudflare_account_id)
     }
   }
 }
 
-# Scenario 6: another zone_id lookup
+# Scenario 6: another zone_id lookup (tests multiple zone_id lookups)
+# For E2E: Uses the same zone so it actually exists
 data "cloudflare_zone" "another_by_id" {
-  zone_id = "xyz789abc123"
+  zone_id = var.cloudflare_zone_id
 }
 
-# Scenario 7: name with local reference
+# Scenario 7: name with local reference (tests that local refs are preserved)
+# For E2E: Uses the zone name from by_id so it actually works
 data "cloudflare_zone" "from_local" {
   filter = {
-    name = local.zone_domain
+    name = coalesce(local.zone_domain, data.cloudflare_zone.by_id.name)
     account = {
-      id = local.cf_account_id
+      id = coalesce(local.cf_account_id, var.cloudflare_account_id)
     }
   }
 }

--- a/integration/v4_to_v5/testdata/zone_datasource/expected/zone.tf
+++ b/integration/v4_to_v5/testdata/zone_datasource/expected/zone.tf
@@ -1,0 +1,58 @@
+# Zone datasource v4 test fixtures
+# Testing all lookup scenarios
+
+# Scenario 1: zone_id lookup (no changes)
+data "cloudflare_zone" "by_id" {
+  zone_id = "abc123def456"
+}
+
+# Scenario 2: name only lookup
+data "cloudflare_zone" "by_name" {
+  filter = {
+    name = "example.com"
+  }
+}
+
+# Scenario 3: account_id only lookup
+data "cloudflare_zone" "by_account" {
+  filter = {
+    account = {
+      id = "account789"
+    }
+  }
+}
+
+# Scenario 4: name + account_id lookup
+data "cloudflare_zone" "by_name_and_account" {
+  filter = {
+    name = "example.org"
+    account = {
+      id = "account456"
+    }
+  }
+}
+
+# Scenario 5: with variable references
+data "cloudflare_zone" "with_variables" {
+  filter = {
+    name = var.zone_name
+    account = {
+      id = var.account_id
+    }
+  }
+}
+
+# Scenario 6: another zone_id lookup
+data "cloudflare_zone" "another_by_id" {
+  zone_id = "xyz789abc123"
+}
+
+# Scenario 7: name with local reference
+data "cloudflare_zone" "from_local" {
+  filter = {
+    name = local.zone_domain
+    account = {
+      id = local.cf_account_id
+    }
+  }
+}

--- a/integration/v4_to_v5/testdata/zone_datasource/input/terraform.tfstate
+++ b/integration/v4_to_v5/testdata/zone_datasource/input/terraform.tfstate
@@ -1,0 +1,50 @@
+{
+  "version": 4,
+  "terraform_version": "1.5.0",
+  "serial": 1,
+  "lineage": "test-lineage",
+  "resources": [
+    {
+      "mode": "data",
+      "type": "cloudflare_zone",
+      "name": "by_id",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 1,
+          "attributes": {
+            "zone_id": "abc123def456",
+            "account_id": "account123",
+            "name": "example.com",
+            "status": "active",
+            "paused": false,
+            "plan": "free",
+            "name_servers": ["ns1.cloudflare.com", "ns2.cloudflare.com"],
+            "vanity_name_servers": []
+          }
+        }
+      ]
+    },
+    {
+      "mode": "data",
+      "type": "cloudflare_zone",
+      "name": "by_name",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 1,
+          "attributes": {
+            "zone_id": "zone456",
+            "account_id": "account123",
+            "name": "example.com",
+            "status": "active",
+            "paused": false,
+            "plan": "pro",
+            "name_servers": ["ns1.cloudflare.com", "ns2.cloudflare.com"],
+            "vanity_name_servers": ["ns1.example.com", "ns2.example.com"]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/integration/v4_to_v5/testdata/zone_datasource/input/zone.tf
+++ b/integration/v4_to_v5/testdata/zone_datasource/input/zone.tf
@@ -1,0 +1,40 @@
+# Zone datasource v4 test fixtures
+# Testing all lookup scenarios
+
+# Scenario 1: zone_id lookup (no changes)
+data "cloudflare_zone" "by_id" {
+  zone_id = "abc123def456"
+}
+
+# Scenario 2: name only lookup
+data "cloudflare_zone" "by_name" {
+  name = "example.com"
+}
+
+# Scenario 3: account_id only lookup
+data "cloudflare_zone" "by_account" {
+  account_id = "account789"
+}
+
+# Scenario 4: name + account_id lookup
+data "cloudflare_zone" "by_name_and_account" {
+  name       = "example.org"
+  account_id = "account456"
+}
+
+# Scenario 5: with variable references
+data "cloudflare_zone" "with_variables" {
+  name       = var.zone_name
+  account_id = var.account_id
+}
+
+# Scenario 6: another zone_id lookup
+data "cloudflare_zone" "another_by_id" {
+  zone_id = "xyz789abc123"
+}
+
+# Scenario 7: name with local reference
+data "cloudflare_zone" "from_local" {
+  name       = local.zone_domain
+  account_id = local.cf_account_id
+}

--- a/integration/v4_to_v5/testdata/zone_datasource/input/zone.tf
+++ b/integration/v4_to_v5/testdata/zone_datasource/input/zone.tf
@@ -1,40 +1,74 @@
+variable "cloudflare_account_id" {
+  description = "Cloudflare account ID"
+  type        = string
+}
+
+variable "cloudflare_zone_id" {
+  description = "Cloudflare zone ID"
+  type        = string
+}
+
+# Test variables for variable/local reference preservation tests
+# For E2E: These will use values from the first zone lookup to ensure they work
+variable "account_id" {
+  type    = string
+  default = ""
+}
+
+variable "zone_name" {
+  type    = string
+  default = ""
+}
+
+locals {
+  # For E2E: Use empty string, will be overridden by direct reference to by_id
+  zone_domain   = ""
+  cf_account_id = ""
+}
+
 # Zone datasource v4 test fixtures
 # Testing all lookup scenarios
 
 # Scenario 1: zone_id lookup (no changes)
 data "cloudflare_zone" "by_id" {
-  zone_id = "abc123def456"
+  zone_id = var.cloudflare_zone_id
 }
 
 # Scenario 2: name only lookup
+# Uses the zone name from by_id lookup so it works with any zone
 data "cloudflare_zone" "by_name" {
-  name = "example.com"
+  name = data.cloudflare_zone.by_id.name
 }
 
-# Scenario 3: account_id only lookup
+# Scenario 3: account_id + name lookup
+# Note: v4 provider requires name or zone_id, so we include name for E2E testing
 data "cloudflare_zone" "by_account" {
-  account_id = "account789"
+  name       = data.cloudflare_zone.by_id.name
+  account_id = var.cloudflare_account_id
 }
 
-# Scenario 4: name + account_id lookup
+# Scenario 4: name + account_id lookup (same as scenario 3 but different instance)
 data "cloudflare_zone" "by_name_and_account" {
-  name       = "example.org"
-  account_id = "account456"
+  name       = data.cloudflare_zone.by_id.name
+  account_id = var.cloudflare_account_id
 }
 
-# Scenario 5: with variable references
+# Scenario 5: with variable references (tests that var refs are preserved)
+# For E2E: Uses the zone name from by_id so it actually works
 data "cloudflare_zone" "with_variables" {
-  name       = var.zone_name
-  account_id = var.account_id
+  name       = coalesce(var.zone_name, data.cloudflare_zone.by_id.name)
+  account_id = coalesce(var.account_id, var.cloudflare_account_id)
 }
 
-# Scenario 6: another zone_id lookup
+# Scenario 6: another zone_id lookup (tests multiple zone_id lookups)
+# For E2E: Uses the same zone so it actually exists
 data "cloudflare_zone" "another_by_id" {
-  zone_id = "xyz789abc123"
+  zone_id = var.cloudflare_zone_id
 }
 
-# Scenario 7: name with local reference
+# Scenario 7: name with local reference (tests that local refs are preserved)
+# For E2E: Uses the zone name from by_id so it actually works
 data "cloudflare_zone" "from_local" {
-  name       = local.zone_domain
-  account_id = local.cf_account_id
+  name       = coalesce(local.zone_domain, data.cloudflare_zone.by_id.name)
+  account_id = coalesce(local.cf_account_id, var.cloudflare_account_id)
 }

--- a/integration/v4_to_v5/testdata/zones_datasource/expected/terraform.tfstate
+++ b/integration/v4_to_v5/testdata/zones_datasource/expected/terraform.tfstate
@@ -1,0 +1,73 @@
+{
+  "lineage": "test",
+  "outputs": {},
+  "resources": [
+    {
+      "instances": [
+        {
+          "attributes": {
+            "filter": [
+              {
+                "account_id": "f037e56e89293a057740de681ac9abbe",
+                "lookup_type": "exact",
+                "match": "",
+                "name": "",
+                "paused": false,
+                "status": ""
+              }
+            ],
+            "id": "checksum1",
+            "result": [
+              {
+                "id": "zone1",
+                "name": "example.com"
+              },
+              {
+                "id": "zone2",
+                "name": "test.com"
+              }
+            ]
+          },
+          "schema_version": 0
+        }
+      ],
+      "mode": "data",
+      "name": "by_account",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_zones"
+    },
+    {
+      "instances": [
+        {
+          "attributes": {
+            "filter": [
+              {
+                "account_id": "",
+                "lookup_type": "exact",
+                "match": "",
+                "name": "example.com",
+                "paused": false,
+                "status": ""
+              }
+            ],
+            "id": "checksum2",
+            "result": [
+              {
+                "id": "zone1",
+                "name": "example.com"
+              }
+            ]
+          },
+          "schema_version": 0
+        }
+      ],
+      "mode": "data",
+      "name": "by_name",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_zones"
+    }
+  ],
+  "serial": 1,
+  "terraform_version": "1.5.0",
+  "version": 4
+}

--- a/integration/v4_to_v5/testdata/zones_datasource/expected/zones.tf
+++ b/integration/v4_to_v5/testdata/zones_datasource/expected/zones.tf
@@ -1,0 +1,52 @@
+# Test various zone datasource filter configurations
+
+# Filter by account_id only
+data "cloudflare_zones" "by_account" {
+  account = {
+    id = "f037e56e89293a057740de681ac9abbe"
+  }
+}
+
+# Filter by name only
+data "cloudflare_zones" "by_name" {
+  name = "example.com"
+}
+
+# Filter by status only
+data "cloudflare_zones" "by_status" {
+  status = "active"
+}
+
+# Filter by account_id and name
+data "cloudflare_zones" "by_account_and_name" {
+  account = {
+    id = "f037e56e89293a057740de681ac9abbe"
+  }
+  name = "example.com"
+}
+
+# Filter with all supported fields
+data "cloudflare_zones" "all_supported" {
+  account = {
+    id = "f037e56e89293a057740de681ac9abbe"
+  }
+  name   = "example.com"
+  status = "active"
+}
+
+# Filter with dropped fields (lookup_type, match, paused)
+data "cloudflare_zones" "with_dropped_fields" {
+  account = {
+    id = "f037e56e89293a057740de681ac9abbe"
+  }
+  name = "example"
+}
+
+# Variable references preserved
+data "cloudflare_zones" "with_variables" {
+  account = {
+    id = var.account_id
+  }
+  name   = var.zone_name
+  status = var.status
+}

--- a/integration/v4_to_v5/testdata/zones_datasource/expected/zones.tf
+++ b/integration/v4_to_v5/testdata/zones_datasource/expected/zones.tf
@@ -1,15 +1,48 @@
+variable "cloudflare_account_id" {
+  description = "Cloudflare account ID"
+  type        = string
+}
+
+variable "cloudflare_zone_id" {
+  description = "Cloudflare zone ID"
+  type        = string
+}
+
+# Test variables for variable reference preservation tests
+# These are only used to test that variable references are preserved during migration
+# They won't be queried in E2E tests
+variable "account_id" {
+  type    = string
+  default = "test-account-abc123"
+}
+
+variable "zone_name" {
+  type    = string
+  default = "test-zone.example.com"
+}
+
+variable "status" {
+  type    = string
+  default = "active"
+}
+
 # Test various zone datasource filter configurations
+
+# First, look up the zone by ID to get its name dynamically
+data "cloudflare_zone" "reference" {
+  zone_id = var.cloudflare_zone_id
+}
 
 # Filter by account_id only
 data "cloudflare_zones" "by_account" {
   account = {
-    id = "f037e56e89293a057740de681ac9abbe"
+    id = var.cloudflare_account_id
   }
 }
 
-# Filter by name only
+# Filter by name only - uses dynamic zone name
 data "cloudflare_zones" "by_name" {
-  name = "example.com"
+  name = data.cloudflare_zone.reference.name
 }
 
 # Filter by status only
@@ -20,26 +53,27 @@ data "cloudflare_zones" "by_status" {
 # Filter by account_id and name
 data "cloudflare_zones" "by_account_and_name" {
   account = {
-    id = "f037e56e89293a057740de681ac9abbe"
+    id = var.cloudflare_account_id
   }
-  name = "example.com"
+  name = data.cloudflare_zone.reference.name
 }
 
 # Filter with all supported fields
 data "cloudflare_zones" "all_supported" {
   account = {
-    id = "f037e56e89293a057740de681ac9abbe"
+    id = var.cloudflare_account_id
   }
-  name   = "example.com"
+  name   = data.cloudflare_zone.reference.name
   status = "active"
 }
 
 # Filter with dropped fields (lookup_type, match, paused)
+# Uses partial name match so lookup_type makes sense
 data "cloudflare_zones" "with_dropped_fields" {
   account = {
-    id = "f037e56e89293a057740de681ac9abbe"
+    id = var.cloudflare_account_id
   }
-  name = "example"
+  name = "test"
 }
 
 # Variable references preserved

--- a/integration/v4_to_v5/testdata/zones_datasource/input/terraform.tfstate
+++ b/integration/v4_to_v5/testdata/zones_datasource/input/terraform.tfstate
@@ -1,0 +1,64 @@
+{
+  "version": 4,
+  "terraform_version": "1.5.0",
+  "serial": 1,
+  "lineage": "test",
+  "outputs": {},
+  "resources": [
+    {
+      "mode": "data",
+      "type": "cloudflare_zones",
+      "name": "by_account",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 1,
+          "attributes": {
+            "filter": [
+              {
+                "account_id": "f037e56e89293a057740de681ac9abbe",
+                "lookup_type": "exact",
+                "match": "",
+                "name": "",
+                "paused": false,
+                "status": ""
+              }
+            ],
+            "id": "checksum1",
+            "zones": [
+              {"id": "zone1", "name": "example.com"},
+              {"id": "zone2", "name": "test.com"}
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "mode": "data",
+      "type": "cloudflare_zones",
+      "name": "by_name",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 1,
+          "attributes": {
+            "filter": [
+              {
+                "account_id": "",
+                "lookup_type": "exact",
+                "match": "",
+                "name": "example.com",
+                "paused": false,
+                "status": ""
+              }
+            ],
+            "id": "checksum2",
+            "zones": [
+              {"id": "zone1", "name": "example.com"}
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/integration/v4_to_v5/testdata/zones_datasource/input/terraform.tfstate.backup
+++ b/integration/v4_to_v5/testdata/zones_datasource/input/terraform.tfstate.backup
@@ -1,0 +1,64 @@
+{
+  "version": 4,
+  "terraform_version": "1.5.0",
+  "serial": 1,
+  "lineage": "test",
+  "outputs": {},
+  "resources": [
+    {
+      "mode": "data",
+      "type": "cloudflare_zones",
+      "name": "by_account",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 1,
+          "attributes": {
+            "filter": [
+              {
+                "account_id": "f037e56e89293a057740de681ac9abbe",
+                "lookup_type": "exact",
+                "match": "",
+                "name": "",
+                "paused": false,
+                "status": ""
+              }
+            ],
+            "id": "checksum1",
+            "zones": [
+              {"id": "zone1", "name": "example.com"},
+              {"id": "zone2", "name": "test.com"}
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "mode": "data",
+      "type": "cloudflare_zones",
+      "name": "by_name",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 1,
+          "attributes": {
+            "filter": [
+              {
+                "account_id": "",
+                "lookup_type": "exact",
+                "match": "",
+                "name": "example.com",
+                "paused": false,
+                "status": ""
+              }
+            ],
+            "id": "checksum2",
+            "zones": [
+              {"id": "zone1", "name": "example.com"}
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/integration/v4_to_v5/testdata/zones_datasource/input/zones.tf
+++ b/integration/v4_to_v5/testdata/zones_datasource/input/zones.tf
@@ -1,16 +1,49 @@
+variable "cloudflare_account_id" {
+  description = "Cloudflare account ID"
+  type        = string
+}
+
+variable "cloudflare_zone_id" {
+  description = "Cloudflare zone ID"
+  type        = string
+}
+
+# Test variables for variable reference preservation tests
+# These are only used to test that variable references are preserved during migration
+# They won't be queried in E2E tests
+variable "account_id" {
+  type    = string
+  default = "test-account-abc123"
+}
+
+variable "zone_name" {
+  type    = string
+  default = "test-zone.example.com"
+}
+
+variable "status" {
+  type    = string
+  default = "active"
+}
+
 # Test various zone datasource filter configurations
+
+# First, look up the zone by ID to get its name dynamically
+data "cloudflare_zone" "reference" {
+  zone_id = var.cloudflare_zone_id
+}
 
 # Filter by account_id only
 data "cloudflare_zones" "by_account" {
   filter {
-    account_id = "f037e56e89293a057740de681ac9abbe"
+    account_id = var.cloudflare_account_id
   }
 }
 
-# Filter by name only
+# Filter by name only - uses dynamic zone name
 data "cloudflare_zones" "by_name" {
   filter {
-    name = "example.com"
+    name = data.cloudflare_zone.reference.name
   }
 }
 
@@ -24,27 +57,28 @@ data "cloudflare_zones" "by_status" {
 # Filter by account_id and name
 data "cloudflare_zones" "by_account_and_name" {
   filter {
-    account_id = "f037e56e89293a057740de681ac9abbe"
-    name       = "example.com"
+    account_id = var.cloudflare_account_id
+    name       = data.cloudflare_zone.reference.name
   }
 }
 
 # Filter with all supported fields
 data "cloudflare_zones" "all_supported" {
   filter {
-    account_id = "f037e56e89293a057740de681ac9abbe"
-    name       = "example.com"
+    account_id = var.cloudflare_account_id
+    name       = data.cloudflare_zone.reference.name
     status     = "active"
   }
 }
 
 # Filter with dropped fields (lookup_type, match, paused)
+# Uses partial name match so lookup_type makes sense
 data "cloudflare_zones" "with_dropped_fields" {
   filter {
-    account_id  = "f037e56e89293a057740de681ac9abbe"
-    name        = "example"
+    account_id  = var.cloudflare_account_id
+    name        = "test"
     lookup_type = "contains"
-    match       = "^example-"
+    match       = "^test-"
     paused      = false
   }
 }

--- a/integration/v4_to_v5/testdata/zones_datasource/input/zones.tf
+++ b/integration/v4_to_v5/testdata/zones_datasource/input/zones.tf
@@ -1,0 +1,59 @@
+# Test various zone datasource filter configurations
+
+# Filter by account_id only
+data "cloudflare_zones" "by_account" {
+  filter {
+    account_id = "f037e56e89293a057740de681ac9abbe"
+  }
+}
+
+# Filter by name only
+data "cloudflare_zones" "by_name" {
+  filter {
+    name = "example.com"
+  }
+}
+
+# Filter by status only
+data "cloudflare_zones" "by_status" {
+  filter {
+    status = "active"
+  }
+}
+
+# Filter by account_id and name
+data "cloudflare_zones" "by_account_and_name" {
+  filter {
+    account_id = "f037e56e89293a057740de681ac9abbe"
+    name       = "example.com"
+  }
+}
+
+# Filter with all supported fields
+data "cloudflare_zones" "all_supported" {
+  filter {
+    account_id = "f037e56e89293a057740de681ac9abbe"
+    name       = "example.com"
+    status     = "active"
+  }
+}
+
+# Filter with dropped fields (lookup_type, match, paused)
+data "cloudflare_zones" "with_dropped_fields" {
+  filter {
+    account_id  = "f037e56e89293a057740de681ac9abbe"
+    name        = "example"
+    lookup_type = "contains"
+    match       = "^example-"
+    paused      = false
+  }
+}
+
+# Variable references preserved
+data "cloudflare_zones" "with_variables" {
+  filter {
+    account_id = var.account_id
+    name       = var.zone_name
+    status     = var.status
+  }
+}

--- a/integration/v4_to_v5/testdata/zones_datasource/input/zones.tf.backup
+++ b/integration/v4_to_v5/testdata/zones_datasource/input/zones.tf.backup
@@ -1,0 +1,59 @@
+# Test various zone datasource filter configurations
+
+# Filter by account_id only
+data "cloudflare_zones" "by_account" {
+  filter {
+    account_id = "f037e56e89293a057740de681ac9abbe"
+  }
+}
+
+# Filter by name only
+data "cloudflare_zones" "by_name" {
+  filter {
+    name = "example.com"
+  }
+}
+
+# Filter by status only
+data "cloudflare_zones" "by_status" {
+  filter {
+    status = "active"
+  }
+}
+
+# Filter by account_id and name
+data "cloudflare_zones" "by_account_and_name" {
+  filter {
+    account_id = "f037e56e89293a057740de681ac9abbe"
+    name       = "example.com"
+  }
+}
+
+# Filter with all supported fields
+data "cloudflare_zones" "all_supported" {
+  filter {
+    account_id = "f037e56e89293a057740de681ac9abbe"
+    name       = "example.com"
+    status     = "active"
+  }
+}
+
+# Filter with dropped fields (lookup_type, match, paused)
+data "cloudflare_zones" "with_dropped_fields" {
+  filter {
+    account_id  = "f037e56e89293a057740de681ac9abbe"
+    name        = "example"
+    lookup_type = "contains"
+    match       = "^example-"
+    paused      = false
+  }
+}
+
+# Variable references preserved
+data "cloudflare_zones" "with_variables" {
+  filter {
+    account_id = var.account_id
+    name       = var.zone_name
+    status     = var.status
+  }
+}

--- a/internal/datasources/zone/v4_to_v5.go
+++ b/internal/datasources/zone/v4_to_v5.go
@@ -1,0 +1,149 @@
+package zone
+
+import (
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/hashicorp/hcl/v2/hclwrite"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+
+	"github.com/cloudflare/tf-migrate/internal"
+	"github.com/cloudflare/tf-migrate/internal/transform"
+)
+
+// V4ToV5Migrator handles the migration of cloudflare_zone datasource from v4 to v5.
+// Key transformations:
+// 1. account_id and/or name → filter = { ... } (wrap in filter attribute)
+// 2. zone_id lookups remain unchanged
+// 3. Minimal state transformation (datasources are mostly computed)
+type V4ToV5Migrator struct{}
+
+// NewV4ToV5Migrator creates a new migrator for cloudflare_zone datasource v4 to v5.
+func NewV4ToV5Migrator() transform.ResourceTransformer {
+	migrator := &V4ToV5Migrator{}
+	// Register with "data." prefix to distinguish from resource migration
+	internal.RegisterMigrator("data.cloudflare_zone", "v4", "v5", migrator)
+	return migrator
+}
+
+// GetResourceType returns the v5 datasource type this migrator handles.
+func (m *V4ToV5Migrator) GetResourceType() string {
+	return "cloudflare_zone"
+}
+
+// CanHandle determines if this migrator can handle the given datasource type.
+func (m *V4ToV5Migrator) CanHandle(resourceType string) bool {
+	// Only match datasource type (with "data." prefix)
+	return resourceType == "data.cloudflare_zone"
+}
+
+// Preprocess handles string-level transformations before HCL parsing.
+// No preprocessing needed for zone datasource migration.
+func (m *V4ToV5Migrator) Preprocess(content string) string {
+	return content
+}
+
+// TransformConfig handles configuration file transformations.
+// Scenarios:
+// 1. zone_id only → No changes
+// 2. name only → filter = { name = "..." }
+// 3. account_id only → filter = { account = { id = "..." } }
+// 4. name + account_id → filter = { name = "...", account = { id = "..." } }
+func (m *V4ToV5Migrator) TransformConfig(ctx *transform.Context, block *hclwrite.Block) (*transform.TransformResult, error) {
+	body := block.Body()
+
+	// Check if we have name or account_id (which need to move to filter)
+	nameAttr := body.GetAttribute("name")
+	accountIdAttr := body.GetAttribute("account_id")
+
+	// Scenario 1: zone_id lookup - no changes needed
+	if nameAttr == nil && accountIdAttr == nil {
+		return &transform.TransformResult{
+			Blocks:         []*hclwrite.Block{block},
+			RemoveOriginal: false,
+		}, nil
+	}
+
+	// Scenarios 2-4: Create filter attribute
+	m.setFilterAttribute(body, nameAttr, accountIdAttr)
+
+	// Remove old attributes
+	if nameAttr != nil {
+		body.RemoveAttribute("name")
+	}
+	if accountIdAttr != nil {
+		body.RemoveAttribute("account_id")
+	}
+
+	return &transform.TransformResult{
+		Blocks:         []*hclwrite.Block{block},
+		RemoveOriginal: false,
+	}, nil
+}
+
+// setFilterAttribute creates the filter = { ... } attribute structure
+// Handles 3 cases:
+// 1. name only: filter = { name = "..." }
+// 2. account_id only: filter = { account = { id = "..." } }
+// 3. both: filter = { name = "...", account = { id = "..." } }
+func (m *V4ToV5Migrator) setFilterAttribute(body *hclwrite.Body, nameAttr, accountIdAttr *hclwrite.Attribute) {
+	// Start building filter object: filter = {
+	tokens := hclwrite.Tokens{
+		{Type: hclsyntax.TokenOBrace, Bytes: []byte("{")},
+		{Type: hclsyntax.TokenNewline, Bytes: []byte("\n")},
+	}
+
+	// Add name field if present
+	if nameAttr != nil {
+		nameTokens := nameAttr.Expr().BuildTokens(nil)
+		tokens = append(tokens,
+			&hclwrite.Token{Type: hclsyntax.TokenIdent, Bytes: []byte("  name")},
+			&hclwrite.Token{Type: hclsyntax.TokenEqual, Bytes: []byte(" = ")},
+		)
+		tokens = append(tokens, nameTokens...)
+		tokens = append(tokens,
+			&hclwrite.Token{Type: hclsyntax.TokenNewline, Bytes: []byte("\n")},
+		)
+	}
+
+	// Add account = { id = "..." } if present
+	if accountIdAttr != nil {
+		accountIdTokens := accountIdAttr.Expr().BuildTokens(nil)
+		tokens = append(tokens,
+			&hclwrite.Token{Type: hclsyntax.TokenIdent, Bytes: []byte("  account")},
+			&hclwrite.Token{Type: hclsyntax.TokenEqual, Bytes: []byte(" = ")},
+			&hclwrite.Token{Type: hclsyntax.TokenOBrace, Bytes: []byte("{")},
+			&hclwrite.Token{Type: hclsyntax.TokenNewline, Bytes: []byte("\n")},
+			&hclwrite.Token{Type: hclsyntax.TokenIdent, Bytes: []byte("    id")},
+			&hclwrite.Token{Type: hclsyntax.TokenEqual, Bytes: []byte(" = ")},
+		)
+		tokens = append(tokens, accountIdTokens...)
+		tokens = append(tokens,
+			&hclwrite.Token{Type: hclsyntax.TokenNewline, Bytes: []byte("\n")},
+			&hclwrite.Token{Type: hclsyntax.TokenIdent, Bytes: []byte("  ")},
+			&hclwrite.Token{Type: hclsyntax.TokenCBrace, Bytes: []byte("}")},
+			&hclwrite.Token{Type: hclsyntax.TokenNewline, Bytes: []byte("\n")},
+		)
+	}
+
+	// Close filter object
+	tokens = append(tokens,
+		&hclwrite.Token{Type: hclsyntax.TokenCBrace, Bytes: []byte("}")},
+	)
+
+	// Set the filter attribute
+	body.SetAttributeRaw("filter", tokens)
+}
+
+// TransformState handles state file transformations.
+// For datasources, state transformation is minimal since fields are mostly computed.
+func (m *V4ToV5Migrator) TransformState(ctx *transform.Context, stateJSON gjson.Result, resourcePath, resourceName string) (string, error) {
+	result := stateJSON.String()
+
+	// Set schema_version to 0 for v5
+	result, _ = sjson.Set(result, "schema_version", 0)
+
+	// Datasource fields are mostly computed - provider will populate them on refresh
+	// No need to transform computed fields
+
+	return result, nil
+}

--- a/internal/datasources/zone/v4_to_v5_test.go
+++ b/internal/datasources/zone/v4_to_v5_test.go
@@ -1,0 +1,165 @@
+package zone
+
+import (
+	"testing"
+
+	"github.com/cloudflare/tf-migrate/internal/testhelpers"
+)
+
+func TestConfigTransformation(t *testing.T) {
+	migrator := NewV4ToV5Migrator()
+
+	tests := []testhelpers.ConfigTestCase{
+		{
+			Name: "zone_id only - no changes",
+			Input: `
+data "cloudflare_zone" "example" {
+  zone_id = "abc123"
+}`,
+			Expected: `
+data "cloudflare_zone" "example" {
+  zone_id = "abc123"
+}`,
+		},
+		{
+			Name: "name only - wrap in filter",
+			Input: `
+data "cloudflare_zone" "example" {
+  name = "example.com"
+}`,
+			Expected: `
+data "cloudflare_zone" "example" {
+  filter = {
+    name = "example.com"
+  }
+}`,
+		},
+		{
+			Name: "account_id only - wrap in filter",
+			Input: `
+data "cloudflare_zone" "example" {
+  account_id = "abc123"
+}`,
+			Expected: `
+data "cloudflare_zone" "example" {
+  filter = {
+    account = {
+      id = "abc123"
+    }
+  }
+}`,
+		},
+		{
+			Name: "name and account_id - both in filter",
+			Input: `
+data "cloudflare_zone" "example" {
+  name       = "example.com"
+  account_id = "abc123"
+}`,
+			Expected: `
+data "cloudflare_zone" "example" {
+  filter = {
+    name = "example.com"
+    account = {
+      id = "abc123"
+    }
+  }
+}`,
+		},
+		{
+			Name: "with variable references",
+			Input: `
+data "cloudflare_zone" "example" {
+  name       = var.zone_name
+  account_id = var.account_id
+}`,
+			Expected: `
+data "cloudflare_zone" "example" {
+  filter = {
+    name = var.zone_name
+    account = {
+      id = var.account_id
+    }
+  }
+}`,
+		},
+		{
+			Name: "multiple datasources in one file",
+			Input: `
+data "cloudflare_zone" "example1" {
+  zone_id = "abc123"
+}
+
+data "cloudflare_zone" "example2" {
+  name = "example.com"
+}`,
+			Expected: `
+data "cloudflare_zone" "example1" {
+  zone_id = "abc123"
+}
+
+data "cloudflare_zone" "example2" {
+  filter = {
+    name = "example.com"
+  }
+}`,
+		},
+	}
+
+	testhelpers.RunConfigTransformTests(t, tests, migrator)
+}
+
+func TestStateTransformation(t *testing.T) {
+	migrator := NewV4ToV5Migrator()
+
+	tests := []testhelpers.StateTestCase{
+		{
+			Name: "minimal state",
+			Input: `{
+  "schema_version": 1,
+  "attributes": {
+    "zone_id": "abc123",
+    "name": "example.com"
+  }
+}`,
+			Expected: `{
+  "schema_version": 0,
+  "attributes": {
+    "zone_id": "abc123",
+    "name": "example.com"
+  }
+}`,
+		},
+		{
+			Name: "full state with all v4 fields",
+			Input: `{
+  "schema_version": 1,
+  "attributes": {
+    "zone_id": "abc123",
+    "account_id": "def456",
+    "name": "example.com",
+    "status": "active",
+    "paused": false,
+    "plan": "free",
+    "name_servers": ["ns1.cloudflare.com", "ns2.cloudflare.com"],
+    "vanity_name_servers": []
+  }
+}`,
+			Expected: `{
+  "schema_version": 0,
+  "attributes": {
+    "zone_id": "abc123",
+    "account_id": "def456",
+    "name": "example.com",
+    "status": "active",
+    "paused": false,
+    "plan": "free",
+    "name_servers": ["ns1.cloudflare.com", "ns2.cloudflare.com"],
+    "vanity_name_servers": []
+  }
+}`,
+		},
+	}
+
+	testhelpers.RunStateTransformTests(t, tests, migrator)
+}

--- a/internal/datasources/zones/v4_to_v5.go
+++ b/internal/datasources/zones/v4_to_v5.go
@@ -35,6 +35,18 @@ func (m *V4ToV5Migrator) GetResourceType() string {
 	return "cloudflare_zones"
 }
 
+// GetAttributeRenames returns attribute renames for cross-file reference updates.
+// The zones datasource changed its output attribute from "zones" to "result".
+func (m *V4ToV5Migrator) GetAttributeRenames() []transform.AttributeRename {
+	return []transform.AttributeRename{
+		{
+			ResourceType: "data.cloudflare_zones",
+			OldAttribute: "zones",
+			NewAttribute: "result",
+		},
+	}
+}
+
 // CanHandle determines if this migrator can handle the given datasource type.
 func (m *V4ToV5Migrator) CanHandle(resourceType string) bool {
 	// Only match datasource type (with "data." prefix)

--- a/internal/datasources/zones/v4_to_v5.go
+++ b/internal/datasources/zones/v4_to_v5.go
@@ -1,0 +1,182 @@
+package zones
+
+import (
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/hashicorp/hcl/v2/hclwrite"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+
+	"github.com/cloudflare/tf-migrate/internal"
+	"github.com/cloudflare/tf-migrate/internal/transform"
+	tfhcl "github.com/cloudflare/tf-migrate/internal/transform/hcl"
+)
+
+// V4ToV5Migrator handles the migration of cloudflare_zones datasource from v4 to v5.
+// Key transformations:
+// 1. Remove filter block wrapper - flatten fields to top-level
+// 2. filter.account_id → account = { id = "..." }
+// 3. filter.name → name (hoist to top-level)
+// 4. filter.status → status (hoist to top-level)
+// 5. Drop: filter.lookup_type, filter.match, filter.paused (not supported in v5)
+// 6. State: zones → result
+type V4ToV5Migrator struct{}
+
+// NewV4ToV5Migrator creates a new migrator for cloudflare_zones datasource v4 to v5.
+func NewV4ToV5Migrator() transform.ResourceTransformer {
+	migrator := &V4ToV5Migrator{}
+	// Register with "data." prefix to distinguish from resource migration
+	internal.RegisterMigrator("data.cloudflare_zones", "v4", "v5", migrator)
+	return migrator
+}
+
+// GetResourceType returns the v5 datasource type this migrator handles.
+func (m *V4ToV5Migrator) GetResourceType() string {
+	return "cloudflare_zones"
+}
+
+// CanHandle determines if this migrator can handle the given datasource type.
+func (m *V4ToV5Migrator) CanHandle(resourceType string) bool {
+	// Only match datasource type (with "data." prefix)
+	return resourceType == "data.cloudflare_zones"
+}
+
+// Preprocess handles string-level transformations before HCL parsing.
+// No preprocessing needed for zones datasource migration.
+func (m *V4ToV5Migrator) Preprocess(content string) string {
+	return content
+}
+
+// TransformConfig handles configuration file transformations.
+// Main transformation: Remove filter block and flatten/restructure fields
+func (m *V4ToV5Migrator) TransformConfig(ctx *transform.Context, block *hclwrite.Block) (*transform.TransformResult, error) {
+	body := block.Body()
+
+	// Find filter block
+	filterBlocks := tfhcl.FindBlocksByType(body, "filter")
+	if len(filterBlocks) == 0 {
+		// No filter block - nothing to transform
+		return &transform.TransformResult{
+			Blocks:         []*hclwrite.Block{block},
+			RemoveOriginal: false,
+		}, nil
+	}
+
+	filterBlock := filterBlocks[0]
+	filterBody := filterBlock.Body()
+
+	// Extract filter attributes
+	accountIdAttr := filterBody.GetAttribute("account_id")
+	nameAttr := filterBody.GetAttribute("name")
+	statusAttr := filterBody.GetAttribute("status")
+	lookupTypeAttr := filterBody.GetAttribute("lookup_type")
+	matchAttr := filterBody.GetAttribute("match")
+	pausedAttr := filterBody.GetAttribute("paused")
+
+	// Transform account_id → account = { id = "..." }
+	if accountIdAttr != nil {
+		m.setAccountAttribute(body, accountIdAttr)
+	}
+
+	// Hoist name to top-level
+	if nameAttr != nil {
+		body.SetAttributeRaw("name", nameAttr.Expr().BuildTokens(nil))
+	}
+
+	// Hoist status to top-level
+	if statusAttr != nil {
+		body.SetAttributeRaw("status", statusAttr.Expr().BuildTokens(nil))
+	}
+
+	// Warn about dropped fields - these cannot be automatically migrated
+	// Users will need to manually adjust their configs if they relied on these fields
+	if lookupTypeAttr != nil {
+		ctx.Diagnostics = append(ctx.Diagnostics, &hcl.Diagnostic{
+			Severity: hcl.DiagWarning,
+			Summary:  "Field 'filter.lookup_type' cannot be automatically migrated",
+			Detail:   "In v5, use name filter operators directly in the name field (e.g., 'contains:example', 'starts_with:test'). See v5 documentation for available operators.",
+		})
+	}
+	if matchAttr != nil {
+		ctx.Diagnostics = append(ctx.Diagnostics, &hcl.Diagnostic{
+			Severity: hcl.DiagWarning,
+			Summary:  "Field 'filter.match' has been dropped",
+			Detail:   "v4's filter.match was a regex pattern for client-side filtering. v5's 'match' attribute has a completely different meaning (any/all combinator for search requirements). Manual migration required.",
+		})
+	}
+	if pausedAttr != nil {
+		ctx.Diagnostics = append(ctx.Diagnostics, &hcl.Diagnostic{
+			Severity: hcl.DiagWarning,
+			Summary:  "Field 'filter.paused' is not supported in v5",
+			Detail:   "The paused filter is not available in the v5 zones datasource. You will need to filter paused zones in your Terraform code after fetching the results.",
+		})
+	}
+
+	// Remove filter block
+	tfhcl.RemoveBlocksByType(body, "filter")
+
+	return &transform.TransformResult{
+		Blocks:         []*hclwrite.Block{block},
+		RemoveOriginal: false,
+	}, nil
+}
+
+// setAccountAttribute creates account = { id = "..." } from v4's account_id
+// Uses manual HCL token construction since account is a SingleNestedAttribute
+func (m *V4ToV5Migrator) setAccountAttribute(body *hclwrite.Body, accountIdAttr *hclwrite.Attribute) {
+	// Build: account = { id = <value> }
+	accountIdTokens := accountIdAttr.Expr().BuildTokens(nil)
+
+	tokens := hclwrite.Tokens{
+		{Type: hclsyntax.TokenOBrace, Bytes: []byte("{")},
+		{Type: hclsyntax.TokenNewline, Bytes: []byte("\n")},
+		{Type: hclsyntax.TokenIdent, Bytes: []byte("  id")},
+		{Type: hclsyntax.TokenEqual, Bytes: []byte(" = ")},
+	}
+	tokens = append(tokens, accountIdTokens...)
+	tokens = append(tokens,
+		&hclwrite.Token{Type: hclsyntax.TokenNewline, Bytes: []byte("\n")},
+		&hclwrite.Token{Type: hclsyntax.TokenCBrace, Bytes: []byte("}")},
+	)
+
+	body.SetAttributeRaw("account", tokens)
+}
+
+// TransformState handles state file transformations.
+// Main transformations:
+// 1. Set schema_version = 0
+// 2. Rename zones → result
+func (m *V4ToV5Migrator) TransformState(ctx *transform.Context, instance gjson.Result, resourcePath, resourceName string) (string, error) {
+	result := instance.String()
+	attrs := instance.Get("attributes")
+
+	if !attrs.Exists() {
+		// No attributes to transform, but still set schema_version
+		result, _ = sjson.Set(result, "schema_version", 0)
+		return result, nil
+	}
+
+	// Set schema_version to 0 for v5
+	result, _ = sjson.Set(result, "schema_version", 0)
+
+	// Rename zones → result
+	zonesField := attrs.Get("zones")
+	if zonesField.Exists() {
+		if zonesField.IsArray() {
+			// Copy zones to result
+			result, _ = sjson.Set(result, "attributes.result", zonesField.Value())
+			// Delete old zones field
+			result, _ = sjson.Delete(result, "attributes.zones")
+		} else {
+			// zones is null or missing - just delete it
+			result, _ = sjson.Delete(result, "attributes.zones")
+		}
+	}
+
+	return result, nil
+}
+
+func init() {
+	// Register the migrator on package initialization
+	NewV4ToV5Migrator()
+}

--- a/internal/datasources/zones/v4_to_v5_test.go
+++ b/internal/datasources/zones/v4_to_v5_test.go
@@ -1,0 +1,255 @@
+package zones
+
+import (
+	"testing"
+
+	"github.com/cloudflare/tf-migrate/internal/testhelpers"
+)
+
+func TestConfigTransformation(t *testing.T) {
+	migrator := NewV4ToV5Migrator()
+
+	testCases := []testhelpers.ConfigTestCase{
+		{
+			Name: "filter with account_id only",
+			Input: `data "cloudflare_zones" "test" {
+  filter {
+    account_id = "f037e56e89293a057740de681ac9abbe"
+  }
+}`,
+			Expected: `data "cloudflare_zones" "test" {
+  account = {
+    id = "f037e56e89293a057740de681ac9abbe"
+  }
+}`,
+		},
+		{
+			Name: "filter with name only",
+			Input: `data "cloudflare_zones" "test" {
+  filter {
+    name = "example.com"
+  }
+}`,
+			Expected: `data "cloudflare_zones" "test" {
+  name = "example.com"
+}`,
+		},
+		{
+			Name: "filter with status only",
+			Input: `data "cloudflare_zones" "test" {
+  filter {
+    status = "active"
+  }
+}`,
+			Expected: `data "cloudflare_zones" "test" {
+  status = "active"
+}`,
+		},
+		{
+			Name: "filter with account_id and name",
+			Input: `data "cloudflare_zones" "test" {
+  filter {
+    account_id = "f037e56e89293a057740de681ac9abbe"
+    name       = "example.com"
+  }
+}`,
+			Expected: `data "cloudflare_zones" "test" {
+  account = {
+    id = "f037e56e89293a057740de681ac9abbe"
+  }
+  name = "example.com"
+}`,
+		},
+		{
+			Name: "filter with all supported fields",
+			Input: `data "cloudflare_zones" "test" {
+  filter {
+    account_id = "f037e56e89293a057740de681ac9abbe"
+    name       = "example.com"
+    status     = "active"
+  }
+}`,
+			Expected: `data "cloudflare_zones" "test" {
+  account = {
+    id = "f037e56e89293a057740de681ac9abbe"
+  }
+  name   = "example.com"
+  status = "active"
+}`,
+		},
+		{
+			Name: "filter with dropped fields (lookup_type, match, paused)",
+			Input: `data "cloudflare_zones" "test" {
+  filter {
+    account_id  = "f037e56e89293a057740de681ac9abbe"
+    name        = "example"
+    lookup_type = "contains"
+    match       = "^not-"
+    paused      = false
+  }
+}`,
+			Expected: `data "cloudflare_zones" "test" {
+  account = {
+    id = "f037e56e89293a057740de681ac9abbe"
+  }
+  name = "example"
+}`,
+		},
+		{
+			Name: "variable references preserved",
+			Input: `data "cloudflare_zones" "test" {
+  filter {
+    account_id = var.account_id
+    name       = var.zone_name
+    status     = var.status
+  }
+}`,
+			Expected: `data "cloudflare_zones" "test" {
+  account = {
+    id = var.account_id
+  }
+  name   = var.zone_name
+  status = var.status
+}`,
+		},
+		{
+			Name: "local references preserved",
+			Input: `data "cloudflare_zones" "test" {
+  filter {
+    account_id = local.account_id
+    name       = local.zone_name
+  }
+}`,
+			Expected: `data "cloudflare_zones" "test" {
+  account = {
+    id = local.account_id
+  }
+  name = local.zone_name
+}`,
+		},
+		{
+			Name: "multiple datasources",
+			Input: `data "cloudflare_zones" "by_account" {
+  filter {
+    account_id = "abc123"
+  }
+}
+
+data "cloudflare_zones" "by_name" {
+  filter {
+    name = "example.com"
+  }
+}
+
+data "cloudflare_zones" "by_both" {
+  filter {
+    account_id = "abc123"
+    name       = "example.com"
+    status     = "active"
+  }
+}`,
+			Expected: `data "cloudflare_zones" "by_account" {
+  account = {
+    id = "abc123"
+  }
+}
+
+data "cloudflare_zones" "by_name" {
+  name = "example.com"
+}
+
+data "cloudflare_zones" "by_both" {
+  account = {
+    id = "abc123"
+  }
+  name   = "example.com"
+  status = "active"
+}`,
+		},
+	}
+
+	testhelpers.RunConfigTransformTests(t, testCases, migrator)
+}
+
+func TestStateTransformation(t *testing.T) {
+	migrator := NewV4ToV5Migrator()
+
+	testCases := []testhelpers.StateTestCase{
+		{
+			Name: "zones array to result array",
+			Input: `{
+  "schema_version": 1,
+  "attributes": {
+    "id": "checksum123",
+    "zones": [
+      {"id": "zone1", "name": "example.com"},
+      {"id": "zone2", "name": "test.com"}
+    ]
+  }
+}`,
+			Expected: `{
+  "schema_version": 0,
+  "attributes": {
+    "id": "checksum123",
+    "result": [
+      {"id": "zone1", "name": "example.com"},
+      {"id": "zone2", "name": "test.com"}
+    ]
+  }
+}`,
+		},
+		{
+			Name: "empty zones array",
+			Input: `{
+  "schema_version": 1,
+  "attributes": {
+    "id": "checksum123",
+    "zones": []
+  }
+}`,
+			Expected: `{
+  "schema_version": 0,
+  "attributes": {
+    "id": "checksum123",
+    "result": []
+  }
+}`,
+		},
+		{
+			Name: "null zones field",
+			Input: `{
+  "schema_version": 1,
+  "attributes": {
+    "id": "checksum123",
+    "zones": null
+  }
+}`,
+			Expected: `{
+  "schema_version": 0,
+  "attributes": {
+    "id": "checksum123"
+  }
+}`,
+		},
+		{
+			Name: "minimal state with no zones",
+			Input: `{
+  "schema_version": 1,
+  "attributes": {
+    "id": "checksum123"
+  }
+}`,
+			Expected: `{
+  "schema_version": 0,
+  "attributes": {
+    "id": "checksum123"
+  }
+}`,
+		},
+	}
+
+	testhelpers.RunStateTransformTests(t, testCases, migrator)
+}
+
+// Note: Warnings for dropped fields (lookup_type, match, paused) are added to ctx.Diagnostics
+// They can be verified through integration testing or manual testing

--- a/internal/handlers/resource_transform.go
+++ b/internal/handlers/resource_transform.go
@@ -35,7 +35,7 @@ func (h *ResourceTransformHandler) Handle(ctx *transform.Context) (*transform.Co
 	var blocksToAdd []*hclwrite.Block
 
 	for _, block := range blocks {
-		if block.Type() != "resource" {
+		if block.Type() != "resource" && block.Type() != "data" {
 			continue
 		}
 
@@ -45,6 +45,10 @@ func (h *ResourceTransformHandler) Handle(ctx *transform.Context) (*transform.Co
 		}
 
 		resourceType := labels[0]
+		// For data blocks, prefix with "data." to look up datasource migrators
+		if block.Type() == "data" {
+			resourceType = "data." + resourceType
+		}
 		migrator := h.provider.GetMigrator(resourceType, ctx.SourceVersion, ctx.TargetVersion)
 		if migrator == nil {
 			h.log.Debug("No migrator found for resource type", "type", resourceType, "source", ctx.SourceVersion, "target", ctx.TargetVersion)

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -2,6 +2,7 @@ package registry
 
 import (
 	zonedata "github.com/cloudflare/tf-migrate/internal/datasources/zone"
+	zonesdata "github.com/cloudflare/tf-migrate/internal/datasources/zones"
 	"github.com/cloudflare/tf-migrate/internal/resources/account_member"
 	"github.com/cloudflare/tf-migrate/internal/resources/api_token"
 	"github.com/cloudflare/tf-migrate/internal/resources/dns_record"
@@ -27,6 +28,7 @@ import (
 func RegisterAllMigrations() {
 	// Datasources
 	zonedata.NewV4ToV5Migrator()
+	zonesdata.NewV4ToV5Migrator()
 
 	// Resources
 	account_member.NewV4ToV5Migrator()

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -1,6 +1,7 @@
 package registry
 
 import (
+	zonedata "github.com/cloudflare/tf-migrate/internal/datasources/zone"
 	"github.com/cloudflare/tf-migrate/internal/resources/account_member"
 	"github.com/cloudflare/tf-migrate/internal/resources/api_token"
 	"github.com/cloudflare/tf-migrate/internal/resources/dns_record"
@@ -24,6 +25,10 @@ import (
 // This function should be called once during initialization to set up all available migrations.
 // Each resource package's NewV4ToV5Migrator function registers itself with the internal registry.
 func RegisterAllMigrations() {
+	// Datasources
+	zonedata.NewV4ToV5Migrator()
+
+	// Resources
 	account_member.NewV4ToV5Migrator()
 	api_token.NewV4ToV5Migrator()
 	dns_record.NewV4ToV5Migrator()

--- a/internal/testhelpers/config.go
+++ b/internal/testhelpers/config.go
@@ -41,8 +41,12 @@ func runConfigTransformTest(t *testing.T, tt ConfigTestCase, migrator transform.
 	// Step 4: Transform using HCL CFGFile
 	body := file.Body()
 	for _, block := range body.Blocks() {
-		if block.Type() == "resource" && len(block.Labels()) >= 2 {
+		if (block.Type() == "resource" || block.Type() == "data") && len(block.Labels()) >= 2 {
 			resourceType := block.Labels()[0]
+			// For data blocks, prefix with "data." to match datasource migrators
+			if block.Type() == "data" {
+				resourceType = "data." + resourceType
+			}
 			if migrator.CanHandle(resourceType) {
 				result, err := migrator.TransformConfig(ctx, block)
 				assert.NoError(t, err, "Failed to transform resource")

--- a/internal/transform/transformer.go
+++ b/internal/transform/transformer.go
@@ -52,6 +52,21 @@ type ResourceRenamer interface {
 	GetResourceRename() (oldType string, newType string)
 }
 
+// AttributeRename represents an attribute name change for a specific resource/datasource type
+type AttributeRename struct {
+	ResourceType string // The resource/datasource type (e.g., "cloudflare_zones", "data.cloudflare_zones")
+	OldAttribute string // The old attribute name (e.g., "zones")
+	NewAttribute string // The new attribute name (e.g., "result")
+}
+
+// AttributeRenamer is an optional interface that migrators can implement
+// to expose attribute renames. This enables global cross-file attribute reference updates.
+type AttributeRenamer interface {
+	// GetAttributeRenames returns a list of attribute renames for this migrator
+	// Each rename specifies the resource type and the old/new attribute names
+	GetAttributeRenames() []AttributeRename
+}
+
 // MigrationProvider specifies the interface for a migrator provider
 // This is used to provide a way to get migrators for a given resource type
 // a migrator defines the strategy which a resource uses to migrate the resource


### PR DESCRIPTION
Adds support for both `cloudflare_zone` and `cloudflare_zones` datasources.

Additionally the following changes were made to the migration tooling itself:

- added support for renamed attributes in references across files
- handle missing migration handlers more gracefully (warns instead of silently removing them)
- updates e2e test runner script to pull remote state so it can be tested with the migration