### PR TITLE
(Phase 0) bot_management v4->v5 migration 

### DIFF
--- a/integration/v4_to_v5/testdata/bot_management/expected/bot_management.tf
+++ b/integration/v4_to_v5/testdata/bot_management/expected/bot_management.tf
@@ -1,0 +1,24 @@
+variable "cloudflare_account_id" {
+  description = "Cloudflare account ID"
+  type        = string
+}
+
+variable "cloudflare_zone_id" {
+  description = "Cloudflare zone ID"
+  type        = string
+}
+
+# Comprehensive bot management test with available fields
+# Note: bot_management is a singleton per zone - only one config per zone
+resource "cloudflare_bot_management" "test" {
+  zone_id                         = var.cloudflare_zone_id
+  enable_js                       = true
+  sbfm_definitely_automated       = "block"
+  sbfm_likely_automated           = "managed_challenge"
+  sbfm_verified_bots              = "allow"
+  sbfm_static_resource_protection = true
+  optimize_wordpress              = false
+  suppress_session_score          = false
+  auto_update_model               = true
+  ai_bots_protection              = "disabled"
+}

--- a/integration/v4_to_v5/testdata/bot_management/expected/terraform.tfstate
+++ b/integration/v4_to_v5/testdata/bot_management/expected/terraform.tfstate
@@ -1,0 +1,33 @@
+{
+  "version": 4,
+  "terraform_version": "1.5.0",
+  "serial": 1,
+  "lineage": "test-bot-management-lineage",
+  "outputs": {},
+  "resources": [
+    {
+      "mode": "managed",
+      "type": "cloudflare_bot_management",
+      "name": "test",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "0da42c8d2132a9ddaf714f9e7c920711",
+            "zone_id": "0da42c8d2132a9ddaf714f9e7c920711",
+            "enable_js": true,
+            "sbfm_definitely_automated": "block",
+            "sbfm_likely_automated": "managed_challenge",
+            "sbfm_verified_bots": "allow",
+            "sbfm_static_resource_protection": true,
+            "optimize_wordpress": false,
+            "suppress_session_score": false,
+            "auto_update_model": true,
+            "ai_bots_protection": "disabled"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/integration/v4_to_v5/testdata/bot_management/input/bot_management.tf
+++ b/integration/v4_to_v5/testdata/bot_management/input/bot_management.tf
@@ -1,0 +1,24 @@
+variable "cloudflare_account_id" {
+  description = "Cloudflare account ID"
+  type        = string
+}
+
+variable "cloudflare_zone_id" {
+  description = "Cloudflare zone ID"
+  type        = string
+}
+
+# Comprehensive bot management test with available fields
+# Note: bot_management is a singleton per zone - only one config per zone
+resource "cloudflare_bot_management" "test" {
+  zone_id                         = var.cloudflare_zone_id
+  enable_js                       = true
+  sbfm_definitely_automated       = "block"
+  sbfm_likely_automated           = "managed_challenge"
+  sbfm_verified_bots              = "allow"
+  sbfm_static_resource_protection = true
+  optimize_wordpress              = false
+  suppress_session_score          = false
+  auto_update_model               = true
+  ai_bots_protection              = "disabled"
+}

--- a/integration/v4_to_v5/testdata/bot_management/input/terraform.tfstate
+++ b/integration/v4_to_v5/testdata/bot_management/input/terraform.tfstate
@@ -1,0 +1,33 @@
+{
+  "version": 4,
+  "terraform_version": "1.5.0",
+  "serial": 1,
+  "lineage": "test-bot-management-lineage",
+  "outputs": {},
+  "resources": [
+    {
+      "mode": "managed",
+      "type": "cloudflare_bot_management",
+      "name": "test",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "0da42c8d2132a9ddaf714f9e7c920711",
+            "zone_id": "0da42c8d2132a9ddaf714f9e7c920711",
+            "enable_js": true,
+            "sbfm_definitely_automated": "block",
+            "sbfm_likely_automated": "managed_challenge",
+            "sbfm_verified_bots": "allow",
+            "sbfm_static_resource_protection": true,
+            "optimize_wordpress": false,
+            "suppress_session_score": false,
+            "auto_update_model": true,
+            "ai_bots_protection": "disabled"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -5,6 +5,7 @@ import (
 	zonesdata "github.com/cloudflare/tf-migrate/internal/datasources/zones"
 	"github.com/cloudflare/tf-migrate/internal/resources/account_member"
 	"github.com/cloudflare/tf-migrate/internal/resources/api_token"
+	"github.com/cloudflare/tf-migrate/internal/resources/bot_management"
 	"github.com/cloudflare/tf-migrate/internal/resources/dns_record"
 	"github.com/cloudflare/tf-migrate/internal/resources/healthcheck"
 	"github.com/cloudflare/tf-migrate/internal/resources/logpull_retention"
@@ -39,6 +40,7 @@ func RegisterAllMigrations() {
 	// Resources
 	account_member.NewV4ToV5Migrator()
 	api_token.NewV4ToV5Migrator()
+	bot_management.NewV4ToV5Migrator()
 	dns_record.NewV4ToV5Migrator()
 	healthcheck.NewV4ToV5Migrator()
 	zone.NewV4ToV5Migrator()

--- a/internal/resources/bot_management/v4_to_v5.go
+++ b/internal/resources/bot_management/v4_to_v5.go
@@ -1,0 +1,71 @@
+package bot_management
+
+import (
+	"github.com/hashicorp/hcl/v2/hclwrite"
+	"github.com/tidwall/gjson"
+
+	"github.com/cloudflare/tf-migrate/internal"
+	"github.com/cloudflare/tf-migrate/internal/transform"
+)
+
+type V4ToV5Migrator struct {
+}
+
+func NewV4ToV5Migrator() transform.ResourceTransformer {
+	migrator := &V4ToV5Migrator{}
+	internal.RegisterMigrator("cloudflare_bot_management", "v4", "v5", migrator)
+	return migrator
+}
+
+// GetResourceType returns the resource type this migrator handles (v5 name).
+func (m *V4ToV5Migrator) GetResourceType() string {
+	return "cloudflare_bot_management"
+}
+
+// CanHandle determines if this migrator can handle the given resource type.
+func (m *V4ToV5Migrator) CanHandle(resourceType string) bool {
+	return resourceType == "cloudflare_bot_management"
+}
+
+// Preprocess handles string-level transformations before HCL parsing.
+func (m *V4ToV5Migrator) Preprocess(content string) string {
+	return content
+}
+
+// GetResourceRename implements the ResourceRenamer interface.
+func (m *V4ToV5Migrator) GetResourceRename() (string, string) {
+	return "cloudflare_bot_management", "cloudflare_bot_management"
+}
+
+// TransformConfig handles configuration file transformations.
+// For bot_management, no HCL transformations are needed because:
+// - All v4 fields exist in v5 with the same names and semantics
+// - No fields were deprecated or renamed
+// - New v5 fields are optional and should not be added during migration
+func (m *V4ToV5Migrator) TransformConfig(ctx *transform.Context, block *hclwrite.Block) (*transform.TransformResult, error) {
+	return &transform.TransformResult{
+		Blocks:         []*hclwrite.Block{block},
+		RemoveOriginal: false,
+	}, nil
+}
+
+// TransformState handles state file transformations.
+// For bot_management, no state transformations are needed because:
+// - All v4 fields exist in v5 with the same names and types
+// - No fields were deprecated or renamed
+// - No type conversions are required
+// - New v5 fields are optional/computed and should not be added during migration
+func (m *V4ToV5Migrator) TransformState(ctx *transform.Context, stateJSON gjson.Result, resourcePath, resourceName string) (string, error) {
+	result := stateJSON.String()
+
+	if !stateJSON.Exists() || !stateJSON.Get("attributes").Exists() {
+		return result, nil
+	}
+
+	attrs := stateJSON.Get("attributes")
+	if !attrs.Get("zone_id").Exists() {
+		return result, nil
+	}
+
+	return result, nil
+}

--- a/internal/resources/bot_management/v4_to_v5_test.go
+++ b/internal/resources/bot_management/v4_to_v5_test.go
@@ -1,0 +1,465 @@
+package bot_management
+
+import (
+	"testing"
+
+	"github.com/cloudflare/tf-migrate/internal/testhelpers"
+)
+
+func TestV4ToV5Transformation(t *testing.T) {
+	migrator := NewV4ToV5Migrator()
+
+	// Test configuration transformations
+	t.Run("ConfigTransformation", func(t *testing.T) {
+		tests := []testhelpers.ConfigTestCase{
+			{
+				Name: "Basic resource with common fields",
+				Input: `
+resource "cloudflare_bot_management" "example" {
+  zone_id                        = "0da42c8d2132a9ddaf714f9e7c920711"
+  enable_js                      = true
+  fight_mode                     = false
+  auto_update_model              = true
+  suppress_session_score         = false
+}`,
+				Expected: `resource "cloudflare_bot_management" "example" {
+  zone_id                = "0da42c8d2132a9ddaf714f9e7c920711"
+  enable_js              = true
+  fight_mode             = false
+  auto_update_model      = true
+  suppress_session_score = false
+}`,
+			},
+			{
+				Name: "Resource with SBFM fields",
+				Input: `
+resource "cloudflare_bot_management" "sbfm" {
+  zone_id                        = "0da42c8d2132a9ddaf714f9e7c920711"
+  sbfm_definitely_automated      = "block"
+  sbfm_likely_automated          = "managed_challenge"
+  sbfm_verified_bots             = "allow"
+  sbfm_static_resource_protection = true
+  optimize_wordpress             = true
+}`,
+				Expected: `resource "cloudflare_bot_management" "sbfm" {
+  zone_id                         = "0da42c8d2132a9ddaf714f9e7c920711"
+  sbfm_definitely_automated       = "block"
+  sbfm_likely_automated           = "managed_challenge"
+  sbfm_verified_bots              = "allow"
+  sbfm_static_resource_protection = true
+  optimize_wordpress              = true
+}`,
+			},
+			{
+				Name: "Resource with AI bots protection",
+				Input: `
+resource "cloudflare_bot_management" "ai_protection" {
+  zone_id            = "0da42c8d2132a9ddaf714f9e7c920711"
+  ai_bots_protection = "block"
+}`,
+				Expected: `resource "cloudflare_bot_management" "ai_protection" {
+  zone_id            = "0da42c8d2132a9ddaf714f9e7c920711"
+  ai_bots_protection = "block"
+}`,
+			},
+			{
+				Name: "Resource with all v4 fields",
+				Input: `
+resource "cloudflare_bot_management" "complete" {
+  zone_id                         = "0da42c8d2132a9ddaf714f9e7c920711"
+  enable_js                       = true
+  fight_mode                      = true
+  sbfm_definitely_automated       = "block"
+  sbfm_likely_automated           = "block"
+  sbfm_verified_bots              = "allow"
+  sbfm_static_resource_protection = true
+  optimize_wordpress              = false
+  suppress_session_score          = false
+  auto_update_model               = true
+  ai_bots_protection              = "disabled"
+}`,
+				Expected: `resource "cloudflare_bot_management" "complete" {
+  zone_id                         = "0da42c8d2132a9ddaf714f9e7c920711"
+  enable_js                       = true
+  fight_mode                      = true
+  sbfm_definitely_automated       = "block"
+  sbfm_likely_automated           = "block"
+  sbfm_verified_bots              = "allow"
+  sbfm_static_resource_protection = true
+  optimize_wordpress              = false
+  suppress_session_score          = false
+  auto_update_model               = true
+  ai_bots_protection              = "disabled"
+}`,
+			},
+			{
+				Name: "Multiple resources in one file",
+				Input: `
+resource "cloudflare_bot_management" "first" {
+  zone_id    = "0da42c8d2132a9ddaf714f9e7c920711"
+  enable_js  = true
+  fight_mode = false
+}
+
+resource "cloudflare_bot_management" "second" {
+  zone_id            = "28fea702d1075b10ba9c8620b86218ec"
+  ai_bots_protection = "block"
+}`,
+				Expected: `resource "cloudflare_bot_management" "first" {
+  zone_id    = "0da42c8d2132a9ddaf714f9e7c920711"
+  enable_js  = true
+  fight_mode = false
+}
+
+resource "cloudflare_bot_management" "second" {
+  zone_id            = "28fea702d1075b10ba9c8620b86218ec"
+  ai_bots_protection = "block"
+}`,
+			},
+			{
+				Name: "Resource with computed field in config (using_latest_model)",
+				Input: `
+resource "cloudflare_bot_management" "with_computed" {
+  zone_id           = "0da42c8d2132a9ddaf714f9e7c920711"
+  auto_update_model = true
+}`,
+				Expected: `resource "cloudflare_bot_management" "with_computed" {
+  zone_id           = "0da42c8d2132a9ddaf714f9e7c920711"
+  auto_update_model = true
+}`,
+			},
+		}
+
+		testhelpers.RunConfigTransformTests(t, tests, migrator)
+	})
+
+	// Test state transformations
+	t.Run("StateTransformation", func(t *testing.T) {
+		tests := []testhelpers.StateTestCase{
+			{
+				Name: "Full state with basic fields",
+				Input: `{
+  "version": 4,
+  "terraform_version": "1.5.0",
+  "resources": [{
+    "type": "cloudflare_bot_management",
+    "name": "example",
+    "instances": [{
+      "attributes": {
+        "id": "0da42c8d2132a9ddaf714f9e7c920711",
+        "zone_id": "0da42c8d2132a9ddaf714f9e7c920711",
+        "enable_js": true,
+        "fight_mode": false,
+        "auto_update_model": true,
+        "suppress_session_score": false
+      }
+    }]
+  }]
+}`,
+				Expected: `{
+  "version": 4,
+  "terraform_version": "1.5.0",
+  "resources": [{
+    "type": "cloudflare_bot_management",
+    "name": "example",
+    "instances": [{
+      "attributes": {
+        "id": "0da42c8d2132a9ddaf714f9e7c920711",
+        "zone_id": "0da42c8d2132a9ddaf714f9e7c920711",
+        "enable_js": true,
+        "fight_mode": false,
+        "auto_update_model": true,
+        "suppress_session_score": false
+      }
+    }]
+  }]
+}`,
+			},
+			{
+				Name: "Full state with all v4 fields",
+				Input: `{
+  "version": 4,
+  "resources": [{
+    "type": "cloudflare_bot_management",
+    "name": "complete",
+    "instances": [{
+      "attributes": {
+        "id": "0da42c8d2132a9ddaf714f9e7c920711",
+        "zone_id": "0da42c8d2132a9ddaf714f9e7c920711",
+        "enable_js": true,
+        "fight_mode": true,
+        "sbfm_definitely_automated": "block",
+        "sbfm_likely_automated": "block",
+        "sbfm_verified_bots": "allow",
+        "sbfm_static_resource_protection": true,
+        "optimize_wordpress": false,
+        "suppress_session_score": false,
+        "auto_update_model": true,
+        "using_latest_model": true,
+        "ai_bots_protection": "disabled"
+      }
+    }]
+  }]
+}`,
+				Expected: `{
+  "version": 4,
+  "resources": [{
+    "type": "cloudflare_bot_management",
+    "name": "complete",
+    "instances": [{
+      "attributes": {
+        "id": "0da42c8d2132a9ddaf714f9e7c920711",
+        "zone_id": "0da42c8d2132a9ddaf714f9e7c920711",
+        "enable_js": true,
+        "fight_mode": true,
+        "sbfm_definitely_automated": "block",
+        "sbfm_likely_automated": "block",
+        "sbfm_verified_bots": "allow",
+        "sbfm_static_resource_protection": true,
+        "optimize_wordpress": false,
+        "suppress_session_score": false,
+        "auto_update_model": true,
+        "using_latest_model": true,
+        "ai_bots_protection": "disabled"
+      }
+    }]
+  }]
+}`,
+			},
+			{
+				Name: "State with computed field - using_latest_model",
+				Input: `{
+  "version": 4,
+  "resources": [{
+    "type": "cloudflare_bot_management",
+    "name": "test",
+    "instances": [{
+      "attributes": {
+        "id": "0da42c8d2132a9ddaf714f9e7c920711",
+        "zone_id": "0da42c8d2132a9ddaf714f9e7c920711",
+        "auto_update_model": true,
+        "using_latest_model": false
+      }
+    }]
+  }]
+}`,
+				Expected: `{
+  "version": 4,
+  "resources": [{
+    "type": "cloudflare_bot_management",
+    "name": "test",
+    "instances": [{
+      "attributes": {
+        "id": "0da42c8d2132a9ddaf714f9e7c920711",
+        "zone_id": "0da42c8d2132a9ddaf714f9e7c920711",
+        "auto_update_model": true,
+        "using_latest_model": false
+      }
+    }]
+  }]
+}`,
+			},
+			{
+				Name: "State with AI bots protection values",
+				Input: `{
+  "version": 4,
+  "resources": [{
+    "type": "cloudflare_bot_management",
+    "name": "ai",
+    "instances": [{
+      "attributes": {
+        "id": "0da42c8d2132a9ddaf714f9e7c920711",
+        "zone_id": "0da42c8d2132a9ddaf714f9e7c920711",
+        "ai_bots_protection": "block"
+      }
+    }]
+  }]
+}`,
+				Expected: `{
+  "version": 4,
+  "resources": [{
+    "type": "cloudflare_bot_management",
+    "name": "ai",
+    "instances": [{
+      "attributes": {
+        "id": "0da42c8d2132a9ddaf714f9e7c920711",
+        "zone_id": "0da42c8d2132a9ddaf714f9e7c920711",
+        "ai_bots_protection": "block"
+      }
+    }]
+  }]
+}`,
+			},
+			{
+				Name: "Minimal state with only required fields",
+				Input: `{
+  "version": 4,
+  "resources": [{
+    "type": "cloudflare_bot_management",
+    "name": "minimal",
+    "instances": [{
+      "attributes": {
+        "id": "0da42c8d2132a9ddaf714f9e7c920711",
+        "zone_id": "0da42c8d2132a9ddaf714f9e7c920711"
+      }
+    }]
+  }]
+}`,
+				Expected: `{
+  "version": 4,
+  "resources": [{
+    "type": "cloudflare_bot_management",
+    "name": "minimal",
+    "instances": [{
+      "attributes": {
+        "id": "0da42c8d2132a9ddaf714f9e7c920711",
+        "zone_id": "0da42c8d2132a9ddaf714f9e7c920711"
+      }
+    }]
+  }]
+}`,
+			},
+			{
+				Name: "Multiple instances of the same resource",
+				Input: `{
+  "version": 4,
+  "resources": [{
+    "type": "cloudflare_bot_management",
+    "name": "multi",
+    "instances": [
+      {
+        "attributes": {
+          "id": "0da42c8d2132a9ddaf714f9e7c920711",
+          "zone_id": "0da42c8d2132a9ddaf714f9e7c920711",
+          "enable_js": true,
+          "fight_mode": false
+        }
+      },
+      {
+        "attributes": {
+          "id": "28fea702d1075b10ba9c8620b86218ec",
+          "zone_id": "28fea702d1075b10ba9c8620b86218ec",
+          "enable_js": false,
+          "fight_mode": true
+        }
+      }
+    ]
+  }]
+}`,
+				Expected: `{
+  "version": 4,
+  "resources": [{
+    "type": "cloudflare_bot_management",
+    "name": "multi",
+    "instances": [
+      {
+        "attributes": {
+          "id": "0da42c8d2132a9ddaf714f9e7c920711",
+          "zone_id": "0da42c8d2132a9ddaf714f9e7c920711",
+          "enable_js": true,
+          "fight_mode": false
+        }
+      },
+      {
+        "attributes": {
+          "id": "28fea702d1075b10ba9c8620b86218ec",
+          "zone_id": "28fea702d1075b10ba9c8620b86218ec",
+          "enable_js": false,
+          "fight_mode": true
+        }
+      }
+    ]
+  }]
+}`,
+			},
+			{
+				Name: "State with empty resources array",
+				Input: `{
+  "resources": []
+}`,
+				Expected: `{
+  "resources": []
+}`,
+			},
+			{
+				Name: "State without instances",
+				Input: `{
+  "resources": [{
+    "type": "cloudflare_bot_management",
+    "name": "empty",
+    "instances": []
+  }]
+}`,
+				Expected: `{
+  "resources": [{
+    "type": "cloudflare_bot_management",
+    "name": "empty",
+    "instances": []
+  }]
+}`,
+			},
+			{
+				Name: "Single instance state (for internal testing)",
+				Input: `{
+  "attributes": {
+    "id": "0da42c8d2132a9ddaf714f9e7c920711",
+    "zone_id": "0da42c8d2132a9ddaf714f9e7c920711",
+    "enable_js": true,
+    "fight_mode": false,
+    "auto_update_model": true
+  }
+}`,
+				Expected: `{
+  "attributes": {
+    "id": "0da42c8d2132a9ddaf714f9e7c920711",
+    "zone_id": "0da42c8d2132a9ddaf714f9e7c920711",
+    "enable_js": true,
+    "fight_mode": false,
+    "auto_update_model": true
+  }
+}`,
+			},
+			{
+				Name: "State with SBFM configuration",
+				Input: `{
+  "version": 4,
+  "resources": [{
+    "type": "cloudflare_bot_management",
+    "name": "sbfm",
+    "instances": [{
+      "attributes": {
+        "id": "0da42c8d2132a9ddaf714f9e7c920711",
+        "zone_id": "0da42c8d2132a9ddaf714f9e7c920711",
+        "sbfm_definitely_automated": "managed_challenge",
+        "sbfm_likely_automated": "managed_challenge",
+        "sbfm_verified_bots": "allow",
+        "sbfm_static_resource_protection": false,
+        "optimize_wordpress": true
+      }
+    }]
+  }]
+}`,
+				Expected: `{
+  "version": 4,
+  "resources": [{
+    "type": "cloudflare_bot_management",
+    "name": "sbfm",
+    "instances": [{
+      "attributes": {
+        "id": "0da42c8d2132a9ddaf714f9e7c920711",
+        "zone_id": "0da42c8d2132a9ddaf714f9e7c920711",
+        "sbfm_definitely_automated": "managed_challenge",
+        "sbfm_likely_automated": "managed_challenge",
+        "sbfm_verified_bots": "allow",
+        "sbfm_static_resource_protection": false,
+        "optimize_wordpress": true
+      }
+    }]
+  }]
+}`,
+			},
+		}
+
+		testhelpers.RunStateTransformTests(t, tests, migrator)
+	})
+}


### PR DESCRIPTION
This migration is essentially a no-op as the HCL & State pass through unchanged. 

```  Why No Changes Are Necessary:
  Schema Compatibility:

  - ✅ All 12 v4 fields exist in v5 with identical names and types
  - ✅ No fields were deprecated or removed
  - ✅ No fields were renamed
  - ✅ No type conversions needed
  - ✅ V5 only adds new optional/computed fields (doesn't change existing ones)
  ```
  
  E2e tests running successfully and no drift in this resource: 
  ```
  ========================================
✓ E2E Test Complete!
========================================

Summary:
  - v4 terraform apply: SUCCESS
  - Migration: SUCCESS
  - v5 terraform apply: WARNING
  - v5 plan (before apply): Plan: 0 to add, 39 to change, 0 to destroy.
  - v5 plan (after apply): DRIFT DETECTED
    Plan: 0 to add, 19 to change, 0 to destroy.
 ```