### PR TITLE
fix: update r2 variables to use CLOUDFLARE_ as a prefix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,7 @@ jobs:
           CLOUDFLARE_EMAIL: ${{ secrets.CLOUDFLARE_EMAIL }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           CLOUDFLARE_ZONE_ID: ${{ secrets.CLOUDFLARE_ZONE_ID }}
-          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
-          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          CLOUDFLARE_R2_ACCESS_KEY_ID: ${{ secrets.CLOUDFLARE_R2_ACCESS_KEY_ID }}
+          CLOUDFLARE_R2_SECRET_ACCESS_KEY: ${{ secrets.CLOUDFLARE_R2_SECRET_ACCESS_KEY }}
         run: |
           ./scripts/run-e2e-tests

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -49,7 +49,7 @@ If you've manually deleted resources from Cloudflare but they still exist in the
 ```bash
 # Remove tunnel modules from state
 cd e2e
-R2_ACCESS_KEY_ID=xxx R2_SECRET_ACCESS_KEY=yyy \
+CLOUDFLARE_R2_ACCESS_KEY_ID=xxx CLOUDFLARE_R2_SECRET_ACCESS_KEY=yyy \
   ./scripts/clean-state-modules \
     zero_trust_tunnel_cloudflared \
     zero_trust_tunnel_cloudflared_route

--- a/e2e/scripts/bootstrap-remote-state
+++ b/e2e/scripts/bootstrap-remote-state
@@ -27,16 +27,16 @@ if [[ -z "${CLOUDFLARE_ACCOUNT_ID:-}" ]]; then
     exit 1
 fi
 
-if [[ -z "${R2_ACCESS_KEY_ID:-}" ]]; then
-    echo -e "${RED}Error: R2_ACCESS_KEY_ID environment variable not set${NC}"
+if [[ -z "${CLOUDFLARE_R2_ACCESS_KEY_ID:-}" ]]; then
+    echo -e "${RED}Error: CLOUDFLARE_R2_ACCESS_KEY_ID environment variable not set${NC}"
     echo "Please set R2 credentials:"
-    echo "  export R2_ACCESS_KEY_ID=your-r2-access-key-id"
-    echo "  export R2_SECRET_ACCESS_KEY=your-r2-secret-access-key"
+    echo "  export CLOUDFLARE_R2_ACCESS_KEY_ID=your-r2-access-key-id"
+    echo "  export CLOUDFLARE_R2_SECRET_ACCESS_KEY=your-r2-secret-access-key"
     exit 1
 fi
 
-if [[ -z "${R2_SECRET_ACCESS_KEY:-}" ]]; then
-    echo -e "${RED}Error: R2_SECRET_ACCESS_KEY environment variable not set${NC}"
+if [[ -z "${CLOUDFLARE_R2_SECRET_ACCESS_KEY:-}" ]]; then
+    echo -e "${RED}Error: CLOUDFLARE_R2_SECRET_ACCESS_KEY environment variable not set${NC}"
     exit 1
 fi
 
@@ -49,7 +49,7 @@ echo -e "${GREEN}Using credentials:${NC}"
 echo -e "  ${CYAN}User:       ${CLOUDFLARE_EMAIL:-<not set>}${NC}"
 echo -e "  ${CYAN}Account ID: ${CLOUDFLARE_ACCOUNT_ID}${NC}"
 echo -e "  ${CYAN}Zone ID:    ${CLOUDFLARE_ZONE_ID:-<not set>}${NC}"
-echo -e "  ${CYAN}R2 Key ID:  ${R2_ACCESS_KEY_ID}${NC}"
+echo -e "  ${CYAN}R2 Key ID:  ${CLOUDFLARE_R2_ACCESS_KEY_ID}${NC}"
 echo ""
 
 # Check if local state exists
@@ -71,8 +71,8 @@ echo -e "${YELLOW}Configuring backend with account ID...${NC}"
 sed "s/ACCOUNT_ID/${CLOUDFLARE_ACCOUNT_ID}/g" "$BACKEND_CONFIG" > "$BACKEND_CONFIG_TMP"
 
 # Set R2 credentials (Terraform uses AWS S3-compatible API)
-export AWS_ACCESS_KEY_ID="$R2_ACCESS_KEY_ID"
-export AWS_SECRET_ACCESS_KEY="$R2_SECRET_ACCESS_KEY"
+export AWS_ACCESS_KEY_ID="$CLOUDFLARE_R2_ACCESS_KEY_ID"
+export AWS_SECRET_ACCESS_KEY="$CLOUDFLARE_R2_SECRET_ACCESS_KEY"
 
 echo -e "${YELLOW}Initializing Terraform with remote backend...${NC}"
 cd "$V4_DIR"

--- a/e2e/scripts/clean-state-modules
+++ b/e2e/scripts/clean-state-modules
@@ -26,8 +26,8 @@ show_usage() {
     echo "                 Multiple modules can be specified"
     echo ""
     echo "Environment variables required:"
-    echo "  R2_ACCESS_KEY_ID        R2 access key ID"
-    echo "  R2_SECRET_ACCESS_KEY    R2 secret access key"
+    echo "  CLOUDFLARE_R2_ACCESS_KEY_ID        R2 access key ID"
+    echo "  CLOUDFLARE_R2_SECRET_ACCESS_KEY    R2 secret access key"
     echo ""
     echo "Examples:"
     echo "  # Remove tunnels module"
@@ -37,7 +37,7 @@ show_usage() {
     echo "  $0 zero_trust_tunnel_cloudflared zero_trust_tunnel_cloudflared_route"
     echo ""
     echo "  # With explicit credentials"
-    echo "  R2_ACCESS_KEY_ID=xxx R2_SECRET_ACCESS_KEY=yyy $0 zero_trust_tunnel_cloudflared"
+    echo "  CLOUDFLARE_R2_ACCESS_KEY_ID=xxx CLOUDFLARE_R2_SECRET_ACCESS_KEY=yyy $0 zero_trust_tunnel_cloudflared"
     exit 1
 }
 
@@ -47,11 +47,11 @@ if [[ $# -eq 0 ]] || [[ "${1:-}" == "-h" ]] || [[ "${1:-}" == "--help" ]]; then
 fi
 
 # Check for R2 credentials
-if [[ -z "${R2_ACCESS_KEY_ID:-}" ]] || [[ -z "${R2_SECRET_ACCESS_KEY:-}" ]]; then
+if [[ -z "${CLOUDFLARE_R2_ACCESS_KEY_ID:-}" ]] || [[ -z "${CLOUDFLARE_R2_SECRET_ACCESS_KEY:-}" ]]; then
     echo -e "${RED}Error: R2 credentials not set${NC}"
-    echo "Please set: R2_ACCESS_KEY_ID and R2_SECRET_ACCESS_KEY"
+    echo "Please set: CLOUDFLARE_R2_ACCESS_KEY_ID and CLOUDFLARE_R2_SECRET_ACCESS_KEY"
     echo ""
-    echo "Usage: R2_ACCESS_KEY_ID=xxx R2_SECRET_ACCESS_KEY=yyy $0 <module_name>"
+    echo "Usage: CLOUDFLARE_R2_ACCESS_KEY_ID=xxx CLOUDFLARE_R2_SECRET_ACCESS_KEY=yyy $0 <module_name>"
     exit 1
 fi
 
@@ -70,8 +70,8 @@ fi
 cd "$V4_DIR"
 
 # Export R2 credentials for terraform
-export AWS_ACCESS_KEY_ID="$R2_ACCESS_KEY_ID"
-export AWS_SECRET_ACCESS_KEY="$R2_SECRET_ACCESS_KEY"
+export AWS_ACCESS_KEY_ID="$CLOUDFLARE_R2_ACCESS_KEY_ID"
+export AWS_SECRET_ACCESS_KEY="$CLOUDFLARE_R2_SECRET_ACCESS_KEY"
 
 echo -e "${CYAN}========================================${NC}"
 echo -e "${CYAN}Cleaning Modules from Remote State${NC}"

--- a/e2e/scripts/init
+++ b/e2e/scripts/init
@@ -210,9 +210,9 @@ if [[ -z "${CLOUDFLARE_EMAIL:-}" ]]; then
     exit 1
 fi
 
-if [[ -z "${R2_ACCESS_KEY_ID:-}" ]] || [[ -z "${R2_SECRET_ACCESS_KEY:-}" ]]; then
+if [[ -z "${CLOUDFLARE_R2_ACCESS_KEY_ID:-}" ]] || [[ -z "${CLOUDFLARE_R2_SECRET_ACCESS_KEY:-}" ]]; then
     echo -e "${RED}Error: R2 credentials not set${NC}"
-    echo "Please set: R2_ACCESS_KEY_ID and R2_SECRET_ACCESS_KEY"
+    echo "Please set: CLOUDFLARE_R2_ACCESS_KEY_ID and CLOUDFLARE_R2_SECRET_ACCESS_KEY"
     exit 1
 fi
 
@@ -223,8 +223,8 @@ BACKEND_CONFIG_TMP="${V4_DIR}/backend.configured.hcl"
 sed "s/ACCOUNT_ID/${CLOUDFLARE_ACCOUNT_ID}/g" "$BACKEND_CONFIG" > "$BACKEND_CONFIG_TMP"
 
 # Set R2 credentials (Terraform uses AWS S3-compatible API)
-export AWS_ACCESS_KEY_ID="$R2_ACCESS_KEY_ID"
-export AWS_SECRET_ACCESS_KEY="$R2_SECRET_ACCESS_KEY"
+export AWS_ACCESS_KEY_ID="$CLOUDFLARE_R2_ACCESS_KEY_ID"
+export AWS_SECRET_ACCESS_KEY="$CLOUDFLARE_R2_SECRET_ACCESS_KEY"
 
 echo -e "${GREEN}  ✓ Backend configured${NC}"
 echo ""

--- a/scripts/run-e2e-tests
+++ b/scripts/run-e2e-tests
@@ -210,9 +210,9 @@ if [[ "$SKIP_V4_TEST" == "false" ]]; then
 
   # Configure backend for terraform init
   # Check required environment variables for remote state
-  if [[ -z "${R2_ACCESS_KEY_ID:-}" ]] || [[ -z "${R2_SECRET_ACCESS_KEY:-}" ]]; then
+  if [[ -z "${CLOUDFLARE_R2_ACCESS_KEY_ID:-}" ]] || [[ -z "${CLOUDFLARE_R2_SECRET_ACCESS_KEY:-}" ]]; then
       echo -e "${RED}Error: R2 credentials not set${NC}"
-      echo "Please set: R2_ACCESS_KEY_ID and R2_SECRET_ACCESS_KEY"
+      echo "Please set: CLOUDFLARE_R2_ACCESS_KEY_ID and CLOUDFLARE_R2_SECRET_ACCESS_KEY"
       exit 1
   fi
 
@@ -222,8 +222,8 @@ if [[ "$SKIP_V4_TEST" == "false" ]]; then
   sed "s/ACCOUNT_ID/${CLOUDFLARE_ACCOUNT_ID}/g" "$BACKEND_CONFIG" > "$BACKEND_CONFIG_TMP"
 
   # Set R2 credentials (Terraform uses AWS S3-compatible API)
-  export AWS_ACCESS_KEY_ID="$R2_ACCESS_KEY_ID"
-  export AWS_SECRET_ACCESS_KEY="$R2_SECRET_ACCESS_KEY"
+  export AWS_ACCESS_KEY_ID="$CLOUDFLARE_R2_ACCESS_KEY_ID"
+  export AWS_SECRET_ACCESS_KEY="$CLOUDFLARE_R2_SECRET_ACCESS_KEY"
 
   # Clean .terraform if switching accounts to avoid migration prompts
   if [[ -f "${V4_DIR}/.terraform/terraform.tfstate" ]]; then


### PR DESCRIPTION
The vars `R2_ACCESS_KEY_ID` and `R2_SECRET_ACCESS_KEY` did not use the prefix `CLOUDFLARE_`. The sweepers expect this prefix, and these env vars were non standard compared to other env vars in use. 