### PR TITLE
fix: add resource prefixes for easier cleanup

### DIFF
--- a/integration/v4_to_v5/testdata/r2_bucket/expected/r2_bucket.tf
+++ b/integration/v4_to_v5/testdata/r2_bucket/expected/r2_bucket.tf
@@ -16,7 +16,7 @@ variable "cloudflare_zone_id" {
 # ============================================================================
 locals {
   common_account = var.cloudflare_account_id
-  name_prefix    = "test-integration"
+  name_prefix    = "cf-tf-test"
   locations = {
     "wnam" = "WNAM"
     "enam" = "ENAM"
@@ -36,37 +36,37 @@ locals {
 # Test Case 1: Minimal bucket with only required fields
 resource "cloudflare_r2_bucket" "minimal" {
   account_id = var.cloudflare_account_id
-  name       = "minimal-bucket"
+  name       = "${local.name_prefix}-minimal-bucket"
 }
 
 # Test Case 2: Bucket with all locations tested
 resource "cloudflare_r2_bucket" "location_wnam" {
   account_id = var.cloudflare_account_id
-  name       = "bucket-wnam"
+  name       = "${local.name_prefix}-bucket-wnam"
   location   = "WNAM"
 }
 
 resource "cloudflare_r2_bucket" "location_enam" {
   account_id = var.cloudflare_account_id
-  name       = "bucket-enam"
+  name       = "${local.name_prefix}-bucket-enam"
   location   = "ENAM"
 }
 
 resource "cloudflare_r2_bucket" "location_weur" {
   account_id = var.cloudflare_account_id
-  name       = "bucket-weur"
+  name       = "${local.name_prefix}-bucket-weur"
   location   = "WEUR"
 }
 
 resource "cloudflare_r2_bucket" "location_eeur" {
   account_id = var.cloudflare_account_id
-  name       = "bucket-eeur"
+  name       = "${local.name_prefix}-bucket-eeur"
   location   = "EEUR"
 }
 
 resource "cloudflare_r2_bucket" "location_apac" {
   account_id = var.cloudflare_account_id
-  name       = "bucket-apac"
+  name       = "${local.name_prefix}-bucket-apac"
   location   = "APAC"
 }
 
@@ -83,15 +83,15 @@ resource "cloudflare_r2_bucket" "location_oc" {
 resource "cloudflare_r2_bucket" "map_example" {
   for_each = {
     "data" = {
-      name     = "data-bucket"
+      name     = "${local.name_prefix}-data-bucket"
       location = "WNAM"
     }
     "logs" = {
-      name     = "logs-bucket"
+      name     = "${local.name_prefix}-logs-bucket"
       location = "ENAM"
     }
     "backups" = {
-      name     = "backups-bucket"
+      name     = "${local.name_prefix}-backups-bucket"
       location = "WEUR"
     }
   }
@@ -114,7 +114,7 @@ resource "cloudflare_r2_bucket" "set_example" {
   ])
 
   account_id = var.cloudflare_account_id
-  name       = "set-${each.value}-bucket"
+  name       = "${local.name_prefix}-set-${each.value}-bucket"
 }
 
 # ============================================================================
@@ -125,7 +125,7 @@ resource "cloudflare_r2_bucket" "counted" {
   count = 3
 
   account_id = var.cloudflare_account_id
-  name       = "counted-bucket-${count.index}"
+  name       = "${local.name_prefix}-counted-bucket-${count.index}"
   location   = count.index == 0 ? "WNAM" : count.index == 1 ? "EEUR" : "APAC"
 }
 
@@ -137,7 +137,7 @@ resource "cloudflare_r2_bucket" "conditional_enabled" {
   count = local.enable_feature ? 1 : 0
 
   account_id = var.cloudflare_account_id
-  name       = "conditional-enabled-bucket"
+  name       = "${local.name_prefix}-conditional-enabled-bucket"
   location   = "WNAM"
 }
 
@@ -145,7 +145,7 @@ resource "cloudflare_r2_bucket" "conditional_disabled" {
   count = local.enable_test ? 1 : 0
 
   account_id = var.cloudflare_account_id
-  name       = "conditional-disabled-bucket"
+  name       = "${local.name_prefix}-conditional-disabled-bucket"
   location   = "EEUR"
 }
 
@@ -171,7 +171,7 @@ resource "cloudflare_r2_bucket" "with_interpolation" {
 
 resource "cloudflare_r2_bucket" "with_lifecycle" {
   account_id = var.cloudflare_account_id
-  name       = "lifecycle-test-bucket"
+  name       = "${local.name_prefix}-lifecycle-test-bucket"
   location   = "WNAM"
 
   lifecycle {
@@ -181,7 +181,7 @@ resource "cloudflare_r2_bucket" "with_lifecycle" {
 
 resource "cloudflare_r2_bucket" "with_prevent_destroy" {
   account_id = var.cloudflare_account_id
-  name       = "prevent-destroy-bucket"
+  name       = "${local.name_prefix}-prevent-destroy-bucket"
   location   = "EEUR"
 
   lifecycle {
@@ -193,21 +193,15 @@ resource "cloudflare_r2_bucket" "with_prevent_destroy" {
 # Pattern Group 9: Edge Cases
 # ============================================================================
 
-# Special characters in bucket names (hyphens and numbers)
-resource "cloudflare_r2_bucket" "special_chars" {
-  account_id = var.cloudflare_account_id
-  name       = "bucket-with-dashes-and-numbers-123"
-}
-
 # Long bucket name (testing near max length - 63 chars max)
 resource "cloudflare_r2_bucket" "long_name" {
   account_id = var.cloudflare_account_id
-  name       = "very-long-bucket-name-for-testing-migration-limits-max-len"
+  name       = "${local.name_prefix}-long-bucket-name-to-test-migration-limits-max-len"
 }
 
 # Bucket name with all allowed characters (lowercase, numbers, hyphens)
 resource "cloudflare_r2_bucket" "all_chars" {
   account_id = var.cloudflare_account_id
-  name       = "bucket-name-with-all-valid-chars-123-test"
+  name       = "${local.name_prefix}-bucket-name-with-all-valid-chars-123-test"
   location   = "WNAM"
 }

--- a/integration/v4_to_v5/testdata/r2_bucket/expected/terraform.tfstate
+++ b/integration/v4_to_v5/testdata/r2_bucket/expected/terraform.tfstate
@@ -14,9 +14,9 @@
         {
           "schema_version": 0,
           "attributes": {
-            "id": "minimal-bucket",
+            "id": "cf-tf-test-minimal-bucket",
             "account_id": "f037e56e89293a057740de681ac9abbe",
-            "name": "minimal-bucket",
+            "name": "cf-tf-test-minimal-bucket",
             "jurisdiction": "default",
             "storage_class": "Standard"
           }
@@ -32,9 +32,9 @@
         {
           "schema_version": 0,
           "attributes": {
-            "id": "bucket-wnam",
+            "id": "cf-tf-test-bucket-wnam",
             "account_id": "f037e56e89293a057740de681ac9abbe",
-            "name": "bucket-wnam",
+            "name": "cf-tf-test-bucket-wnam",
             "location": "WNAM",
             "jurisdiction": "default",
             "storage_class": "Standard"
@@ -51,9 +51,9 @@
         {
           "schema_version": 0,
           "attributes": {
-            "id": "bucket-enam",
+            "id": "cf-tf-test-bucket-enam",
             "account_id": "f037e56e89293a057740de681ac9abbe",
-            "name": "bucket-enam",
+            "name": "cf-tf-test-bucket-enam",
             "location": "ENAM",
             "jurisdiction": "default",
             "storage_class": "Standard"
@@ -70,9 +70,9 @@
         {
           "schema_version": 0,
           "attributes": {
-            "id": "bucket-weur",
+            "id": "cf-tf-test-bucket-weur",
             "account_id": "f037e56e89293a057740de681ac9abbe",
-            "name": "bucket-weur",
+            "name": "cf-tf-test-bucket-weur",
             "location": "WEUR",
             "jurisdiction": "default",
             "storage_class": "Standard"
@@ -89,9 +89,9 @@
         {
           "schema_version": 0,
           "attributes": {
-            "id": "bucket-eeur",
+            "id": "cf-tf-test-bucket-eeur",
             "account_id": "f037e56e89293a057740de681ac9abbe",
-            "name": "bucket-eeur",
+            "name": "cf-tf-test-bucket-eeur",
             "location": "EEUR",
             "jurisdiction": "default",
             "storage_class": "Standard"
@@ -108,9 +108,9 @@
         {
           "schema_version": 0,
           "attributes": {
-            "id": "bucket-apac",
+            "id": "cf-tf-test-bucket-apac",
             "account_id": "f037e56e89293a057740de681ac9abbe",
-            "name": "bucket-apac",
+            "name": "cf-tf-test-bucket-apac",
             "location": "APAC",
             "jurisdiction": "default",
             "storage_class": "Standard"
@@ -147,9 +147,9 @@
           "index_key": "backups",
           "schema_version": 0,
           "attributes": {
-            "id": "backups-bucket",
+            "id": "cf-tf-test-backups-bucket",
             "account_id": "f037e56e89293a057740de681ac9abbe",
-            "name": "backups-bucket",
+            "name": "cf-tf-test-backups-bucket",
             "location": "WEUR",
             "jurisdiction": "default",
             "storage_class": "Standard"
@@ -159,9 +159,9 @@
           "index_key": "data",
           "schema_version": 0,
           "attributes": {
-            "id": "data-bucket",
+            "id": "cf-tf-test-data-bucket",
             "account_id": "f037e56e89293a057740de681ac9abbe",
-            "name": "data-bucket",
+            "name": "cf-tf-test-data-bucket",
             "location": "WNAM",
             "jurisdiction": "default",
             "storage_class": "Standard"
@@ -171,9 +171,9 @@
           "index_key": "logs",
           "schema_version": 0,
           "attributes": {
-            "id": "logs-bucket",
+            "id": "cf-tf-test-logs-bucket",
             "account_id": "f037e56e89293a057740de681ac9abbe",
-            "name": "logs-bucket",
+            "name": "cf-tf-test-logs-bucket",
             "location": "ENAM",
             "jurisdiction": "default",
             "storage_class": "Standard"
@@ -191,9 +191,9 @@
           "index_key": "alpha",
           "schema_version": 0,
           "attributes": {
-            "id": "set-alpha-bucket",
+            "id": "cf-tf-test-set-alpha-bucket",
             "account_id": "f037e56e89293a057740de681ac9abbe",
-            "name": "set-alpha-bucket",
+            "name": "cf-tf-test-set-alpha-bucket",
             "jurisdiction": "default",
             "storage_class": "Standard"
           }
@@ -202,9 +202,9 @@
           "index_key": "beta",
           "schema_version": 0,
           "attributes": {
-            "id": "set-beta-bucket",
+            "id": "cf-tf-test-set-beta-bucket",
             "account_id": "f037e56e89293a057740de681ac9abbe",
-            "name": "set-beta-bucket",
+            "name": "cf-tf-test-set-beta-bucket",
             "jurisdiction": "default",
             "storage_class": "Standard"
           }
@@ -213,9 +213,9 @@
           "index_key": "delta",
           "schema_version": 0,
           "attributes": {
-            "id": "set-delta-bucket",
+            "id": "cf-tf-test-set-delta-bucket",
             "account_id": "f037e56e89293a057740de681ac9abbe",
-            "name": "set-delta-bucket",
+            "name": "cf-tf-test-set-delta-bucket",
             "jurisdiction": "default",
             "storage_class": "Standard"
           }
@@ -224,9 +224,9 @@
           "index_key": "gamma",
           "schema_version": 0,
           "attributes": {
-            "id": "set-gamma-bucket",
+            "id": "cf-tf-test-set-gamma-bucket",
             "account_id": "f037e56e89293a057740de681ac9abbe",
-            "name": "set-gamma-bucket",
+            "name": "cf-tf-test-set-gamma-bucket",
             "jurisdiction": "default",
             "storage_class": "Standard"
           }
@@ -243,9 +243,9 @@
           "index": 0,
           "schema_version": 0,
           "attributes": {
-            "id": "counted-bucket-0",
+            "id": "cf-tf-test-counted-bucket-0",
             "account_id": "f037e56e89293a057740de681ac9abbe",
-            "name": "counted-bucket-0",
+            "name": "cf-tf-test-counted-bucket-0",
             "location": "WNAM",
             "jurisdiction": "default",
             "storage_class": "Standard"
@@ -255,9 +255,9 @@
           "index": 1,
           "schema_version": 0,
           "attributes": {
-            "id": "counted-bucket-1",
+            "id": "cf-tf-test-counted-bucket-1",
             "account_id": "f037e56e89293a057740de681ac9abbe",
-            "name": "counted-bucket-1",
+            "name": "cf-tf-test-counted-bucket-1",
             "location": "EEUR",
             "jurisdiction": "default",
             "storage_class": "Standard"
@@ -267,9 +267,9 @@
           "index": 2,
           "schema_version": 0,
           "attributes": {
-            "id": "counted-bucket-2",
+            "id": "cf-tf-test-counted-bucket-2",
             "account_id": "f037e56e89293a057740de681ac9abbe",
-            "name": "counted-bucket-2",
+            "name": "cf-tf-test-counted-bucket-2",
             "location": "APAC",
             "jurisdiction": "default",
             "storage_class": "Standard"
@@ -287,9 +287,9 @@
           "index": 0,
           "schema_version": 0,
           "attributes": {
-            "id": "conditional-enabled-bucket",
+            "id": "cf-tf-test-conditional-enabled-bucket",
             "account_id": "f037e56e89293a057740de681ac9abbe",
-            "name": "conditional-enabled-bucket",
+            "name": "cf-tf-test-conditional-enabled-bucket",
             "location": "WNAM",
             "jurisdiction": "default",
             "storage_class": "Standard"
@@ -306,9 +306,9 @@
         {
           "schema_version": 0,
           "attributes": {
-            "id": "test-integration-function-test",
+            "id": "cf-tf-test-function-test",
             "account_id": "f037e56e89293a057740de681ac9abbe",
-            "name": "test-integration-function-test",
+            "name": "cf-tf-test-function-test",
             "location": "WNAM",
             "jurisdiction": "default",
             "storage_class": "Standard"
@@ -325,9 +325,9 @@
         {
           "schema_version": 0,
           "attributes": {
-            "id": "test-integration-interpolated-bucket",
+            "id": "cf-tf-test-interpolated-bucket",
             "account_id": "f037e56e89293a057740de681ac9abbe",
-            "name": "test-integration-interpolated-bucket",
+            "name": "cf-tf-test-interpolated-bucket",
             "location": "EEUR",
             "jurisdiction": "default",
             "storage_class": "Standard"
@@ -344,9 +344,9 @@
         {
           "schema_version": 0,
           "attributes": {
-            "id": "lifecycle-test-bucket",
+            "id": "cf-tf-test-lifecycle-test-bucket",
             "account_id": "f037e56e89293a057740de681ac9abbe",
-            "name": "lifecycle-test-bucket",
+            "name": "cf-tf-test-lifecycle-test-bucket",
             "location": "WNAM",
             "jurisdiction": "default",
             "storage_class": "Standard"
@@ -363,9 +363,9 @@
         {
           "schema_version": 0,
           "attributes": {
-            "id": "prevent-destroy-bucket",
+            "id": "cf-tf-test-prevent-destroy-bucket",
             "account_id": "f037e56e89293a057740de681ac9abbe",
-            "name": "prevent-destroy-bucket",
+            "name": "cf-tf-test-prevent-destroy-bucket",
             "location": "EEUR",
             "jurisdiction": "default",
             "storage_class": "Standard"
@@ -382,28 +382,10 @@
         {
           "schema_version": 0,
           "attributes": {
-            "id": "bucket-name-with-all-valid-chars-123-test",
+            "id": "cf-tf-test-bucket-name-with-all-valid-chars-123-test",
             "account_id": "f037e56e89293a057740de681ac9abbe",
-            "name": "bucket-name-with-all-valid-chars-123-test",
+            "name": "cf-tf-test-bucket-name-with-all-valid-chars-123-test",
             "location": "WNAM",
-            "jurisdiction": "default",
-            "storage_class": "Standard"
-          }
-        }
-      ]
-    },
-    {
-      "mode": "managed",
-      "type": "cloudflare_r2_bucket",
-      "name": "special_chars",
-      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
-      "instances": [
-        {
-          "schema_version": 0,
-          "attributes": {
-            "id": "bucket-with-dashes-and-numbers-123",
-            "account_id": "f037e56e89293a057740de681ac9abbe",
-            "name": "bucket-with-dashes-and-numbers-123",
             "jurisdiction": "default",
             "storage_class": "Standard"
           }
@@ -419,9 +401,9 @@
         {
           "schema_version": 0,
           "attributes": {
-            "id": "very-long-bucket-name-for-testing-migration-limits-max-len",
+            "id": "cf-tf-test-long-bucket-name-to-test-migration-limits-max-len",
             "account_id": "f037e56e89293a057740de681ac9abbe",
-            "name": "very-long-bucket-name-for-testing-migration-limits-max-len",
+            "name": "cf-tf-test-long-bucket-name-to-test-migration-limits-max-len",
             "jurisdiction": "default",
             "storage_class": "Standard"
           }

--- a/integration/v4_to_v5/testdata/r2_bucket/input/r2_bucket.tf
+++ b/integration/v4_to_v5/testdata/r2_bucket/input/r2_bucket.tf
@@ -16,7 +16,7 @@ variable "cloudflare_zone_id" {
 # ============================================================================
 locals {
   common_account = var.cloudflare_account_id
-  name_prefix    = "test-integration"
+  name_prefix    = "cf-tf-test"
   locations = {
     "wnam" = "WNAM"
     "enam" = "ENAM"
@@ -36,37 +36,37 @@ locals {
 # Test Case 1: Minimal bucket with only required fields
 resource "cloudflare_r2_bucket" "minimal" {
   account_id = var.cloudflare_account_id
-  name       = "minimal-bucket"
+  name       = "${local.name_prefix}-minimal-bucket"
 }
 
 # Test Case 2: Bucket with all locations tested
 resource "cloudflare_r2_bucket" "location_wnam" {
   account_id = var.cloudflare_account_id
-  name       = "bucket-wnam"
+  name       = "${local.name_prefix}-bucket-wnam"
   location   = "WNAM"
 }
 
 resource "cloudflare_r2_bucket" "location_enam" {
   account_id = var.cloudflare_account_id
-  name       = "bucket-enam"
+  name       = "${local.name_prefix}-bucket-enam"
   location   = "ENAM"
 }
 
 resource "cloudflare_r2_bucket" "location_weur" {
   account_id = var.cloudflare_account_id
-  name       = "bucket-weur"
+  name       = "${local.name_prefix}-bucket-weur"
   location   = "WEUR"
 }
 
 resource "cloudflare_r2_bucket" "location_eeur" {
   account_id = var.cloudflare_account_id
-  name       = "bucket-eeur"
+  name       = "${local.name_prefix}-bucket-eeur"
   location   = "EEUR"
 }
 
 resource "cloudflare_r2_bucket" "location_apac" {
   account_id = var.cloudflare_account_id
-  name       = "bucket-apac"
+  name       = "${local.name_prefix}-bucket-apac"
   location   = "APAC"
 }
 
@@ -83,15 +83,15 @@ resource "cloudflare_r2_bucket" "location_oc" {
 resource "cloudflare_r2_bucket" "map_example" {
   for_each = {
     "data" = {
-      name     = "data-bucket"
+      name     = "${local.name_prefix}-data-bucket"
       location = "WNAM"
     }
     "logs" = {
-      name     = "logs-bucket"
+      name     = "${local.name_prefix}-logs-bucket"
       location = "ENAM"
     }
     "backups" = {
-      name     = "backups-bucket"
+      name     = "${local.name_prefix}-backups-bucket"
       location = "WEUR"
     }
   }
@@ -114,7 +114,7 @@ resource "cloudflare_r2_bucket" "set_example" {
   ])
 
   account_id = var.cloudflare_account_id
-  name       = "set-${each.value}-bucket"
+  name       = "${local.name_prefix}-set-${each.value}-bucket"
 }
 
 # ============================================================================
@@ -125,7 +125,7 @@ resource "cloudflare_r2_bucket" "counted" {
   count = 3
 
   account_id = var.cloudflare_account_id
-  name       = "counted-bucket-${count.index}"
+  name       = "${local.name_prefix}-counted-bucket-${count.index}"
   location   = count.index == 0 ? "WNAM" : count.index == 1 ? "EEUR" : "APAC"
 }
 
@@ -137,7 +137,7 @@ resource "cloudflare_r2_bucket" "conditional_enabled" {
   count = local.enable_feature ? 1 : 0
 
   account_id = var.cloudflare_account_id
-  name       = "conditional-enabled-bucket"
+  name       = "${local.name_prefix}-conditional-enabled-bucket"
   location   = "WNAM"
 }
 
@@ -145,7 +145,7 @@ resource "cloudflare_r2_bucket" "conditional_disabled" {
   count = local.enable_test ? 1 : 0
 
   account_id = var.cloudflare_account_id
-  name       = "conditional-disabled-bucket"
+  name       = "${local.name_prefix}-conditional-disabled-bucket"
   location   = "EEUR"
 }
 
@@ -171,7 +171,7 @@ resource "cloudflare_r2_bucket" "with_interpolation" {
 
 resource "cloudflare_r2_bucket" "with_lifecycle" {
   account_id = var.cloudflare_account_id
-  name       = "lifecycle-test-bucket"
+  name       = "${local.name_prefix}-lifecycle-test-bucket"
   location   = "WNAM"
 
   lifecycle {
@@ -181,7 +181,7 @@ resource "cloudflare_r2_bucket" "with_lifecycle" {
 
 resource "cloudflare_r2_bucket" "with_prevent_destroy" {
   account_id = var.cloudflare_account_id
-  name       = "prevent-destroy-bucket"
+  name       = "${local.name_prefix}-prevent-destroy-bucket"
   location   = "EEUR"
 
   lifecycle {
@@ -193,21 +193,15 @@ resource "cloudflare_r2_bucket" "with_prevent_destroy" {
 # Pattern Group 9: Edge Cases
 # ============================================================================
 
-# Special characters in bucket names (hyphens and numbers)
-resource "cloudflare_r2_bucket" "special_chars" {
-  account_id = var.cloudflare_account_id
-  name       = "bucket-with-dashes-and-numbers-123"
-}
-
 # Long bucket name (testing near max length - 63 chars max)
 resource "cloudflare_r2_bucket" "long_name" {
   account_id = var.cloudflare_account_id
-  name       = "very-long-bucket-name-for-testing-migration-limits-max-len"
+  name       = "${local.name_prefix}-long-bucket-name-to-test-migration-limits-max-len"
 }
 
 # Bucket name with all allowed characters (lowercase, numbers, hyphens)
 resource "cloudflare_r2_bucket" "all_chars" {
   account_id = var.cloudflare_account_id
-  name       = "bucket-name-with-all-valid-chars-123-test"
+  name       = "${local.name_prefix}-bucket-name-with-all-valid-chars-123-test"
   location   = "WNAM"
 }

--- a/integration/v4_to_v5/testdata/r2_bucket/input/terraform.tfstate
+++ b/integration/v4_to_v5/testdata/r2_bucket/input/terraform.tfstate
@@ -14,9 +14,9 @@
         {
           "schema_version": 0,
           "attributes": {
-            "id": "minimal-bucket",
+            "id": "cf-tf-test-minimal-bucket",
             "account_id": "f037e56e89293a057740de681ac9abbe",
-            "name": "minimal-bucket"
+            "name": "cf-tf-test-minimal-bucket"
           }
         }
       ]
@@ -30,9 +30,9 @@
         {
           "schema_version": 0,
           "attributes": {
-            "id": "bucket-wnam",
+            "id": "cf-tf-test-bucket-wnam",
             "account_id": "f037e56e89293a057740de681ac9abbe",
-            "name": "bucket-wnam",
+            "name": "cf-tf-test-bucket-wnam",
             "location": "WNAM"
           }
         }
@@ -47,9 +47,9 @@
         {
           "schema_version": 0,
           "attributes": {
-            "id": "bucket-enam",
+            "id": "cf-tf-test-bucket-enam",
             "account_id": "f037e56e89293a057740de681ac9abbe",
-            "name": "bucket-enam",
+            "name": "cf-tf-test-bucket-enam",
             "location": "ENAM"
           }
         }
@@ -64,9 +64,9 @@
         {
           "schema_version": 0,
           "attributes": {
-            "id": "bucket-weur",
+            "id": "cf-tf-test-bucket-weur",
             "account_id": "f037e56e89293a057740de681ac9abbe",
-            "name": "bucket-weur",
+            "name": "cf-tf-test-bucket-weur",
             "location": "WEUR"
           }
         }
@@ -81,9 +81,9 @@
         {
           "schema_version": 0,
           "attributes": {
-            "id": "bucket-eeur",
+            "id": "cf-tf-test-bucket-eeur",
             "account_id": "f037e56e89293a057740de681ac9abbe",
-            "name": "bucket-eeur",
+            "name": "cf-tf-test-bucket-eeur",
             "location": "EEUR"
           }
         }
@@ -98,9 +98,9 @@
         {
           "schema_version": 0,
           "attributes": {
-            "id": "bucket-apac",
+            "id": "cf-tf-test-bucket-apac",
             "account_id": "f037e56e89293a057740de681ac9abbe",
-            "name": "bucket-apac",
+            "name": "cf-tf-test-bucket-apac",
             "location": "APAC"
           }
         }
@@ -133,9 +133,9 @@
           "index_key": "backups",
           "schema_version": 0,
           "attributes": {
-            "id": "backups-bucket",
+            "id": "cf-tf-test-backups-bucket",
             "account_id": "f037e56e89293a057740de681ac9abbe",
-            "name": "backups-bucket",
+            "name": "cf-tf-test-backups-bucket",
             "location": "WEUR"
           }
         },
@@ -143,9 +143,9 @@
           "index_key": "data",
           "schema_version": 0,
           "attributes": {
-            "id": "data-bucket",
+            "id": "cf-tf-test-data-bucket",
             "account_id": "f037e56e89293a057740de681ac9abbe",
-            "name": "data-bucket",
+            "name": "cf-tf-test-data-bucket",
             "location": "WNAM"
           }
         },
@@ -153,9 +153,9 @@
           "index_key": "logs",
           "schema_version": 0,
           "attributes": {
-            "id": "logs-bucket",
+            "id": "cf-tf-test-logs-bucket",
             "account_id": "f037e56e89293a057740de681ac9abbe",
-            "name": "logs-bucket",
+            "name": "cf-tf-test-logs-bucket",
             "location": "ENAM"
           }
         }
@@ -171,36 +171,36 @@
           "index_key": "alpha",
           "schema_version": 0,
           "attributes": {
-            "id": "set-alpha-bucket",
+            "id": "cf-tf-test-set-alpha-bucket",
             "account_id": "f037e56e89293a057740de681ac9abbe",
-            "name": "set-alpha-bucket"
+            "name": "cf-tf-test-set-alpha-bucket"
           }
         },
         {
           "index_key": "beta",
           "schema_version": 0,
           "attributes": {
-            "id": "set-beta-bucket",
+            "id": "cf-tf-test-set-beta-bucket",
             "account_id": "f037e56e89293a057740de681ac9abbe",
-            "name": "set-beta-bucket"
+            "name": "cf-tf-test-set-beta-bucket"
           }
         },
         {
           "index_key": "delta",
           "schema_version": 0,
           "attributes": {
-            "id": "set-delta-bucket",
+            "id": "cf-tf-test-set-delta-bucket",
             "account_id": "f037e56e89293a057740de681ac9abbe",
-            "name": "set-delta-bucket"
+            "name": "cf-tf-test-set-delta-bucket"
           }
         },
         {
           "index_key": "gamma",
           "schema_version": 0,
           "attributes": {
-            "id": "set-gamma-bucket",
+            "id": "cf-tf-test-set-gamma-bucket",
             "account_id": "f037e56e89293a057740de681ac9abbe",
-            "name": "set-gamma-bucket"
+            "name": "cf-tf-test-set-gamma-bucket"
           }
         }
       ]
@@ -215,9 +215,9 @@
           "index": 0,
           "schema_version": 0,
           "attributes": {
-            "id": "counted-bucket-0",
+            "id": "cf-tf-test-counted-bucket-0",
             "account_id": "f037e56e89293a057740de681ac9abbe",
-            "name": "counted-bucket-0",
+            "name": "cf-tf-test-counted-bucket-0",
             "location": "WNAM"
           }
         },
@@ -225,9 +225,9 @@
           "index": 1,
           "schema_version": 0,
           "attributes": {
-            "id": "counted-bucket-1",
+            "id": "cf-tf-test-counted-bucket-1",
             "account_id": "f037e56e89293a057740de681ac9abbe",
-            "name": "counted-bucket-1",
+            "name": "cf-tf-test-counted-bucket-1",
             "location": "EEUR"
           }
         },
@@ -235,9 +235,9 @@
           "index": 2,
           "schema_version": 0,
           "attributes": {
-            "id": "counted-bucket-2",
+            "id": "cf-tf-test-counted-bucket-2",
             "account_id": "f037e56e89293a057740de681ac9abbe",
-            "name": "counted-bucket-2",
+            "name": "cf-tf-test-counted-bucket-2",
             "location": "APAC"
           }
         }
@@ -253,9 +253,9 @@
           "index": 0,
           "schema_version": 0,
           "attributes": {
-            "id": "conditional-enabled-bucket",
+            "id": "cf-tf-test-conditional-enabled-bucket",
             "account_id": "f037e56e89293a057740de681ac9abbe",
-            "name": "conditional-enabled-bucket",
+            "name": "cf-tf-test-conditional-enabled-bucket",
             "location": "WNAM"
           }
         }
@@ -270,9 +270,9 @@
         {
           "schema_version": 0,
           "attributes": {
-            "id": "test-integration-function-test",
+            "id": "cf-tf-test-function-test",
             "account_id": "f037e56e89293a057740de681ac9abbe",
-            "name": "test-integration-function-test",
+            "name": "cf-tf-test-function-test",
             "location": "WNAM"
           }
         }
@@ -287,9 +287,9 @@
         {
           "schema_version": 0,
           "attributes": {
-            "id": "test-integration-interpolated-bucket",
+            "id": "cf-tf-test-interpolated-bucket",
             "account_id": "f037e56e89293a057740de681ac9abbe",
-            "name": "test-integration-interpolated-bucket",
+            "name": "cf-tf-test-interpolated-bucket",
             "location": "EEUR"
           }
         }
@@ -304,9 +304,9 @@
         {
           "schema_version": 0,
           "attributes": {
-            "id": "lifecycle-test-bucket",
+            "id": "cf-tf-test-lifecycle-test-bucket",
             "account_id": "f037e56e89293a057740de681ac9abbe",
-            "name": "lifecycle-test-bucket",
+            "name": "cf-tf-test-lifecycle-test-bucket",
             "location": "WNAM"
           }
         }
@@ -321,9 +321,9 @@
         {
           "schema_version": 0,
           "attributes": {
-            "id": "prevent-destroy-bucket",
+            "id": "cf-tf-test-prevent-destroy-bucket",
             "account_id": "f037e56e89293a057740de681ac9abbe",
-            "name": "prevent-destroy-bucket",
+            "name": "cf-tf-test-prevent-destroy-bucket",
             "location": "EEUR"
           }
         }
@@ -338,26 +338,10 @@
         {
           "schema_version": 0,
           "attributes": {
-            "id": "bucket-name-with-all-valid-chars-123-test",
+            "id": "cf-tf-test-bucket-name-with-all-valid-chars-123-test",
             "account_id": "f037e56e89293a057740de681ac9abbe",
-            "name": "bucket-name-with-all-valid-chars-123-test",
+            "name": "cf-tf-test-bucket-name-with-all-valid-chars-123-test",
             "location": "WNAM"
-          }
-        }
-      ]
-    },
-    {
-      "mode": "managed",
-      "type": "cloudflare_r2_bucket",
-      "name": "special_chars",
-      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
-      "instances": [
-        {
-          "schema_version": 0,
-          "attributes": {
-            "id": "bucket-with-dashes-and-numbers-123",
-            "account_id": "f037e56e89293a057740de681ac9abbe",
-            "name": "bucket-with-dashes-and-numbers-123"
           }
         }
       ]
@@ -371,9 +355,9 @@
         {
           "schema_version": 0,
           "attributes": {
-            "id": "very-long-bucket-name-for-testing-migration-limits-max-len",
+            "id": "cf-tf-test-long-bucket-name-to-test-migration-limits-max-len",
             "account_id": "f037e56e89293a057740de681ac9abbe",
-            "name": "very-long-bucket-name-for-testing-migration-limits-max-len"
+            "name": "cf-tf-test-long-bucket-name-to-test-migration-limits-max-len"
           }
         }
       ]

--- a/integration/v4_to_v5/testdata/workers_kv/expected/workers_kv.tf
+++ b/integration/v4_to_v5/testdata/workers_kv/expected/workers_kv.tf
@@ -11,7 +11,7 @@ variable "cloudflare_zone_id" {
 # Locals for reusable values
 locals {
   common_account   = var.cloudflare_account_id
-  namespace_prefix = "test-kv"
+  namespace_prefix = "cf-tf-test-kv"
   test_keys = [
     "config_key_1",
     "config_key_2",

--- a/integration/v4_to_v5/testdata/workers_kv/input/workers_kv.tf
+++ b/integration/v4_to_v5/testdata/workers_kv/input/workers_kv.tf
@@ -11,7 +11,7 @@ variable "cloudflare_zone_id" {
 # Locals for reusable values
 locals {
   common_account   = var.cloudflare_account_id
-  namespace_prefix = "test-kv"
+  namespace_prefix = "cf-tf-test-kv"
   test_keys = [
     "config_key_1",
     "config_key_2",

--- a/integration/v4_to_v5/testdata/workers_kv_namespace/expected/terraform.tfstate
+++ b/integration/v4_to_v5/testdata/workers_kv_namespace/expected/terraform.tfstate
@@ -18,7 +18,7 @@
           "attributes": {
             "account_id": "f037e56e89293a057740de681ac9abbe",
             "id": "map_cache_id_001",
-            "title": "test-integration-Cache Store"
+            "title": "cf-tf-test-Cache Store"
           }
         },
         {
@@ -27,7 +27,7 @@
           "attributes": {
             "account_id": "f037e56e89293a057740de681ac9abbe",
             "id": "map_config_id_002",
-            "title": "test-integration-Configuration Store"
+            "title": "cf-tf-test-Configuration Store"
           }
         },
         {
@@ -36,7 +36,7 @@
           "attributes": {
             "account_id": "f037e56e89293a057740de681ac9abbe",
             "id": "map_session_id_003",
-            "title": "test-integration-Session Store"
+            "title": "cf-tf-test-Session Store"
           }
         }
       ]
@@ -54,7 +54,7 @@
           "attributes": {
             "account_id": "f037e56e89293a057740de681ac9abbe",
             "id": "set_alpha_id_004",
-            "title": "set-alpha-namespace"
+            "title": "cf-tf-test-set-alpha-namespace"
           }
         },
         {
@@ -63,7 +63,7 @@
           "attributes": {
             "account_id": "f037e56e89293a057740de681ac9abbe",
             "id": "set_beta_id_005",
-            "title": "set-beta-namespace"
+            "title": "cf-tf-test-set-beta-namespace"
           }
         },
         {
@@ -72,7 +72,7 @@
           "attributes": {
             "account_id": "f037e56e89293a057740de681ac9abbe",
             "id": "set_delta_id_006",
-            "title": "set-delta-namespace"
+            "title": "cf-tf-test-set-delta-namespace"
           }
         },
         {
@@ -81,7 +81,7 @@
           "attributes": {
             "account_id": "f037e56e89293a057740de681ac9abbe",
             "id": "set_gamma_id_007",
-            "title": "set-gamma-namespace"
+            "title": "cf-tf-test-set-gamma-namespace"
           }
         }
       ]
@@ -98,7 +98,7 @@
           "attributes": {
             "account_id": "f037e56e89293a057740de681ac9abbe",
             "id": "counted_0_id_008",
-            "title": "counted-namespace-0"
+            "title": "cf-tf-test-counted-namespace-0"
           }
         },
         {
@@ -107,7 +107,7 @@
           "attributes": {
             "account_id": "f037e56e89293a057740de681ac9abbe",
             "id": "counted_1_id_009",
-            "title": "counted-namespace-1"
+            "title": "cf-tf-test-counted-namespace-1"
           }
         },
         {
@@ -116,7 +116,7 @@
           "attributes": {
             "account_id": "f037e56e89293a057740de681ac9abbe",
             "id": "counted_2_id_010",
-            "title": "counted-namespace-2"
+            "title": "cf-tf-test-counted-namespace-2"
           }
         }
       ]
@@ -133,7 +133,7 @@
           "attributes": {
             "account_id": "f037e56e89293a057740de681ac9abbe",
             "id": "conditional_enabled_id_011",
-            "title": "conditional-enabled-namespace"
+            "title": "cf-tf-test-conditional-enabled-namespace"
           }
         }
       ]
@@ -149,7 +149,7 @@
           "attributes": {
             "account_id": "f037e56e89293a057740de681ac9abbe",
             "id": "with_join_id_012",
-            "title": "workers-kv-joined"
+            "title": "cf-tf-test-workers-kv-joined"
           }
         }
       ]
@@ -165,7 +165,7 @@
           "attributes": {
             "account_id": "f037e56e89293a057740de681ac9abbe",
             "id": "with_format_id_013",
-            "title": "formatted-namespace-001"
+            "title": "cf-tf-test-formatted-namespace-001"
           }
         }
       ]
@@ -181,7 +181,7 @@
           "attributes": {
             "account_id": "f037e56e89293a057740de681ac9abbe",
             "id": "with_interpolation_id_014",
-            "title": "namespace-for-account-f037e56e89293a057740de681ac9abbe"
+            "title": "cf-tf-test-namespace-for-account-f037e56e89293a057740de681ac9abbe"
           }
         }
       ]
@@ -197,7 +197,7 @@
           "attributes": {
             "account_id": "f037e56e89293a057740de681ac9abbe",
             "id": "with_lifecycle_id_015",
-            "title": "lifecycle-test-namespace"
+            "title": "cf-tf-test-lifecycle-test-namespace"
           }
         }
       ]
@@ -213,7 +213,7 @@
           "attributes": {
             "account_id": "f037e56e89293a057740de681ac9abbe",
             "id": "with_prevent_destroy_id_016",
-            "title": "prevent-destroy-namespace"
+            "title": "cf-tf-test-prevent-destroy-namespace"
           }
         }
       ]
@@ -229,23 +229,7 @@
           "attributes": {
             "account_id": "f037e56e89293a057740de681ac9abbe",
             "id": "minimal_id_017",
-            "title": "minimal"
-          }
-        }
-      ]
-    },
-    {
-      "mode": "managed",
-      "type": "cloudflare_workers_kv_namespace",
-      "name": "special_chars",
-      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
-      "instances": [
-        {
-          "schema_version": 0,
-          "attributes": {
-            "account_id": "f037e56e89293a057740de681ac9abbe",
-            "id": "special_chars_id_018",
-            "title": "test_namespace-with.special-chars!2024"
+            "title": "cf-tf-test-minimal"
           }
         }
       ]
@@ -260,8 +244,8 @@
           "schema_version": 0,
           "attributes": {
             "account_id": "f037e56e89293a057740de681ac9abbe",
-            "id": "with_spaces_id_019",
-            "title": "My Workers KV Namespace With Spaces"
+            "id": "with_spaces_id_018",
+            "title": "cf-tf-test-KV Namespace With Spaces!2024émojis-🚀-and-spëcial-chàrs"
           }
         }
       ]
@@ -276,24 +260,8 @@
           "schema_version": 0,
           "attributes": {
             "account_id": "f037e56e89293a057740de681ac9abbe",
-            "id": "long_title_id_020",
-            "title": "very-long-namespace-title-that-tests-maximum-length-handling-in-migration-process-2024"
-          }
-        }
-      ]
-    },
-    {
-      "mode": "managed",
-      "type": "cloudflare_workers_kv_namespace",
-      "name": "unicode",
-      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
-      "instances": [
-        {
-          "schema_version": 0,
-          "attributes": {
-            "account_id": "f037e56e89293a057740de681ac9abbe",
-            "id": "unicode_id_021",
-            "title": "namespace-with-émojis-🚀-and-spëcial-chàrs"
+            "id": "long_title_id_019",
+            "title": "cf-tf-test-long-title-that-tests-maximum-length-handling-in-migration"
           }
         }
       ]
@@ -309,7 +277,7 @@
           "attributes": {
             "account_id": "f037e56e89293a057740de681ac9abbe",
             "id": "from_locals_id_022",
-            "title": "test-integration-from-locals"
+            "title": "cf-tf-test-from-locals"
           }
         }
       ]

--- a/integration/v4_to_v5/testdata/workers_kv_namespace/expected/workers_kv_namespace.tf
+++ b/integration/v4_to_v5/testdata/workers_kv_namespace/expected/workers_kv_namespace.tf
@@ -14,7 +14,7 @@ variable "cloudflare_zone_id" {
 
 locals {
   common_account = var.cloudflare_account_id
-  name_prefix    = "test-integration"
+  name_prefix    = "cf-tf-test"
   tags           = ["test", "migration", "v4_to_v5"]
   environments   = ["dev", "staging", "prod"]
 }
@@ -47,7 +47,7 @@ resource "cloudflare_workers_kv_namespace" "set_example" {
   ])
 
   account_id = var.cloudflare_account_id
-  title      = "set-${each.value}-namespace"
+  title      = "${local.name_prefix}-set-${each.value}-namespace"
 }
 
 # Pattern Group 4: count-based Resources (3 instances)
@@ -55,7 +55,7 @@ resource "cloudflare_workers_kv_namespace" "counted" {
   count = 3
 
   account_id = var.cloudflare_account_id
-  title      = "counted-namespace-${count.index}"
+  title      = "${local.name_prefix}-counted-namespace-${count.index}"
 }
 
 # Pattern Group 5: Conditional Creation (1 instance created, 1 not created)
@@ -68,36 +68,36 @@ resource "cloudflare_workers_kv_namespace" "conditional_enabled" {
   count = local.enable_feature ? 1 : 0
 
   account_id = var.cloudflare_account_id
-  title      = "conditional-enabled-namespace"
+  title      = "${local.name_prefix}-conditional-enabled-namespace"
 }
 
 resource "cloudflare_workers_kv_namespace" "conditional_disabled" {
   count = local.enable_test ? 1 : 0
 
   account_id = var.cloudflare_account_id
-  title      = "conditional-disabled-namespace"
+  title      = "${local.name_prefix}-conditional-disabled-namespace"
 }
 
 # Pattern Group 6: Terraform Functions (3 instances)
 resource "cloudflare_workers_kv_namespace" "with_join" {
   account_id = var.cloudflare_account_id
-  title      = join("-", ["workers", "kv", "joined"])
+  title      = join("-", [local.name_prefix, "workers", "kv", "joined"])
 }
 
 resource "cloudflare_workers_kv_namespace" "with_format" {
   account_id = var.cloudflare_account_id
-  title      = "formatted-namespace-001"
+  title      = "${local.name_prefix}-formatted-namespace-001"
 }
 
 resource "cloudflare_workers_kv_namespace" "with_interpolation" {
   account_id = var.cloudflare_account_id
-  title      = "namespace-for-account-${var.cloudflare_account_id}"
+  title      = "${local.name_prefix}-namespace-for-account-${var.cloudflare_account_id}"
 }
 
 # Pattern Group 7: Lifecycle Meta-Arguments (2 instances)
 resource "cloudflare_workers_kv_namespace" "with_lifecycle" {
   account_id = var.cloudflare_account_id
-  title      = "lifecycle-test-namespace"
+  title      = "${local.name_prefix}-lifecycle-test-namespace"
 
   lifecycle {
     create_before_destroy = true
@@ -107,7 +107,7 @@ resource "cloudflare_workers_kv_namespace" "with_lifecycle" {
 
 resource "cloudflare_workers_kv_namespace" "with_prevent_destroy" {
   account_id = var.cloudflare_account_id
-  title      = "prevent-destroy-namespace"
+  title      = "${local.name_prefix}-prevent-destroy-namespace"
 
   lifecycle {
     prevent_destroy = false
@@ -119,31 +119,19 @@ resource "cloudflare_workers_kv_namespace" "with_prevent_destroy" {
 # Minimal resource (only required fields)
 resource "cloudflare_workers_kv_namespace" "minimal" {
   account_id = var.cloudflare_account_id
-  title      = "minimal"
+  title      = "${local.name_prefix}-minimal"
 }
 
-# Resource with special characters in title
-resource "cloudflare_workers_kv_namespace" "special_chars" {
-  account_id = var.cloudflare_account_id
-  title      = "test_namespace-with.special-chars!2024"
-}
-
-# Resource with spaces in title
+# Resource with spaces, special chars, unicode in title
 resource "cloudflare_workers_kv_namespace" "with_spaces" {
   account_id = var.cloudflare_account_id
-  title      = "My Workers KV Namespace With Spaces"
+  title      = "${local.name_prefix}-KV Namespace With Spaces!2024émojis-🚀-and-spëcial-chàrs"
 }
 
 # Resource with very long title
 resource "cloudflare_workers_kv_namespace" "long_title" {
   account_id = var.cloudflare_account_id
-  title      = "very-long-namespace-title-that-tests-maximum-length-handling-in-migration-process-2024"
-}
-
-# Resource with unicode characters
-resource "cloudflare_workers_kv_namespace" "unicode" {
-  account_id = var.cloudflare_account_id
-  title      = "namespace-with-émojis-🚀-and-spëcial-chàrs"
+  title      = "${local.name_prefix}-long-title-that-tests-maximum-length-handling-in-migration"
 }
 
 # Pattern Group 9: Production-like Patterns
@@ -160,7 +148,7 @@ resource "cloudflare_workers_kv_namespace" "variable_driven" {
   title      = "namespace-${var.cloudflare_zone_id}"
 }
 
-# Total instances: 25
+# Total instances: 21
 # - map_example: 3 instances (cache, session, config)
 # - set_example: 4 instances (alpha, beta, gamma, delta)
 # - counted: 3 instances (0, 1, 2)
@@ -172,10 +160,8 @@ resource "cloudflare_workers_kv_namespace" "variable_driven" {
 # - with_lifecycle: 1 instance
 # - with_prevent_destroy: 1 instance
 # - minimal: 1 instance
-# - special_chars: 1 instance
-# - with_spaces: 1 instance
+# - with_spaces: 1 instance (combined: spaces, special chars, unicode, emojis)
 # - long_title: 1 instance
-# - unicode: 1 instance
 # - from_locals: 1 instance
 # - variable_driven: 1 instance
-# Total: 23 instances (excluding conditional_disabled which has count = 0)
+# Total: 21 instances (excluding conditional_disabled which has count = 0)

--- a/integration/v4_to_v5/testdata/workers_kv_namespace/input/terraform.tfstate
+++ b/integration/v4_to_v5/testdata/workers_kv_namespace/input/terraform.tfstate
@@ -18,7 +18,7 @@
           "attributes": {
             "account_id": "f037e56e89293a057740de681ac9abbe",
             "id": "map_cache_id_001",
-            "title": "test-integration-Cache Store"
+            "title": "cf-tf-test-Cache Store"
           }
         },
         {
@@ -27,7 +27,7 @@
           "attributes": {
             "account_id": "f037e56e89293a057740de681ac9abbe",
             "id": "map_config_id_002",
-            "title": "test-integration-Configuration Store"
+            "title": "cf-tf-test-Configuration Store"
           }
         },
         {
@@ -36,7 +36,7 @@
           "attributes": {
             "account_id": "f037e56e89293a057740de681ac9abbe",
             "id": "map_session_id_003",
-            "title": "test-integration-Session Store"
+            "title": "cf-tf-test-Session Store"
           }
         }
       ]
@@ -54,7 +54,7 @@
           "attributes": {
             "account_id": "f037e56e89293a057740de681ac9abbe",
             "id": "set_alpha_id_004",
-            "title": "set-alpha-namespace"
+            "title": "cf-tf-test-set-alpha-namespace"
           }
         },
         {
@@ -63,7 +63,7 @@
           "attributes": {
             "account_id": "f037e56e89293a057740de681ac9abbe",
             "id": "set_beta_id_005",
-            "title": "set-beta-namespace"
+            "title": "cf-tf-test-set-beta-namespace"
           }
         },
         {
@@ -72,7 +72,7 @@
           "attributes": {
             "account_id": "f037e56e89293a057740de681ac9abbe",
             "id": "set_delta_id_006",
-            "title": "set-delta-namespace"
+            "title": "cf-tf-test-set-delta-namespace"
           }
         },
         {
@@ -81,7 +81,7 @@
           "attributes": {
             "account_id": "f037e56e89293a057740de681ac9abbe",
             "id": "set_gamma_id_007",
-            "title": "set-gamma-namespace"
+            "title": "cf-tf-test-set-gamma-namespace"
           }
         }
       ]
@@ -98,7 +98,7 @@
           "attributes": {
             "account_id": "f037e56e89293a057740de681ac9abbe",
             "id": "counted_0_id_008",
-            "title": "counted-namespace-0"
+            "title": "cf-tf-test-counted-namespace-0"
           }
         },
         {
@@ -107,7 +107,7 @@
           "attributes": {
             "account_id": "f037e56e89293a057740de681ac9abbe",
             "id": "counted_1_id_009",
-            "title": "counted-namespace-1"
+            "title": "cf-tf-test-counted-namespace-1"
           }
         },
         {
@@ -116,7 +116,7 @@
           "attributes": {
             "account_id": "f037e56e89293a057740de681ac9abbe",
             "id": "counted_2_id_010",
-            "title": "counted-namespace-2"
+            "title": "cf-tf-test-counted-namespace-2"
           }
         }
       ]
@@ -133,7 +133,7 @@
           "attributes": {
             "account_id": "f037e56e89293a057740de681ac9abbe",
             "id": "conditional_enabled_id_011",
-            "title": "conditional-enabled-namespace"
+            "title": "cf-tf-test-conditional-enabled-namespace"
           }
         }
       ]
@@ -149,7 +149,7 @@
           "attributes": {
             "account_id": "f037e56e89293a057740de681ac9abbe",
             "id": "with_join_id_012",
-            "title": "workers-kv-joined"
+            "title": "cf-tf-test-workers-kv-joined"
           }
         }
       ]
@@ -165,7 +165,7 @@
           "attributes": {
             "account_id": "f037e56e89293a057740de681ac9abbe",
             "id": "with_format_id_013",
-            "title": "formatted-namespace-001"
+            "title": "cf-tf-test-formatted-namespace-001"
           }
         }
       ]
@@ -181,7 +181,7 @@
           "attributes": {
             "account_id": "f037e56e89293a057740de681ac9abbe",
             "id": "with_interpolation_id_014",
-            "title": "namespace-for-account-f037e56e89293a057740de681ac9abbe"
+            "title": "cf-tf-test-namespace-for-account-f037e56e89293a057740de681ac9abbe"
           }
         }
       ]
@@ -197,7 +197,7 @@
           "attributes": {
             "account_id": "f037e56e89293a057740de681ac9abbe",
             "id": "with_lifecycle_id_015",
-            "title": "lifecycle-test-namespace"
+            "title": "cf-tf-test-lifecycle-test-namespace"
           }
         }
       ]
@@ -213,7 +213,7 @@
           "attributes": {
             "account_id": "f037e56e89293a057740de681ac9abbe",
             "id": "with_prevent_destroy_id_016",
-            "title": "prevent-destroy-namespace"
+            "title": "cf-tf-test-prevent-destroy-namespace"
           }
         }
       ]
@@ -229,23 +229,7 @@
           "attributes": {
             "account_id": "f037e56e89293a057740de681ac9abbe",
             "id": "minimal_id_017",
-            "title": "minimal"
-          }
-        }
-      ]
-    },
-    {
-      "mode": "managed",
-      "type": "cloudflare_workers_kv_namespace",
-      "name": "special_chars",
-      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
-      "instances": [
-        {
-          "schema_version": 0,
-          "attributes": {
-            "account_id": "f037e56e89293a057740de681ac9abbe",
-            "id": "special_chars_id_018",
-            "title": "test_namespace-with.special-chars!2024"
+            "title": "cf-tf-test-minimal"
           }
         }
       ]
@@ -260,8 +244,8 @@
           "schema_version": 0,
           "attributes": {
             "account_id": "f037e56e89293a057740de681ac9abbe",
-            "id": "with_spaces_id_019",
-            "title": "My Workers KV Namespace With Spaces"
+            "id": "with_spaces_id_018",
+            "title": "cf-tf-test-KV Namespace With Spaces!2024émojis-🚀-and-spëcial-chàrs"
           }
         }
       ]
@@ -276,24 +260,8 @@
           "schema_version": 0,
           "attributes": {
             "account_id": "f037e56e89293a057740de681ac9abbe",
-            "id": "long_title_id_020",
-            "title": "very-long-namespace-title-that-tests-maximum-length-handling-in-migration-process-2024"
-          }
-        }
-      ]
-    },
-    {
-      "mode": "managed",
-      "type": "cloudflare_workers_kv_namespace",
-      "name": "unicode",
-      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
-      "instances": [
-        {
-          "schema_version": 0,
-          "attributes": {
-            "account_id": "f037e56e89293a057740de681ac9abbe",
-            "id": "unicode_id_021",
-            "title": "namespace-with-émojis-🚀-and-spëcial-chàrs"
+            "id": "long_title_id_019",
+            "title": "cf-tf-test-long-title-that-tests-maximum-length-handling-in-migration"
           }
         }
       ]
@@ -309,7 +277,7 @@
           "attributes": {
             "account_id": "f037e56e89293a057740de681ac9abbe",
             "id": "from_locals_id_022",
-            "title": "test-integration-from-locals"
+            "title": "cf-tf-test-from-locals"
           }
         }
       ]

--- a/integration/v4_to_v5/testdata/workers_kv_namespace/input/workers_kv_namespace.tf
+++ b/integration/v4_to_v5/testdata/workers_kv_namespace/input/workers_kv_namespace.tf
@@ -14,7 +14,7 @@ variable "cloudflare_zone_id" {
 
 locals {
   common_account = var.cloudflare_account_id
-  name_prefix    = "test-integration"
+  name_prefix    = "cf-tf-test"
   tags           = ["test", "migration", "v4_to_v5"]
   environments   = ["dev", "staging", "prod"]
 }
@@ -47,7 +47,7 @@ resource "cloudflare_workers_kv_namespace" "set_example" {
   ])
 
   account_id = var.cloudflare_account_id
-  title      = "set-${each.value}-namespace"
+  title      = "${local.name_prefix}-set-${each.value}-namespace"
 }
 
 # Pattern Group 4: count-based Resources (3 instances)
@@ -55,7 +55,7 @@ resource "cloudflare_workers_kv_namespace" "counted" {
   count = 3
 
   account_id = var.cloudflare_account_id
-  title      = "counted-namespace-${count.index}"
+  title      = "${local.name_prefix}-counted-namespace-${count.index}"
 }
 
 # Pattern Group 5: Conditional Creation (1 instance created, 1 not created)
@@ -68,36 +68,36 @@ resource "cloudflare_workers_kv_namespace" "conditional_enabled" {
   count = local.enable_feature ? 1 : 0
 
   account_id = var.cloudflare_account_id
-  title      = "conditional-enabled-namespace"
+  title      = "${local.name_prefix}-conditional-enabled-namespace"
 }
 
 resource "cloudflare_workers_kv_namespace" "conditional_disabled" {
   count = local.enable_test ? 1 : 0
 
   account_id = var.cloudflare_account_id
-  title      = "conditional-disabled-namespace"
+  title      = "${local.name_prefix}-conditional-disabled-namespace"
 }
 
 # Pattern Group 6: Terraform Functions (3 instances)
 resource "cloudflare_workers_kv_namespace" "with_join" {
   account_id = var.cloudflare_account_id
-  title      = join("-", ["workers", "kv", "joined"])
+  title      = join("-", [local.name_prefix, "workers", "kv", "joined"])
 }
 
 resource "cloudflare_workers_kv_namespace" "with_format" {
   account_id = var.cloudflare_account_id
-  title      = "formatted-namespace-001"
+  title      = "${local.name_prefix}-formatted-namespace-001"
 }
 
 resource "cloudflare_workers_kv_namespace" "with_interpolation" {
   account_id = var.cloudflare_account_id
-  title      = "namespace-for-account-${var.cloudflare_account_id}"
+  title      = "${local.name_prefix}-namespace-for-account-${var.cloudflare_account_id}"
 }
 
 # Pattern Group 7: Lifecycle Meta-Arguments (2 instances)
 resource "cloudflare_workers_kv_namespace" "with_lifecycle" {
   account_id = var.cloudflare_account_id
-  title      = "lifecycle-test-namespace"
+  title      = "${local.name_prefix}-lifecycle-test-namespace"
 
   lifecycle {
     create_before_destroy = true
@@ -107,7 +107,7 @@ resource "cloudflare_workers_kv_namespace" "with_lifecycle" {
 
 resource "cloudflare_workers_kv_namespace" "with_prevent_destroy" {
   account_id = var.cloudflare_account_id
-  title      = "prevent-destroy-namespace"
+  title      = "${local.name_prefix}-prevent-destroy-namespace"
 
   lifecycle {
     prevent_destroy = false
@@ -119,31 +119,19 @@ resource "cloudflare_workers_kv_namespace" "with_prevent_destroy" {
 # Minimal resource (only required fields)
 resource "cloudflare_workers_kv_namespace" "minimal" {
   account_id = var.cloudflare_account_id
-  title      = "minimal"
+  title      = "${local.name_prefix}-minimal"
 }
 
-# Resource with special characters in title
-resource "cloudflare_workers_kv_namespace" "special_chars" {
-  account_id = var.cloudflare_account_id
-  title      = "test_namespace-with.special-chars!2024"
-}
-
-# Resource with spaces in title
+# Resource with spaces, special chars, unicode in title
 resource "cloudflare_workers_kv_namespace" "with_spaces" {
   account_id = var.cloudflare_account_id
-  title      = "My Workers KV Namespace With Spaces"
+  title      = "${local.name_prefix}-KV Namespace With Spaces!2024émojis-🚀-and-spëcial-chàrs"
 }
 
 # Resource with very long title
 resource "cloudflare_workers_kv_namespace" "long_title" {
   account_id = var.cloudflare_account_id
-  title      = "very-long-namespace-title-that-tests-maximum-length-handling-in-migration-process-2024"
-}
-
-# Resource with unicode characters
-resource "cloudflare_workers_kv_namespace" "unicode" {
-  account_id = var.cloudflare_account_id
-  title      = "namespace-with-émojis-🚀-and-spëcial-chàrs"
+  title      = "${local.name_prefix}-long-title-that-tests-maximum-length-handling-in-migration"
 }
 
 # Pattern Group 9: Production-like Patterns
@@ -160,7 +148,7 @@ resource "cloudflare_workers_kv_namespace" "variable_driven" {
   title      = "namespace-${var.cloudflare_zone_id}"
 }
 
-# Total instances: 25
+# Total instances: 21
 # - map_example: 3 instances (cache, session, config)
 # - set_example: 4 instances (alpha, beta, gamma, delta)
 # - counted: 3 instances (0, 1, 2)
@@ -172,10 +160,8 @@ resource "cloudflare_workers_kv_namespace" "variable_driven" {
 # - with_lifecycle: 1 instance
 # - with_prevent_destroy: 1 instance
 # - minimal: 1 instance
-# - special_chars: 1 instance
-# - with_spaces: 1 instance
+# - with_spaces: 1 instance (combined: spaces, special chars, unicode, emojis)
 # - long_title: 1 instance
-# - unicode: 1 instance
 # - from_locals: 1 instance
 # - variable_driven: 1 instance
-# Total: 23 instances (excluding conditional_disabled which has count = 0)
+# Total: 21 instances (excluding conditional_disabled which has count = 0)


### PR DESCRIPTION
Adds prefixes for `r2_bucket`, `workers_kv`, and `workers_kv_namespace` so that sweepers can clean these resources. 