### PR TITLE
feat: v4 to v5 migration for custom_pages

### DIFF
--- a/integration/v4_to_v5/integration_test.go
+++ b/integration/v4_to_v5/integration_test.go
@@ -9,6 +9,7 @@ import (
 	// Explicitly import the migrations we want to test
 	_ "github.com/cloudflare/tf-migrate/internal/resources/account_member"
 	_ "github.com/cloudflare/tf-migrate/internal/resources/api_token"
+	_ "github.com/cloudflare/tf-migrate/internal/resources/custom_pages"
 	_ "github.com/cloudflare/tf-migrate/internal/resources/dns_record"
 	_ "github.com/cloudflare/tf-migrate/internal/resources/healthcheck"
 	_ "github.com/cloudflare/tf-migrate/internal/resources/logpull_retention"

--- a/integration/v4_to_v5/testdata/custom_pages/expected/custom_pages.tf
+++ b/integration/v4_to_v5/testdata/custom_pages/expected/custom_pages.tf
@@ -1,0 +1,18 @@
+# Variables (no defaults as per pattern)
+variable "cloudflare_account_id" {
+  description = "Cloudflare account ID"
+  type        = string
+}
+
+variable "cloudflare_zone_id" {
+  description = "Cloudflare zone ID"
+  type        = string
+}
+
+# Basic zone-scoped custom page with real URL
+resource "cloudflare_custom_pages" "error_500" {
+  zone_id    = var.cloudflare_zone_id
+  url        = "https://custom-pages-500-error-for-e2e.terraform-testing-a09.workers.dev/"
+  state      = "customized"
+  identifier = "500_errors"
+}

--- a/integration/v4_to_v5/testdata/custom_pages/expected/terraform.tfstate
+++ b/integration/v4_to_v5/testdata/custom_pages/expected/terraform.tfstate
@@ -1,0 +1,44 @@
+{
+  "resources": [
+    {
+      "instances": [
+        {
+          "attributes": {
+            "account_id": null,
+            "id": "500_errors",
+            "identifier": "500_errors",
+            "state": "customized",
+            "url": "https://www.cloudflare.com/cdn-cgi/trace",
+            "zone_id": "14e48053f1836c10cb86ba178633826a"
+          },
+          "schema_version": 0
+        }
+      ],
+      "mode": "managed",
+      "name": "error_500",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_custom_pages"
+    },
+    {
+      "instances": [
+        {
+          "attributes": {
+            "account_id": null,
+            "id": "basic_challenge",
+            "identifier": "basic_challenge",
+            "state": "default",
+            "url": "https://www.cloudflare.com/cdn-cgi/trace",
+            "zone_id": "14e48053f1836c10cb86ba178633826a"
+          },
+          "schema_version": 0
+        }
+      ],
+      "mode": "managed",
+      "name": "no_state",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_custom_pages"
+    }
+  ],
+  "terraform_version": "1.5.0",
+  "version": 4
+}

--- a/integration/v4_to_v5/testdata/custom_pages/input/custom_pages.tf
+++ b/integration/v4_to_v5/testdata/custom_pages/input/custom_pages.tf
@@ -1,0 +1,18 @@
+# Variables (no defaults as per pattern)
+variable "cloudflare_account_id" {
+  description = "Cloudflare account ID"
+  type        = string
+}
+
+variable "cloudflare_zone_id" {
+  description = "Cloudflare zone ID"
+  type        = string
+}
+
+# Basic zone-scoped custom page with real URL
+resource "cloudflare_custom_pages" "error_500" {
+  zone_id = var.cloudflare_zone_id
+  type    = "500_errors"
+  url     = "https://custom-pages-500-error-for-e2e.terraform-testing-a09.workers.dev/"
+  state   = "customized"
+}

--- a/integration/v4_to_v5/testdata/custom_pages/input/terraform.tfstate
+++ b/integration/v4_to_v5/testdata/custom_pages/input/terraform.tfstate
@@ -1,0 +1,43 @@
+{
+  "resources": [
+    {
+      "instances": [
+        {
+          "attributes": {
+            "account_id": null,
+            "id": "500_errors",
+            "type": "500_errors",
+            "state": "customized",
+            "url": "https://www.cloudflare.com/cdn-cgi/trace",
+            "zone_id": "14e48053f1836c10cb86ba178633826a"
+          },
+          "schema_version": 0
+        }
+      ],
+      "mode": "managed",
+      "name": "error_500",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_custom_pages"
+    },
+    {
+      "instances": [
+        {
+          "attributes": {
+            "account_id": null,
+            "id": "basic_challenge",
+            "type": "basic_challenge",
+            "url": "https://www.cloudflare.com/cdn-cgi/trace",
+            "zone_id": "14e48053f1836c10cb86ba178633826a"
+          },
+          "schema_version": 0
+        }
+      ],
+      "mode": "managed",
+      "name": "no_state",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_custom_pages"
+    }
+  ],
+  "terraform_version": "1.5.0",
+  "version": 4
+}

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -5,6 +5,7 @@ import (
 	zonesdata "github.com/cloudflare/tf-migrate/internal/datasources/zones"
 	"github.com/cloudflare/tf-migrate/internal/resources/account_member"
 	"github.com/cloudflare/tf-migrate/internal/resources/api_token"
+	"github.com/cloudflare/tf-migrate/internal/resources/custom_pages"
 	"github.com/cloudflare/tf-migrate/internal/resources/bot_management"
 	"github.com/cloudflare/tf-migrate/internal/resources/dns_record"
 	"github.com/cloudflare/tf-migrate/internal/resources/healthcheck"
@@ -40,6 +41,7 @@ func RegisterAllMigrations() {
 	// Resources
 	account_member.NewV4ToV5Migrator()
 	api_token.NewV4ToV5Migrator()
+	custom_pages.NewV4ToV5Migrator()
 	bot_management.NewV4ToV5Migrator()
 	dns_record.NewV4ToV5Migrator()
 	healthcheck.NewV4ToV5Migrator()

--- a/internal/resources/custom_pages/v4_to_v5.go
+++ b/internal/resources/custom_pages/v4_to_v5.go
@@ -1,0 +1,93 @@
+package custom_pages
+
+import (
+	"github.com/hashicorp/hcl/v2/hclwrite"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+
+	"github.com/cloudflare/tf-migrate/internal"
+	"github.com/cloudflare/tf-migrate/internal/transform"
+	tfhcl "github.com/cloudflare/tf-migrate/internal/transform/hcl"
+)
+
+// V4ToV5Migrator handles the migration of cloudflare_custom_pages from v4 to v5.
+// Key transformations:
+// 1. type → identifier (field rename)
+// 2. state: Optional → Required (ensure field exists with default)
+type V4ToV5Migrator struct{}
+
+// NewV4ToV5Migrator creates a new migrator for cloudflare_custom_pages v4 to v5.
+func NewV4ToV5Migrator() transform.ResourceTransformer {
+	migrator := &V4ToV5Migrator{}
+	// Register with v4 resource name
+	internal.RegisterMigrator("cloudflare_custom_pages", "v4", "v5", migrator)
+	return migrator
+}
+
+// GetResourceType returns the v5 resource type this migrator handles.
+func (m *V4ToV5Migrator) GetResourceType() string {
+	return "cloudflare_custom_pages"
+}
+
+// CanHandle determines if this migrator can handle the given resource type.
+func (m *V4ToV5Migrator) CanHandle(resourceType string) bool {
+	return resourceType == "cloudflare_custom_pages"
+}
+
+// Preprocess handles string-level transformations before HCL parsing.
+// No preprocessing needed for custom_pages migration.
+func (m *V4ToV5Migrator) Preprocess(content string) string {
+	return content
+}
+
+// TransformConfig handles configuration file transformations.
+// Transformations:
+// 1. type → identifier
+// 2. Ensure state field exists (add default if missing)
+func (m *V4ToV5Migrator) TransformConfig(ctx *transform.Context, block *hclwrite.Block) (*transform.TransformResult, error) {
+	body := block.Body()
+
+	// 1. Rename type → identifier
+	tfhcl.RenameAttribute(body, "type", "identifier")
+
+	// 2. Ensure state field exists (required in v5, optional in v4)
+	// Note: If state already exists, EnsureAttribute won't overwrite it
+	tfhcl.EnsureAttribute(body, "state", "default")
+
+	return &transform.TransformResult{
+		Blocks:         []*hclwrite.Block{block},
+		RemoveOriginal: false,
+	}, nil
+}
+
+// TransformState handles state file transformations.
+// This function receives a single resource instance and returns the transformed instance JSON.
+func (m *V4ToV5Migrator) TransformState(ctx *transform.Context, stateJSON gjson.Result, resourcePath, resourceName string) (string, error) {
+	result := stateJSON.String()
+
+	// Check if it's a valid custom_pages instance
+	if !stateJSON.Exists() || !stateJSON.Get("attributes").Exists() {
+		// Even for invalid instances, set schema_version for v5
+		result, _ = sjson.Set(result, "schema_version", 0)
+		return result, nil
+	}
+
+	attrs := stateJSON.Get("attributes")
+
+	// 1. type → identifier
+	if typeField := attrs.Get("type"); typeField.Exists() {
+		result, _ = sjson.Set(result, "attributes.identifier", typeField.Value())
+		result, _ = sjson.Delete(result, "attributes.type")
+	}
+
+	// 2. Ensure state field exists (required in v5, optional in v4)
+	if !attrs.Get("state").Exists() {
+		// Add default value if missing
+		result, _ = sjson.Set(result, "attributes.state", "default")
+	}
+
+	// 3. Set schema_version to 0 for v5
+	result, _ = sjson.Set(result, "schema_version", 0)
+
+	return result, nil
+}

--- a/internal/resources/custom_pages/v4_to_v5_test.go
+++ b/internal/resources/custom_pages/v4_to_v5_test.go
@@ -1,0 +1,180 @@
+package custom_pages
+
+import (
+	"testing"
+
+	"github.com/cloudflare/tf-migrate/internal/testhelpers"
+)
+
+func TestV4ToV5Transformation(t *testing.T) {
+	migrator := NewV4ToV5Migrator()
+
+	// Test configuration transformations
+	t.Run("ConfigTransformation", func(t *testing.T) {
+		tests := []testhelpers.ConfigTestCase{
+			{
+				Name: "basic zone-scoped custom page",
+				Input: `
+resource "cloudflare_custom_pages" "test" {
+  zone_id = var.cloudflare_zone_id
+  type    = "500_errors"
+  url     = "https://cf-tf-test.com/500.html"
+  state   = "customized"
+}`,
+				Expected: `
+resource "cloudflare_custom_pages" "test" {
+  zone_id    = var.cloudflare_zone_id
+  url        = "https://cf-tf-test.com/500.html"
+  state      = "customized"
+  identifier = "500_errors"
+}`,
+			},
+			{
+				Name: "account-scoped custom page",
+				Input: `
+resource "cloudflare_custom_pages" "test" {
+  account_id = var.cloudflare_account_id
+  type       = "basic_challenge"
+  url        = "https://cf-tf-test.com/challenge.html"
+  state      = "default"
+}`,
+				Expected: `
+resource "cloudflare_custom_pages" "test" {
+  account_id = var.cloudflare_account_id
+  url        = "https://cf-tf-test.com/challenge.html"
+  state      = "default"
+  identifier = "basic_challenge"
+}`,
+			},
+			{
+				Name: "missing state field - default added",
+				Input: `
+resource "cloudflare_custom_pages" "test" {
+  zone_id = var.cloudflare_zone_id
+  type    = "500_errors"
+  url     = "https://cf-tf-test.com/500.html"
+}`,
+				Expected: `
+resource "cloudflare_custom_pages" "test" {
+  zone_id    = var.cloudflare_zone_id
+  url        = "https://cf-tf-test.com/500.html"
+  identifier = "500_errors"
+  state      = "default"
+}`,
+			},
+			{
+				Name: "multiple page types",
+				Input: `
+resource "cloudflare_custom_pages" "error_500" {
+  zone_id = var.cloudflare_zone_id
+  type    = "500_errors"
+  url     = "https://cf-tf-test.com/500.html"
+  state   = "customized"
+}
+
+resource "cloudflare_custom_pages" "error_1000" {
+  zone_id = var.cloudflare_zone_id
+  type    = "1000_errors"
+  url     = "https://cf-tf-test.com/1000.html"
+  state   = "customized"
+}`,
+				Expected: `
+resource "cloudflare_custom_pages" "error_500" {
+  zone_id    = var.cloudflare_zone_id
+  url        = "https://cf-tf-test.com/500.html"
+  state      = "customized"
+  identifier = "500_errors"
+}
+
+resource "cloudflare_custom_pages" "error_1000" {
+  zone_id    = var.cloudflare_zone_id
+  url        = "https://cf-tf-test.com/1000.html"
+  state      = "customized"
+  identifier = "1000_errors"
+}`,
+			},
+		}
+
+		testhelpers.RunConfigTransformTests(t, tests, migrator)
+	})
+
+	// Test state transformations
+	t.Run("StateTransformation", func(t *testing.T) {
+		tests := []testhelpers.StateTestCase{
+			{
+				Name: "basic state transformation",
+				Input: `{
+  "schema_version": 0,
+  "attributes": {
+    "id": "500_errors",
+    "zone_id": "14e48053f1836c10cb86ba178633826a",
+    "account_id": null,
+    "type": "500_errors",
+    "url": "https://cf-tf-test.com/500.html",
+    "state": "customized"
+  }
+}`,
+				Expected: `{
+  "schema_version": 0,
+  "attributes": {
+    "id": "500_errors",
+    "zone_id": "14e48053f1836c10cb86ba178633826a",
+    "account_id": null,
+    "identifier": "500_errors",
+    "url": "https://cf-tf-test.com/500.html",
+    "state": "customized"
+  }
+}`,
+			},
+			{
+				Name: "state transformation with missing state field",
+				Input: `{
+  "schema_version": 0,
+  "attributes": {
+    "id": "500_errors",
+    "zone_id": "14e48053f1836c10cb86ba178633826a",
+    "type": "500_errors",
+    "url": "https://cf-tf-test.com/500.html"
+  }
+}`,
+				Expected: `{
+  "schema_version": 0,
+  "attributes": {
+    "id": "500_errors",
+    "zone_id": "14e48053f1836c10cb86ba178633826a",
+    "identifier": "500_errors",
+    "url": "https://cf-tf-test.com/500.html",
+    "state": "default"
+  }
+}`,
+			},
+			{
+				Name: "account-scoped state",
+				Input: `{
+  "schema_version": 0,
+  "attributes": {
+    "id": "basic_challenge",
+    "account_id": "dbb2ef7988061049c4bd32bf6883fde0",
+    "zone_id": null,
+    "type": "basic_challenge",
+    "url": "https://cf-tf-test.com/challenge.html",
+    "state": "default"
+  }
+}`,
+				Expected: `{
+  "schema_version": 0,
+  "attributes": {
+    "id": "basic_challenge",
+    "account_id": "dbb2ef7988061049c4bd32bf6883fde0",
+    "zone_id": null,
+    "identifier": "basic_challenge",
+    "url": "https://cf-tf-test.com/challenge.html",
+    "state": "default"
+  }
+}`,
+			},
+		}
+
+		testhelpers.RunStateTransformTests(t, tests, migrator)
+	})
+}


### PR DESCRIPTION
  Add custom_pages migration from v4 to v5

  Implements migration for cloudflare_custom_pages resource from provider v4 to v5.

  Key transformations:
  - Rename field: type → identifier
  - Make state field required (was optional in v4, defaults to "default" if missing)
  - Update schema_version to 0 in state files

  The migration handles both zone-scoped and account-scoped custom pages.

  Testing:
  - Unit tests: 7 test cases covering config and state transformations
  - Integration tests: Simplified to use real Workers URL for practical E2E usage

  Files modified:
  - internal/resources/custom_pages/v4_to_v5.go (migration logic)
  - internal/resources/custom_pages/v4_to_v5_test.go (unit tests)
  - integration/v4_to_v5/testdata/custom_pages/ (integration test fixtures)
  - integration/v4_to_v5/integration_test.go (register migration)