### PR TITLE
fix(zero_trust_dlp_custom_profile): update profiles to standard prefix for sweepers

### DIFF
--- a/integration/v4_to_v5/testdata/zero_trust_dlp_custom_profile/expected/terraform.tfstate
+++ b/integration/v4_to_v5/testdata/zero_trust_dlp_custom_profile/expected/terraform.tfstate
@@ -28,7 +28,7 @@
               }
             ],
             "id": "credit-cards-basic-id",
-            "name": "Credit Card Detection Basic"
+            "name": "tfmigrate-e2e-test-dlp-credit-cards-basic"
           },
           "schema_version": 0
         }
@@ -54,7 +54,7 @@
               }
             ],
             "id": "ssn-detection-id",
-            "name": "test-dlp-ssn-detection"
+            "name": "tfmigrate-e2e-test-dlp-ssn-detection"
           },
           "schema_version": 0
         }
@@ -81,7 +81,7 @@
               }
             ],
             "id": "minimal-id",
-            "name": "test-dlp-minimal"
+            "name": "tfmigrate-e2e-test-dlp-minimal"
           },
           "schema_version": 0
         }
@@ -109,7 +109,7 @@
               }
             ],
             "id": "card-amex-id",
-            "name": "Card Detection - AMEX"
+            "name": "tfmigrate-e2e-test-dlp-card-amex"
           },
           "index_key": "amex",
           "schema_version": 0
@@ -130,7 +130,7 @@
               }
             ],
             "id": "card-discover-id",
-            "name": "Card Detection - DISCOVER"
+            "name": "tfmigrate-e2e-test-dlp-card-discover"
           },
           "index_key": "discover",
           "schema_version": 0
@@ -151,7 +151,7 @@
               }
             ],
             "id": "card-mastercard-id",
-            "name": "Card Detection - MASTERCARD"
+            "name": "tfmigrate-e2e-test-dlp-card-mastercard"
           },
           "index_key": "mastercard",
           "schema_version": 0
@@ -172,7 +172,7 @@
               }
             ],
             "id": "card-visa-id",
-            "name": "Card Detection - VISA"
+            "name": "tfmigrate-e2e-test-dlp-card-visa"
           },
           "index_key": "visa",
           "schema_version": 0
@@ -199,7 +199,7 @@
               }
             ],
             "id": "pii-drivers-license-id",
-            "name": "PII Detection - DRIVERS LICENSE"
+            "name": "tfmigrate-e2e-test-dlp-pii-drivers_license"
           },
           "index_key": "drivers_license",
           "schema_version": 0
@@ -218,7 +218,7 @@
               }
             ],
             "id": "pii-passport-id",
-            "name": "PII Detection - PASSPORT"
+            "name": "tfmigrate-e2e-test-dlp-pii-passport"
           },
           "index_key": "passport",
           "schema_version": 0
@@ -237,7 +237,7 @@
               }
             ],
             "id": "pii-ssn-id",
-            "name": "PII Detection - SSN"
+            "name": "tfmigrate-e2e-test-dlp-pii-ssn"
           },
           "index_key": "ssn",
           "schema_version": 0
@@ -256,7 +256,7 @@
               }
             ],
             "id": "pii-tax-id-id",
-            "name": "PII Detection - TAX ID"
+            "name": "tfmigrate-e2e-test-dlp-pii-tax_id"
           },
           "index_key": "tax_id",
           "schema_version": 0
@@ -284,7 +284,7 @@
               }
             ],
             "id": "counted-0-id",
-            "name": "Counted Profile 1"
+            "name": "tfmigrate-e2e-test-dlp-counted-0"
           },
           "index_key": 0,
           "schema_version": 0
@@ -304,7 +304,7 @@
               }
             ],
             "id": "counted-1-id",
-            "name": "Counted Profile 2"
+            "name": "tfmigrate-e2e-test-dlp-counted-1"
           },
           "index_key": 1,
           "schema_version": 0
@@ -324,7 +324,7 @@
               }
             ],
             "id": "counted-2-id",
-            "name": "Counted Profile 3"
+            "name": "tfmigrate-e2e-test-dlp-counted-2"
           },
           "index_key": 2,
           "schema_version": 0
@@ -353,7 +353,7 @@
               }
             ],
             "id": "conditional-credit-id",
-            "name": "Conditional Credit Card Profile"
+            "name": "tfmigrate-e2e-test-dlp-conditional-credit"
           },
           "index_key": 0,
           "schema_version": 0
@@ -395,7 +395,7 @@
               }
             ],
             "id": "dynamic-entries-id",
-            "name": "Dynamic Entries Profile"
+            "name": "tfmigrate-e2e-test-dlp-dynamic-entries"
           },
           "schema_version": 0
         }
@@ -422,7 +422,7 @@
               }
             ],
             "id": "with-nulls-id",
-            "name": "Profile with Null Values"
+            "name": "tfmigrate-e2e-test-dlp-with-nulls"
           },
           "schema_version": 0
         }
@@ -449,7 +449,7 @@
               }
             ],
             "id": "prevent-destroy-id",
-            "name": "Protected Profile"
+            "name": "tfmigrate-e2e-test-dlp-protected"
           },
           "schema_version": 0
         }

--- a/integration/v4_to_v5/testdata/zero_trust_dlp_custom_profile/expected/zero_trust_dlp_custom_profile.tf
+++ b/integration/v4_to_v5/testdata/zero_trust_dlp_custom_profile/expected/zero_trust_dlp_custom_profile.tf
@@ -28,7 +28,7 @@ variable "max_allowed_matches" {
 # Locals for common values and computed configurations
 locals {
   common_account = var.cloudflare_account_id
-  name_prefix    = "test-dlp"
+  name_prefix    = "tfmigrate-e2e-test-dlp"
   tags           = ["migration", "test", "v4_to_v5"]
 
   # Map for for_each iteration
@@ -67,7 +67,7 @@ locals {
 # Pattern 1: Basic profiles with entries
 resource "cloudflare_zero_trust_dlp_custom_profile" "credit_cards_basic" {
   account_id          = local.common_account
-  name                = "Credit Card Detection Basic"
+  name                = "${local.name_prefix}-credit-cards-basic"
   description         = "Basic profile for detecting credit card numbers"
   allowed_match_count = var.max_allowed_matches
 
@@ -123,7 +123,7 @@ resource "cloudflare_zero_trust_dlp_custom_profile" "card_profiles_map" {
   for_each = local.card_patterns
 
   account_id          = var.cloudflare_account_id
-  name                = "Card Detection - ${upper(each.key)}"
+  name                = "${local.name_prefix}-card-${each.key}"
   description         = "Dedicated profile for ${each.key} cards"
   allowed_match_count = 10
 
@@ -142,7 +142,7 @@ resource "cloudflare_zero_trust_dlp_custom_profile" "pii_profiles_set" {
   for_each = local.pii_types
 
   account_id          = var.cloudflare_account_id
-  name                = "PII Detection - ${upper(replace(each.value, "_", " "))}"
+  name                = "${local.name_prefix}-pii-${each.value}"
   allowed_match_count = 2
 
   entries = [{
@@ -159,7 +159,7 @@ resource "cloudflare_zero_trust_dlp_custom_profile" "counted_profiles" {
   count = 3
 
   account_id          = var.cloudflare_account_id
-  name                = "Counted Profile ${count.index + 1}"
+  name                = "${local.name_prefix}-counted-${count.index}"
   description         = "This is profile number ${count.index}"
   allowed_match_count = count.index + 1
 
@@ -177,7 +177,7 @@ resource "cloudflare_zero_trust_dlp_custom_profile" "conditional_credit" {
   count = var.enable_credit_detection ? 1 : 0
 
   account_id          = var.cloudflare_account_id
-  name                = "Conditional Credit Card Profile"
+  name                = "${local.name_prefix}-conditional-credit"
   description         = "Created conditionally based on variable"
   allowed_match_count = 15
 
@@ -195,7 +195,7 @@ resource "cloudflare_zero_trust_dlp_custom_profile" "conditional_pii" {
   count = var.enable_pii_detection ? 1 : 0
 
   account_id          = var.cloudflare_account_id
-  name                = "Conditional PII Profile"
+  name                = "${local.name_prefix}-conditional-pii"
   allowed_match_count = 20
 
   entries = [{
@@ -210,7 +210,7 @@ resource "cloudflare_zero_trust_dlp_custom_profile" "conditional_pii" {
 # Pattern 6: Multiple entries
 resource "cloudflare_zero_trust_dlp_custom_profile" "dynamic_entries" {
   account_id          = var.cloudflare_account_id
-  name                = "Dynamic Entries Profile"
+  name                = "${local.name_prefix}-dynamic-entries"
   description         = "Profile with multiple entries"
   allowed_match_count = 30
 
@@ -240,7 +240,7 @@ resource "cloudflare_zero_trust_dlp_custom_profile" "dynamic_entries" {
 # Pattern 7: Profile with null values
 resource "cloudflare_zero_trust_dlp_custom_profile" "with_nulls" {
   account_id          = var.cloudflare_account_id
-  name                = "Profile with Null Values"
+  name                = "${local.name_prefix}-with-nulls"
   description         = null
   allowed_match_count = 4
 
@@ -257,7 +257,7 @@ resource "cloudflare_zero_trust_dlp_custom_profile" "with_nulls" {
 # Pattern 8: Profile with lifecycle meta-arguments
 resource "cloudflare_zero_trust_dlp_custom_profile" "prevent_destroy" {
   account_id          = var.cloudflare_account_id
-  name                = "Protected Profile"
+  name                = "${local.name_prefix}-protected"
   description         = "This profile should not be destroyed"
   allowed_match_count = 50
 

--- a/integration/v4_to_v5/testdata/zero_trust_dlp_custom_profile/input/terraform.tfstate
+++ b/integration/v4_to_v5/testdata/zero_trust_dlp_custom_profile/input/terraform.tfstate
@@ -15,7 +15,7 @@
           "attributes": {
             "id": "credit-cards-basic-id",
             "account_id": "test-account-id",
-            "name": "Credit Card Detection Basic",
+            "name": "tfmigrate-e2e-test-dlp-credit-cards-basic",
             "description": "Basic profile for detecting credit card numbers",
             "type": "custom",
             "allowed_match_count": 5,
@@ -57,7 +57,7 @@
           "attributes": {
             "id": "ssn-detection-id",
             "account_id": "test-account-id",
-            "name": "test-dlp-ssn-detection",
+            "name": "tfmigrate-e2e-test-dlp-ssn-detection",
             "type": "custom",
             "allowed_match_count": 3,
             "entry": [
@@ -87,7 +87,7 @@
           "attributes": {
             "id": "minimal-id",
             "account_id": "test-account-id",
-            "name": "test-dlp-minimal",
+            "name": "tfmigrate-e2e-test-dlp-minimal",
             "description": "Minimal configuration for test-account-id",
             "type": "custom",
             "allowed_match_count": 1,
@@ -119,7 +119,7 @@
           "attributes": {
             "id": "card-amex-id",
             "account_id": "test-account-id",
-            "name": "Card Detection - AMEX",
+            "name": "tfmigrate-e2e-test-dlp-card-amex",
             "description": "Dedicated profile for amex cards",
             "type": "custom",
             "allowed_match_count": 10,
@@ -143,7 +143,7 @@
           "attributes": {
             "id": "card-discover-id",
             "account_id": "test-account-id",
-            "name": "Card Detection - DISCOVER",
+            "name": "tfmigrate-e2e-test-dlp-card-discover",
             "description": "Dedicated profile for discover cards",
             "type": "custom",
             "allowed_match_count": 10,
@@ -167,7 +167,7 @@
           "attributes": {
             "id": "card-mastercard-id",
             "account_id": "test-account-id",
-            "name": "Card Detection - MASTERCARD",
+            "name": "tfmigrate-e2e-test-dlp-card-mastercard",
             "description": "Dedicated profile for mastercard cards",
             "type": "custom",
             "allowed_match_count": 10,
@@ -191,7 +191,7 @@
           "attributes": {
             "id": "card-visa-id",
             "account_id": "test-account-id",
-            "name": "Card Detection - VISA",
+            "name": "tfmigrate-e2e-test-dlp-card-visa",
             "description": "Dedicated profile for visa cards",
             "type": "custom",
             "allowed_match_count": 10,
@@ -223,7 +223,7 @@
           "attributes": {
             "id": "pii-drivers-license-id",
             "account_id": "test-account-id",
-            "name": "PII Detection - DRIVERS LICENSE",
+            "name": "tfmigrate-e2e-test-dlp-pii-drivers_license",
             "type": "custom",
             "allowed_match_count": 2,
             "entry": [
@@ -246,7 +246,7 @@
           "attributes": {
             "id": "pii-passport-id",
             "account_id": "test-account-id",
-            "name": "PII Detection - PASSPORT",
+            "name": "tfmigrate-e2e-test-dlp-pii-passport",
             "type": "custom",
             "allowed_match_count": 2,
             "entry": [
@@ -269,7 +269,7 @@
           "attributes": {
             "id": "pii-ssn-id",
             "account_id": "test-account-id",
-            "name": "PII Detection - SSN",
+            "name": "tfmigrate-e2e-test-dlp-pii-ssn",
             "type": "custom",
             "allowed_match_count": 2,
             "entry": [
@@ -292,7 +292,7 @@
           "attributes": {
             "id": "pii-tax-id-id",
             "account_id": "test-account-id",
-            "name": "PII Detection - TAX ID",
+            "name": "tfmigrate-e2e-test-dlp-pii-tax_id",
             "type": "custom",
             "allowed_match_count": 2,
             "entry": [
@@ -323,7 +323,7 @@
           "attributes": {
             "id": "counted-0-id",
             "account_id": "test-account-id",
-            "name": "Counted Profile 1",
+            "name": "tfmigrate-e2e-test-dlp-counted-0",
             "description": "This is profile number 0",
             "type": "custom",
             "allowed_match_count": 1,
@@ -347,7 +347,7 @@
           "attributes": {
             "id": "counted-1-id",
             "account_id": "test-account-id",
-            "name": "Counted Profile 2",
+            "name": "tfmigrate-e2e-test-dlp-counted-1",
             "description": "This is profile number 1",
             "type": "custom",
             "allowed_match_count": 2,
@@ -371,7 +371,7 @@
           "attributes": {
             "id": "counted-2-id",
             "account_id": "test-account-id",
-            "name": "Counted Profile 3",
+            "name": "tfmigrate-e2e-test-dlp-counted-2",
             "description": "This is profile number 2",
             "type": "custom",
             "allowed_match_count": 3,
@@ -403,7 +403,7 @@
           "attributes": {
             "id": "conditional-credit-id",
             "account_id": "test-account-id",
-            "name": "Conditional Credit Card Profile",
+            "name": "tfmigrate-e2e-test-dlp-conditional-credit",
             "description": "Created conditionally based on variable",
             "type": "custom",
             "allowed_match_count": 15,
@@ -434,7 +434,7 @@
           "attributes": {
             "id": "dynamic-entries-id",
             "account_id": "test-account-id",
-            "name": "Dynamic Entries Profile",
+            "name": "tfmigrate-e2e-test-dlp-dynamic-entries",
             "description": "Profile with dynamically generated entries",
             "type": "custom",
             "allowed_match_count": 30,
@@ -487,7 +487,7 @@
           "attributes": {
             "id": "with-nulls-id",
             "account_id": "test-account-id",
-            "name": "Profile with Null Values",
+            "name": "tfmigrate-e2e-test-dlp-with-nulls",
             "description": null,
             "type": "custom",
             "allowed_match_count": 4,
@@ -518,7 +518,7 @@
           "attributes": {
             "id": "prevent-destroy-id",
             "account_id": "test-account-id",
-            "name": "Protected Profile",
+            "name": "tfmigrate-e2e-test-dlp-protected",
             "description": "This profile should not be destroyed",
             "type": "custom",
             "allowed_match_count": 50,

--- a/integration/v4_to_v5/testdata/zero_trust_dlp_custom_profile/input/zero_trust_dlp_custom_profile.tf
+++ b/integration/v4_to_v5/testdata/zero_trust_dlp_custom_profile/input/zero_trust_dlp_custom_profile.tf
@@ -28,7 +28,7 @@ variable "max_allowed_matches" {
 # Locals for common values and computed configurations
 locals {
   common_account = var.cloudflare_account_id
-  name_prefix    = "test-dlp"
+  name_prefix    = "tfmigrate-e2e-test-dlp"
   tags           = ["migration", "test", "v4_to_v5"]
 
   # Map for for_each iteration
@@ -67,7 +67,7 @@ locals {
 # Pattern 1: Basic profiles with entries
 resource "cloudflare_dlp_profile" "credit_cards_basic" {
   account_id          = local.common_account
-  name                = "Credit Card Detection Basic"
+  name                = "${local.name_prefix}-credit-cards-basic"
   description         = "Basic profile for detecting credit card numbers"
   type                = "custom"
   allowed_match_count = var.max_allowed_matches
@@ -129,7 +129,7 @@ resource "cloudflare_dlp_profile" "card_profiles_map" {
   for_each = local.card_patterns
 
   account_id          = var.cloudflare_account_id
-  name                = "Card Detection - ${upper(each.key)}"
+  name                = "${local.name_prefix}-card-${each.key}"
   description         = "Dedicated profile for ${each.key} cards"
   type                = "custom"
   allowed_match_count = 10
@@ -150,7 +150,7 @@ resource "cloudflare_dlp_profile" "pii_profiles_set" {
   for_each = local.pii_types
 
   account_id          = var.cloudflare_account_id
-  name                = "PII Detection - ${upper(replace(each.value, "_", " "))}"
+  name                = "${local.name_prefix}-pii-${each.value}"
   type                = "custom"
   allowed_match_count = 2
 
@@ -168,7 +168,7 @@ resource "cloudflare_dlp_profile" "counted_profiles" {
   count = 3
 
   account_id          = var.cloudflare_account_id
-  name                = "Counted Profile ${count.index + 1}"
+  name                = "${local.name_prefix}-counted-${count.index}"
   description         = "This is profile number ${count.index}"
   type                = "custom"
   allowed_match_count = count.index + 1
@@ -188,7 +188,7 @@ resource "cloudflare_dlp_profile" "conditional_credit" {
   count = var.enable_credit_detection ? 1 : 0
 
   account_id          = var.cloudflare_account_id
-  name                = "Conditional Credit Card Profile"
+  name                = "${local.name_prefix}-conditional-credit"
   description         = "Created conditionally based on variable"
   type                = "custom"
   allowed_match_count = 15
@@ -208,7 +208,7 @@ resource "cloudflare_dlp_profile" "conditional_pii" {
   count = var.enable_pii_detection ? 1 : 0
 
   account_id          = var.cloudflare_account_id
-  name                = "Conditional PII Profile"
+  name                = "${local.name_prefix}-conditional-pii"
   type                = "custom"
   allowed_match_count = 20
 
@@ -224,7 +224,7 @@ resource "cloudflare_dlp_profile" "conditional_pii" {
 # Pattern 6: Multiple entries
 resource "cloudflare_dlp_profile" "dynamic_entries" {
   account_id          = var.cloudflare_account_id
-  name                = "Dynamic Entries Profile"
+  name                = "${local.name_prefix}-dynamic-entries"
   description         = "Profile with multiple entries"
   type                = "custom"
   allowed_match_count = 30
@@ -260,7 +260,7 @@ resource "cloudflare_dlp_profile" "dynamic_entries" {
 # Pattern 7: Profile with null values
 resource "cloudflare_dlp_profile" "with_nulls" {
   account_id          = var.cloudflare_account_id
-  name                = "Profile with Null Values"
+  name                = "${local.name_prefix}-with-nulls"
   description         = null
   type                = "custom"
   allowed_match_count = 4
@@ -279,7 +279,7 @@ resource "cloudflare_dlp_profile" "with_nulls" {
 # Pattern 8: Profile with lifecycle meta-arguments
 resource "cloudflare_dlp_profile" "prevent_destroy" {
   account_id          = var.cloudflare_account_id
-  name                = "Protected Profile"
+  name                = "${local.name_prefix}-protected"
   description         = "This profile should not be destroyed"
   type                = "custom"
   allowed_match_count = 50


### PR DESCRIPTION
- updates the profiles to use a prefix of `tfmigrate-e2e` so the sweeper in the provider can identify and delete them
- updates all profiles to use the same way of naming (`test-type-name`)