### PR TITLE
feat: v4 to v5 migration for load_balancer_monitor

### DIFF
--- a/integration/v4_to_v5/testdata/load_balancer_monitor/expected/load_balancer_monitor.tf
+++ b/integration/v4_to_v5/testdata/load_balancer_monitor/expected/load_balancer_monitor.tf
@@ -1,0 +1,252 @@
+# Terraform v4 Load Balancer Monitor Test Configuration
+# This file tests the migration from cloudflare_load_balancer_monitor (v4) to cloudflare_load_balancer_monitor (v5)
+# NOTE: Resource name stays the same, but field structures change
+
+# Variables - auto-provided by test infrastructure
+
+variable "cloudflare_zone_id" {
+  description = "Cloudflare zone ID"
+  type        = string
+}
+
+variable "cloudflare_account_id" {
+  description = "Cloudflare account ID"
+  type        = string
+}
+
+# Locals for DRY and testing
+locals {
+  name_prefix    = "cftftest"
+  common_account = var.cloudflare_account_id
+  monitor_types  = ["http", "https", "tcp"]
+}
+
+# Test Case 1: Minimal monitor (only required fields)
+resource "cloudflare_load_balancer_monitor" "minimal" {
+  account_id     = var.cloudflare_account_id
+  expected_codes = "200"
+}
+
+# Test Case 3: HTTPS monitor with multiple headers
+resource "cloudflare_load_balancer_monitor" "https_with_headers" {
+  account_id     = var.cloudflare_account_id
+  type           = "https"
+  method         = "GET"
+  path           = "/api/health"
+  expected_codes = "200"
+  expected_body  = "OK"
+  interval       = 45
+  retries        = 3
+  timeout        = 10
+  port           = 443
+  header = {
+    "Host"          = ["api.cf-tf-test.com"]
+    "Authorization" = ["Bearer token123"]
+  }
+}
+
+# Test Case 4: TCP monitor (no headers)
+resource "cloudflare_load_balancer_monitor" "tcp" {
+  account_id = var.cloudflare_account_id
+  type       = "tcp"
+  method     = "connection_established"
+  port       = 8080
+  interval   = 60
+  retries    = 2
+  timeout    = 5
+}
+
+# Test Case 5: Monitor with all optional fields
+resource "cloudflare_load_balancer_monitor" "maximal" {
+  account_id       = var.cloudflare_account_id
+  description      = "Comprehensive test monitor"
+  type             = "https"
+  method           = "GET"
+  path             = "/status"
+  port             = 8443
+  interval         = 120
+  retries          = 5
+  timeout          = 10
+  expected_codes   = "2xx,3xx"
+  expected_body    = "healthy"
+  follow_redirects = true
+  allow_insecure   = false
+  consecutive_down = 3
+  consecutive_up   = 2
+  header = {
+    "Host"            = ["status.cf-tf-test.com"]
+    "X-Custom-Header" = ["custom-value"]
+  }
+}
+
+# Test Case 7: for_each with set
+resource "cloudflare_load_balancer_monitor" "set_monitors" {
+  for_each = toset([
+    "alpha",
+    "beta",
+    "gamma",
+    "delta"
+  ])
+
+  account_id     = var.cloudflare_account_id
+  description    = "${local.name_prefix}-monitor-${each.value}"
+  type           = "http"
+  method         = "GET"
+  path           = "/healthz"
+  interval       = 60
+  expected_codes = "200"
+}
+
+# Test Case 8: count-based resources
+resource "cloudflare_load_balancer_monitor" "counted" {
+  count = 3
+
+  account_id     = var.cloudflare_account_id
+  description    = "${local.name_prefix}-monitor-${count.index}"
+  type           = "http"
+  method         = "GET"
+  path           = "/health${count.index}"
+  port           = 8080 + count.index
+  interval       = 30 + (count.index * 10)
+  expected_codes = "200"
+}
+
+# Test Case 9: Conditional creation
+resource "cloudflare_load_balancer_monitor" "conditional_enabled" {
+  count = true ? 1 : 0
+
+  account_id     = var.cloudflare_account_id
+  description    = "${local.name_prefix}-conditional-enabled"
+  type           = "http"
+  method         = "GET"
+  path           = "/enabled"
+  expected_codes = "200"
+}
+
+resource "cloudflare_load_balancer_monitor" "conditional_disabled" {
+  count = false ? 1 : 0
+
+  account_id  = var.cloudflare_account_id
+  description = "${local.name_prefix}-conditional-disabled"
+  type        = "http"
+  method      = "GET"
+  path        = "/disabled"
+}
+
+# Test Case 10: Using Terraform functions
+resource "cloudflare_load_balancer_monitor" "with_functions" {
+  account_id     = var.cloudflare_account_id
+  description    = join("-", [local.name_prefix, "function", "test"])
+  type           = "https"
+  method         = "GET"
+  path           = "/check"
+  interval       = 60
+  expected_codes = "200"
+
+  header = {
+    "Host" = [join(".", [local.name_prefix, "example", "com"])]
+  }
+}
+
+# Test Case 11: Lifecycle meta-arguments
+resource "cloudflare_load_balancer_monitor" "with_lifecycle" {
+  account_id     = var.cloudflare_account_id
+  description    = "${local.name_prefix}-lifecycle-test"
+  type           = "http"
+  method         = "GET"
+  path           = "/lifecycle"
+  expected_codes = "200"
+
+  lifecycle {
+    create_before_destroy = true
+    ignore_changes        = [description]
+  }
+}
+
+# Test Case 12: Monitor with empty optional fields
+resource "cloudflare_load_balancer_monitor" "empty_optionals" {
+  account_id     = var.cloudflare_account_id
+  type           = "http"
+  method         = "GET"
+  expected_codes = "200"
+  # No path, no port, no headers - test default handling
+}
+
+# Test Case 13: SMTP monitor type
+resource "cloudflare_load_balancer_monitor" "smtp" {
+  account_id = var.cloudflare_account_id
+  type       = "smtp"
+  port       = 25
+  interval   = 60
+  retries    = 3
+  timeout    = 10
+}
+
+# Test Case 14: UDP-ICMP monitor type
+resource "cloudflare_load_balancer_monitor" "udp_icmp" {
+  account_id = var.cloudflare_account_id
+  type       = "udp_icmp"
+  port       = 53
+  interval   = 30
+  timeout    = 1
+}
+
+# Test Case 15: ICMP-PING monitor type
+resource "cloudflare_load_balancer_monitor" "icmp_ping" {
+  account_id = var.cloudflare_account_id
+  type       = "icmp_ping"
+  interval   = 60
+  retries    = 2
+  timeout    = 1
+}
+
+# Test Case 16: Header with multiple values
+resource "cloudflare_load_balancer_monitor" "multi_value_header" {
+  account_id     = var.cloudflare_account_id
+  type           = "https"
+  method         = "GET"
+  path           = "/multi"
+  expected_codes = "200"
+  header = {
+    "Accept"          = ["application/json", "application/xml", "text/html"]
+    "Accept-Language" = ["en-US", "en", "fr"]
+  }
+}
+
+# Test Case 17: String interpolation
+resource "cloudflare_load_balancer_monitor" "with_interpolation" {
+  account_id     = var.cloudflare_account_id
+  description    = "Monitor for account ${var.cloudflare_account_id}"
+  type           = "http"
+  method         = "GET"
+  path           = "/check"
+  expected_codes = "200"
+}
+
+# Test Case 18: Special characters in fields
+resource "cloudflare_load_balancer_monitor" "special_chars" {
+  account_id     = var.cloudflare_account_id
+  description    = "Test: Special & chars <> in \"description\""
+  type           = "https"
+  method         = "GET"
+  path           = "/api/v2/status?detailed=true&format=json"
+  expected_body  = "Status: OK | Ready: true"
+  expected_codes = "200"
+  header = {
+    "X-Api-Key" = ["key_with-dashes.and_underscores"]
+  }
+}
+
+# Test Case 19: Edge case - consecutive values
+resource "cloudflare_load_balancer_monitor" "consecutive_values" {
+  account_id       = var.cloudflare_account_id
+  type             = "http"
+  method           = "GET"
+  path             = "/check"
+  consecutive_down = 5
+  consecutive_up   = 3
+  interval         = 45
+  retries          = 4
+  timeout          = 8
+  expected_codes   = "200"
+}

--- a/integration/v4_to_v5/testdata/load_balancer_monitor/expected/terraform.tfstate
+++ b/integration/v4_to_v5/testdata/load_balancer_monitor/expected/terraform.tfstate
@@ -1,0 +1,819 @@
+{
+  "lineage": "test-load-balancer-monitor-lineage",
+  "outputs": {},
+  "resources": [
+    {
+      "instances": [
+        {
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "allow_insecure": null,
+            "created_on": "2023-01-01T00:00:00Z",
+            "description": null,
+            "expected_body": null,
+            "expected_codes": null,
+            "follow_redirects": null,
+            "id": "minimal-monitor-id",
+            "interval": 60,
+            "method": "GET",
+            "modified_on": "2023-01-01T00:00:00Z",
+            "probe_zone": null,
+            "retries": 2,
+            "timeout": 5,
+            "type": "http"
+          },
+          "schema_version": 0
+        }
+      ],
+      "mode": "managed",
+      "name": "minimal",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_load_balancer_monitor"
+    },
+    {
+      "instances": [
+        {
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "allow_insecure": null,
+            "created_on": "2023-01-01T00:00:00Z",
+            "description": null,
+            "expected_body": null,
+            "expected_codes": null,
+            "follow_redirects": null,
+            "header": {
+              "Host": [
+                "cf-tf-test.com"
+              ]
+            },
+            "id": "http-with-header-id",
+            "interval": 60,
+            "method": "GET",
+            "modified_on": "2023-01-01T00:00:00Z",
+            "path": "/health",
+            "probe_zone": null,
+            "retries": 2,
+            "timeout": 5,
+            "type": "http"
+          },
+          "schema_version": 0
+        }
+      ],
+      "mode": "managed",
+      "name": "http_with_header",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_load_balancer_monitor"
+    },
+    {
+      "instances": [
+        {
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "allow_insecure": null,
+            "created_on": "2023-01-01T00:00:00Z",
+            "description": null,
+            "expected_body": "OK",
+            "expected_codes": "200",
+            "follow_redirects": null,
+            "header": {
+              "Authorization": [
+                "Bearer token123"
+              ],
+              "Host": [
+                "api.cf-tf-test.com"
+              ],
+              "User-Agent": [
+                "CloudflareHealthCheck/1.0"
+              ]
+            },
+            "id": "https-with-headers-id",
+            "interval": 30,
+            "method": "GET",
+            "modified_on": "2023-01-01T00:00:00Z",
+            "path": "/api/health",
+            "port": 443,
+            "probe_zone": null,
+            "retries": 3,
+            "timeout": 10,
+            "type": "https"
+          },
+          "schema_version": 0
+        }
+      ],
+      "mode": "managed",
+      "name": "https_with_headers",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_load_balancer_monitor"
+    },
+    {
+      "instances": [
+        {
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "allow_insecure": null,
+            "created_on": "2023-01-01T00:00:00Z",
+            "description": null,
+            "expected_body": null,
+            "expected_codes": null,
+            "follow_redirects": null,
+            "id": "tcp-monitor-id",
+            "interval": 60,
+            "method": "connection_established",
+            "modified_on": "2023-01-01T00:00:00Z",
+            "port": 8080,
+            "probe_zone": null,
+            "retries": 2,
+            "timeout": 5,
+            "type": "tcp"
+          },
+          "schema_version": 0
+        }
+      ],
+      "mode": "managed",
+      "name": "tcp",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_load_balancer_monitor"
+    },
+    {
+      "instances": [
+        {
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "allow_insecure": false,
+            "consecutive_down": 3,
+            "consecutive_up": 2,
+            "created_on": "2023-01-01T00:00:00Z",
+            "description": "Comprehensive test monitor",
+            "expected_body": "healthy",
+            "expected_codes": "2xx,3xx",
+            "follow_redirects": true,
+            "header": {
+              "Host": [
+                "status.cf-tf-test.com"
+              ],
+              "X-Custom-Header": [
+                "custom-value"
+              ]
+            },
+            "id": "maximal-monitor-id",
+            "interval": 120,
+            "method": "POST",
+            "modified_on": "2023-01-01T00:00:00Z",
+            "path": "/status",
+            "port": 8443,
+            "probe_zone": "cf-tf-test.com",
+            "retries": 5,
+            "timeout": 15,
+            "type": "https"
+          },
+          "schema_version": 0
+        }
+      ],
+      "mode": "managed",
+      "name": "maximal",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_load_balancer_monitor"
+    },
+    {
+      "instances": [
+        {
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "allow_insecure": null,
+            "created_on": "2023-01-01T00:00:00Z",
+            "description": "API server health check",
+            "expected_body": null,
+            "expected_codes": null,
+            "follow_redirects": null,
+            "header": {
+              "Host": [
+                "api.cftftest.cf-tf-test.com"
+              ]
+            },
+            "id": "map-api-monitor-id",
+            "interval": 60,
+            "method": "GET",
+            "modified_on": "2023-01-01T00:00:00Z",
+            "path": "/api/status",
+            "port": 8443,
+            "probe_zone": null,
+            "retries": 2,
+            "timeout": 5,
+            "type": "https"
+          },
+          "index_key": "api",
+          "schema_version": 0
+        },
+        {
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "allow_insecure": null,
+            "created_on": "2023-01-01T00:00:00Z",
+            "description": "Cache server health check",
+            "expected_body": null,
+            "expected_codes": null,
+            "follow_redirects": null,
+            "header": {
+              "Host": [
+                "cache.cftftest.cf-tf-test.com"
+              ]
+            },
+            "id": "map-cache-monitor-id",
+            "interval": 60,
+            "method": "GET",
+            "modified_on": "2023-01-01T00:00:00Z",
+            "path": "/ping",
+            "port": 80,
+            "probe_zone": null,
+            "retries": 2,
+            "timeout": 5,
+            "type": "http"
+          },
+          "index_key": "cache",
+          "schema_version": 0
+        },
+        {
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "allow_insecure": null,
+            "created_on": "2023-01-01T00:00:00Z",
+            "description": "Web server health check",
+            "expected_body": null,
+            "expected_codes": null,
+            "follow_redirects": null,
+            "header": {
+              "Host": [
+                "web.cftftest.cf-tf-test.com"
+              ]
+            },
+            "id": "map-web-monitor-id",
+            "interval": 60,
+            "method": "GET",
+            "modified_on": "2023-01-01T00:00:00Z",
+            "path": "/health",
+            "port": 443,
+            "probe_zone": null,
+            "retries": 2,
+            "timeout": 5,
+            "type": "https"
+          },
+          "index_key": "web",
+          "schema_version": 0
+        }
+      ],
+      "mode": "managed",
+      "name": "map_monitors",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_load_balancer_monitor"
+    },
+    {
+      "instances": [
+        {
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "allow_insecure": null,
+            "created_on": "2023-01-01T00:00:00Z",
+            "description": "cftftest-monitor-alpha",
+            "expected_body": null,
+            "expected_codes": null,
+            "follow_redirects": null,
+            "id": "set-alpha-monitor-id",
+            "interval": 60,
+            "method": "GET",
+            "modified_on": "2023-01-01T00:00:00Z",
+            "path": "/healthz",
+            "probe_zone": null,
+            "retries": 2,
+            "timeout": 5,
+            "type": "http"
+          },
+          "index_key": "alpha",
+          "schema_version": 0
+        },
+        {
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "allow_insecure": null,
+            "created_on": "2023-01-01T00:00:00Z",
+            "description": "cftftest-monitor-beta",
+            "expected_body": null,
+            "expected_codes": null,
+            "follow_redirects": null,
+            "id": "set-beta-monitor-id",
+            "interval": 60,
+            "method": "GET",
+            "modified_on": "2023-01-01T00:00:00Z",
+            "path": "/healthz",
+            "probe_zone": null,
+            "retries": 2,
+            "timeout": 5,
+            "type": "http"
+          },
+          "index_key": "beta",
+          "schema_version": 0
+        },
+        {
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "allow_insecure": null,
+            "created_on": "2023-01-01T00:00:00Z",
+            "description": "cftftest-monitor-delta",
+            "expected_body": null,
+            "expected_codes": null,
+            "follow_redirects": null,
+            "id": "set-delta-monitor-id",
+            "interval": 60,
+            "method": "GET",
+            "modified_on": "2023-01-01T00:00:00Z",
+            "path": "/healthz",
+            "probe_zone": null,
+            "retries": 2,
+            "timeout": 5,
+            "type": "http"
+          },
+          "index_key": "delta",
+          "schema_version": 0
+        },
+        {
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "allow_insecure": null,
+            "created_on": "2023-01-01T00:00:00Z",
+            "description": "cftftest-monitor-gamma",
+            "expected_body": null,
+            "expected_codes": null,
+            "follow_redirects": null,
+            "id": "set-gamma-monitor-id",
+            "interval": 60,
+            "method": "GET",
+            "modified_on": "2023-01-01T00:00:00Z",
+            "path": "/healthz",
+            "probe_zone": null,
+            "retries": 2,
+            "timeout": 5,
+            "type": "http"
+          },
+          "index_key": "gamma",
+          "schema_version": 0
+        }
+      ],
+      "mode": "managed",
+      "name": "set_monitors",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_load_balancer_monitor"
+    },
+    {
+      "instances": [
+        {
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "allow_insecure": null,
+            "created_on": "2023-01-01T00:00:00Z",
+            "description": "cftftest-monitor-0",
+            "expected_body": null,
+            "expected_codes": null,
+            "follow_redirects": null,
+            "id": "counted-0-monitor-id",
+            "interval": 30,
+            "method": "GET",
+            "modified_on": "2023-01-01T00:00:00Z",
+            "path": "/health0",
+            "port": 8080,
+            "probe_zone": null,
+            "retries": 2,
+            "timeout": 5,
+            "type": "http"
+          },
+          "index_key": 0,
+          "schema_version": 0
+        },
+        {
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "allow_insecure": null,
+            "created_on": "2023-01-01T00:00:00Z",
+            "description": "cftftest-monitor-1",
+            "expected_body": null,
+            "expected_codes": null,
+            "follow_redirects": null,
+            "id": "counted-1-monitor-id",
+            "interval": 40,
+            "method": "GET",
+            "modified_on": "2023-01-01T00:00:00Z",
+            "path": "/health1",
+            "port": 8081,
+            "probe_zone": null,
+            "retries": 2,
+            "timeout": 5,
+            "type": "http"
+          },
+          "index_key": 1,
+          "schema_version": 0
+        },
+        {
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "allow_insecure": null,
+            "created_on": "2023-01-01T00:00:00Z",
+            "description": "cftftest-monitor-2",
+            "expected_body": null,
+            "expected_codes": null,
+            "follow_redirects": null,
+            "id": "counted-2-monitor-id",
+            "interval": 50,
+            "method": "GET",
+            "modified_on": "2023-01-01T00:00:00Z",
+            "path": "/health2",
+            "port": 8082,
+            "probe_zone": null,
+            "retries": 2,
+            "timeout": 5,
+            "type": "http"
+          },
+          "index_key": 2,
+          "schema_version": 0
+        }
+      ],
+      "mode": "managed",
+      "name": "counted",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_load_balancer_monitor"
+    },
+    {
+      "instances": [
+        {
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "allow_insecure": null,
+            "created_on": "2023-01-01T00:00:00Z",
+            "description": "cftftest-conditional-enabled",
+            "expected_body": null,
+            "expected_codes": null,
+            "follow_redirects": null,
+            "id": "conditional-enabled-id",
+            "interval": 60,
+            "method": "GET",
+            "modified_on": "2023-01-01T00:00:00Z",
+            "path": "/enabled",
+            "probe_zone": null,
+            "retries": 2,
+            "timeout": 5,
+            "type": "http"
+          },
+          "index_key": 0,
+          "schema_version": 0
+        }
+      ],
+      "mode": "managed",
+      "name": "conditional_enabled",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_load_balancer_monitor"
+    },
+    {
+      "instances": [
+        {
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "allow_insecure": null,
+            "created_on": "2023-01-01T00:00:00Z",
+            "description": "cftftest-function-test",
+            "expected_body": null,
+            "expected_codes": null,
+            "follow_redirects": null,
+            "header": {
+              "Host": [
+                "cftftest.cf-tf-test.com"
+              ]
+            },
+            "id": "with-functions-id",
+            "interval": 60,
+            "method": "GET",
+            "modified_on": "2023-01-01T00:00:00Z",
+            "path": "/check",
+            "probe_zone": null,
+            "retries": 2,
+            "timeout": 5,
+            "type": "https"
+          },
+          "schema_version": 0
+        }
+      ],
+      "mode": "managed",
+      "name": "with_functions",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_load_balancer_monitor"
+    },
+    {
+      "instances": [
+        {
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "allow_insecure": null,
+            "created_on": "2023-01-01T00:00:00Z",
+            "description": "cftftest-lifecycle-test",
+            "expected_body": null,
+            "expected_codes": null,
+            "follow_redirects": null,
+            "id": "with-lifecycle-id",
+            "interval": 60,
+            "method": "GET",
+            "modified_on": "2023-01-01T00:00:00Z",
+            "path": "/lifecycle",
+            "probe_zone": null,
+            "retries": 2,
+            "timeout": 5,
+            "type": "http"
+          },
+          "schema_version": 0
+        }
+      ],
+      "mode": "managed",
+      "name": "with_lifecycle",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_load_balancer_monitor"
+    },
+    {
+      "instances": [
+        {
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "allow_insecure": null,
+            "created_on": "2023-01-01T00:00:00Z",
+            "description": null,
+            "expected_body": null,
+            "expected_codes": null,
+            "follow_redirects": null,
+            "id": "empty-optionals-id",
+            "interval": 60,
+            "method": "GET",
+            "modified_on": "2023-01-01T00:00:00Z",
+            "probe_zone": null,
+            "retries": 2,
+            "timeout": 5,
+            "type": "http"
+          },
+          "schema_version": 0
+        }
+      ],
+      "mode": "managed",
+      "name": "empty_optionals",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_load_balancer_monitor"
+    },
+    {
+      "instances": [
+        {
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "allow_insecure": null,
+            "created_on": "2023-01-01T00:00:00Z",
+            "description": null,
+            "expected_body": null,
+            "expected_codes": null,
+            "follow_redirects": null,
+            "id": "smtp-monitor-id",
+            "interval": 60,
+            "modified_on": "2023-01-01T00:00:00Z",
+            "port": 25,
+            "probe_zone": null,
+            "retries": 3,
+            "timeout": 10,
+            "type": "smtp"
+          },
+          "schema_version": 0
+        }
+      ],
+      "mode": "managed",
+      "name": "smtp",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_load_balancer_monitor"
+    },
+    {
+      "instances": [
+        {
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "allow_insecure": null,
+            "created_on": "2023-01-01T00:00:00Z",
+            "description": null,
+            "expected_body": null,
+            "expected_codes": null,
+            "follow_redirects": null,
+            "id": "udp-icmp-monitor-id",
+            "interval": 30,
+            "modified_on": "2023-01-01T00:00:00Z",
+            "port": 53,
+            "probe_zone": null,
+            "retries": 2,
+            "timeout": 5,
+            "type": "udp_icmp"
+          },
+          "schema_version": 0
+        }
+      ],
+      "mode": "managed",
+      "name": "udp_icmp",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_load_balancer_monitor"
+    },
+    {
+      "instances": [
+        {
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "allow_insecure": null,
+            "created_on": "2023-01-01T00:00:00Z",
+            "description": null,
+            "expected_body": null,
+            "expected_codes": null,
+            "follow_redirects": null,
+            "id": "icmp-ping-monitor-id",
+            "interval": 60,
+            "modified_on": "2023-01-01T00:00:00Z",
+            "probe_zone": null,
+            "retries": 2,
+            "timeout": 5,
+            "type": "icmp_ping"
+          },
+          "schema_version": 0
+        }
+      ],
+      "mode": "managed",
+      "name": "icmp_ping",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_load_balancer_monitor"
+    },
+    {
+      "instances": [
+        {
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "allow_insecure": null,
+            "created_on": "2023-01-01T00:00:00Z",
+            "description": null,
+            "expected_body": null,
+            "expected_codes": null,
+            "follow_redirects": null,
+            "header": {
+              "Accept": [
+                "application/json",
+                "application/xml",
+                "text/html"
+              ],
+              "Accept-Language": [
+                "en-US",
+                "en",
+                "fr"
+              ]
+            },
+            "id": "multi-value-header-id",
+            "interval": 60,
+            "method": "GET",
+            "modified_on": "2023-01-01T00:00:00Z",
+            "path": "/multi",
+            "probe_zone": null,
+            "retries": 2,
+            "timeout": 5,
+            "type": "https"
+          },
+          "schema_version": 0
+        }
+      ],
+      "mode": "managed",
+      "name": "multi_value_header",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_load_balancer_monitor"
+    },
+    {
+      "instances": [
+        {
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "allow_insecure": null,
+            "created_on": "2023-01-01T00:00:00Z",
+            "description": "Monitor for account f037e56e89293a057740de681ac9abbe",
+            "expected_body": null,
+            "expected_codes": null,
+            "follow_redirects": null,
+            "id": "with-interpolation-id",
+            "interval": 60,
+            "method": "GET",
+            "modified_on": "2023-01-01T00:00:00Z",
+            "path": "/check",
+            "probe_zone": null,
+            "retries": 2,
+            "timeout": 5,
+            "type": "http"
+          },
+          "schema_version": 0
+        }
+      ],
+      "mode": "managed",
+      "name": "with_interpolation",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_load_balancer_monitor"
+    },
+    {
+      "instances": [
+        {
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "allow_insecure": null,
+            "created_on": "2023-01-01T00:00:00Z",
+            "description": "Test: Special \u0026 chars \u003c\u003e in \"description\"",
+            "expected_body": "Status: OK | Ready: true",
+            "expected_codes": null,
+            "follow_redirects": null,
+            "header": {
+              "X-API-Key": [
+                "key_with-dashes.and_underscores"
+              ]
+            },
+            "id": "special-chars-id",
+            "interval": 60,
+            "method": "GET",
+            "modified_on": "2023-01-01T00:00:00Z",
+            "path": "/api/v2/status?detailed=true\u0026format=json",
+            "probe_zone": null,
+            "retries": 2,
+            "timeout": 5,
+            "type": "https"
+          },
+          "schema_version": 0
+        }
+      ],
+      "mode": "managed",
+      "name": "special_chars",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_load_balancer_monitor"
+    },
+    {
+      "instances": [
+        {
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "allow_insecure": null,
+            "consecutive_down": 5,
+            "consecutive_up": 3,
+            "created_on": "2023-01-01T00:00:00Z",
+            "description": null,
+            "expected_body": null,
+            "expected_codes": null,
+            "follow_redirects": null,
+            "id": "consecutive-values-id",
+            "interval": 45,
+            "method": "GET",
+            "modified_on": "2023-01-01T00:00:00Z",
+            "path": "/check",
+            "probe_zone": null,
+            "retries": 4,
+            "timeout": 8,
+            "type": "http"
+          },
+          "schema_version": 0
+        }
+      ],
+      "mode": "managed",
+      "name": "consecutive_values",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_load_balancer_monitor"
+    },
+    {
+      "instances": [
+        {
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "allow_insecure": null,
+            "created_on": "2023-01-01T00:00:00Z",
+            "description": null,
+            "expected_body": null,
+            "expected_codes": null,
+            "follow_redirects": null,
+            "header": {
+              "Host": [
+                "cftftest.cf-tf-test.com"
+              ]
+            },
+            "id": "with-probe-zone-id",
+            "interval": 60,
+            "method": "GET",
+            "modified_on": "2023-01-01T00:00:00Z",
+            "path": "/health",
+            "probe_zone": "cftftest.cf-tf-test.com",
+            "retries": 2,
+            "timeout": 5,
+            "type": "https"
+          },
+          "schema_version": 0
+        }
+      ],
+      "mode": "managed",
+      "name": "with_probe_zone",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_load_balancer_monitor"
+    }
+  ],
+  "serial": 1,
+  "terraform_version": "1.5.0",
+  "version": 4
+}

--- a/integration/v4_to_v5/testdata/load_balancer_monitor/input/load_balancer_monitor.tf
+++ b/integration/v4_to_v5/testdata/load_balancer_monitor/input/load_balancer_monitor.tf
@@ -1,0 +1,266 @@
+# Terraform v4 Load Balancer Monitor Test Configuration
+# This file tests the migration from cloudflare_load_balancer_monitor (v4) to cloudflare_load_balancer_monitor (v5)
+# NOTE: Resource name stays the same, but field structures change
+
+# Variables - auto-provided by test infrastructure
+
+variable "cloudflare_zone_id" {
+  description = "Cloudflare zone ID"
+  type        = string
+}
+
+variable "cloudflare_account_id" {
+  description = "Cloudflare account ID"
+  type        = string
+}
+
+# Locals for DRY and testing
+locals {
+  name_prefix    = "cftftest"
+  common_account = var.cloudflare_account_id
+  monitor_types  = ["http", "https", "tcp"]
+}
+
+# Test Case 1: Minimal monitor (only required fields)
+resource "cloudflare_load_balancer_monitor" "minimal" {
+  account_id = var.cloudflare_account_id
+  expected_codes = "200"
+}
+
+# Test Case 3: HTTPS monitor with multiple headers
+resource "cloudflare_load_balancer_monitor" "https_with_headers" {
+  account_id     = var.cloudflare_account_id
+  type           = "https"
+  method         = "GET"
+  path           = "/api/health"
+  expected_codes = "200"
+  expected_body  = "OK"
+  interval       = 45
+  retries        = 3
+  timeout        = 10
+  port           = 443
+  header {
+    header = "Host"
+    values = ["api.cf-tf-test.com"]
+  }
+  header {
+    header = "Authorization"
+    values = ["Bearer token123"]
+  }
+}
+
+# Test Case 4: TCP monitor (no headers)
+resource "cloudflare_load_balancer_monitor" "tcp" {
+  account_id = var.cloudflare_account_id
+  type       = "tcp"
+  method     = "connection_established"
+  port       = 8080
+  interval   = 60
+  retries    = 2
+  timeout    = 5
+}
+
+# Test Case 5: Monitor with all optional fields
+resource "cloudflare_load_balancer_monitor" "maximal" {
+  account_id       = var.cloudflare_account_id
+  description      = "Comprehensive test monitor"
+  type             = "https"
+  method           = "GET"
+  path             = "/status"
+  port             = 8443
+  interval         = 120
+  retries          = 5
+  timeout          = 10
+  expected_codes   = "2xx,3xx"
+  expected_body    = "healthy"
+  follow_redirects = true
+  allow_insecure   = false
+  consecutive_down = 3
+  consecutive_up   = 2
+  header {
+    header = "Host"
+    values = ["status.cf-tf-test.com"]
+  }
+  header {
+    header = "X-Custom-Header"
+    values = ["custom-value"]
+  }
+}
+
+# Test Case 7: for_each with set
+resource "cloudflare_load_balancer_monitor" "set_monitors" {
+  for_each = toset([
+    "alpha",
+    "beta",
+    "gamma",
+    "delta"
+  ])
+
+  account_id  = var.cloudflare_account_id
+  description = "${local.name_prefix}-monitor-${each.value}"
+  type        = "http"
+  method      = "GET"
+  path        = "/healthz"
+  interval    = 60
+  expected_codes = "200"
+}
+
+# Test Case 8: count-based resources
+resource "cloudflare_load_balancer_monitor" "counted" {
+  count = 3
+
+  account_id  = var.cloudflare_account_id
+  description = "${local.name_prefix}-monitor-${count.index}"
+  type        = "http"
+  method      = "GET"
+  path        = "/health${count.index}"
+  port        = 8080 + count.index
+  interval    = 30 + (count.index * 10)
+  expected_codes = "200"
+}
+
+# Test Case 9: Conditional creation
+resource "cloudflare_load_balancer_monitor" "conditional_enabled" {
+  count = true ? 1 : 0
+
+  account_id  = var.cloudflare_account_id
+  description = "${local.name_prefix}-conditional-enabled"
+  type        = "http"
+  method      = "GET"
+  path        = "/enabled"
+  expected_codes = "200"
+}
+
+resource "cloudflare_load_balancer_monitor" "conditional_disabled" {
+  count = false ? 1 : 0
+
+  account_id  = var.cloudflare_account_id
+  description = "${local.name_prefix}-conditional-disabled"
+  type        = "http"
+  method      = "GET"
+  path        = "/disabled"
+}
+
+# Test Case 10: Using Terraform functions
+resource "cloudflare_load_balancer_monitor" "with_functions" {
+  account_id  = var.cloudflare_account_id
+  description = join("-", [local.name_prefix, "function", "test"])
+  type        = "https"
+  method      = "GET"
+  path        = "/check"
+  interval    = 60
+  expected_codes = "200"
+
+  header {
+    header = "Host"
+    values = [join(".", [local.name_prefix, "example", "com"])]
+  }
+}
+
+# Test Case 11: Lifecycle meta-arguments
+resource "cloudflare_load_balancer_monitor" "with_lifecycle" {
+  account_id  = var.cloudflare_account_id
+  description = "${local.name_prefix}-lifecycle-test"
+  type        = "http"
+  method      = "GET"
+  path        = "/lifecycle"
+  expected_codes = "200"
+
+  lifecycle {
+    create_before_destroy = true
+    ignore_changes        = [description]
+  }
+}
+
+# Test Case 12: Monitor with empty optional fields
+resource "cloudflare_load_balancer_monitor" "empty_optionals" {
+  account_id = var.cloudflare_account_id
+  type       = "http"
+  method     = "GET"
+  expected_codes = "200"
+  # No path, no port, no headers - test default handling
+}
+
+# Test Case 13: SMTP monitor type
+resource "cloudflare_load_balancer_monitor" "smtp" {
+  account_id = var.cloudflare_account_id
+  type       = "smtp"
+  port       = 25
+  interval   = 60
+  retries    = 3
+  timeout    = 10
+}
+
+# Test Case 14: UDP-ICMP monitor type
+resource "cloudflare_load_balancer_monitor" "udp_icmp" {
+  account_id = var.cloudflare_account_id
+  type       = "udp_icmp"
+  port       = 53
+  interval   = 30
+  timeout    = 1
+}
+
+# Test Case 15: ICMP-PING monitor type
+resource "cloudflare_load_balancer_monitor" "icmp_ping" {
+  account_id = var.cloudflare_account_id
+  type       = "icmp_ping"
+  interval   = 60
+  retries    = 2
+  timeout    = 1
+}
+
+# Test Case 16: Header with multiple values
+resource "cloudflare_load_balancer_monitor" "multi_value_header" {
+  account_id = var.cloudflare_account_id
+  type       = "https"
+  method     = "GET"
+  path       = "/multi"
+  expected_codes = "200"
+  header {
+    header = "Accept"
+    values = ["application/json", "application/xml", "text/html"]
+  }
+  header {
+    header = "Accept-Language"
+    values = ["en-US", "en", "fr"]
+  }
+}
+
+# Test Case 17: String interpolation
+resource "cloudflare_load_balancer_monitor" "with_interpolation" {
+  account_id  = var.cloudflare_account_id
+  description = "Monitor for account ${var.cloudflare_account_id}"
+  type        = "http"
+  method      = "GET"
+  path        = "/check"
+  expected_codes = "200"
+}
+
+# Test Case 18: Special characters in fields
+resource "cloudflare_load_balancer_monitor" "special_chars" {
+  account_id    = var.cloudflare_account_id
+  description   = "Test: Special & chars <> in \"description\""
+  type          = "https"
+  method        = "GET"
+  path          = "/api/v2/status?detailed=true&format=json"
+  expected_body = "Status: OK | Ready: true"
+  expected_codes = "200"
+  header {
+    header = "X-Api-Key"
+    values = ["key_with-dashes.and_underscores"]
+  }
+}
+
+# Test Case 19: Edge case - consecutive values
+resource "cloudflare_load_balancer_monitor" "consecutive_values" {
+  account_id       = var.cloudflare_account_id
+  type             = "http"
+  method           = "GET"
+  path             = "/check"
+  consecutive_down = 5
+  consecutive_up   = 3
+  interval         = 45
+  retries          = 4
+  timeout          = 8
+  expected_codes = "200"
+}

--- a/integration/v4_to_v5/testdata/load_balancer_monitor/input/terraform.tfstate
+++ b/integration/v4_to_v5/testdata/load_balancer_monitor/input/terraform.tfstate
@@ -1,0 +1,819 @@
+{
+  "lineage": "test-load-balancer-monitor-lineage",
+  "outputs": {},
+  "resources": [
+    {
+      "instances": [
+        {
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "allow_insecure": null,
+            "created_on": "2023-01-01T00:00:00Z",
+            "description": null,
+            "expected_body": null,
+            "expected_codes": null,
+            "follow_redirects": null,
+            "id": "minimal-monitor-id",
+            "interval": 60,
+            "method": "GET",
+            "modified_on": "2023-01-01T00:00:00Z",
+            "probe_zone": null,
+            "retries": 2,
+            "timeout": 5,
+            "type": "http"
+          },
+          "schema_version": 0
+        }
+      ],
+      "mode": "managed",
+      "name": "minimal",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_load_balancer_monitor"
+    },
+    {
+      "instances": [
+        {
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "allow_insecure": null,
+            "created_on": "2023-01-01T00:00:00Z",
+            "description": null,
+            "expected_body": null,
+            "expected_codes": null,
+            "follow_redirects": null,
+            "header": {
+              "Host": [
+                "cf-tf-test.com"
+              ]
+            },
+            "id": "http-with-header-id",
+            "interval": 60,
+            "method": "GET",
+            "modified_on": "2023-01-01T00:00:00Z",
+            "path": "/health",
+            "probe_zone": null,
+            "retries": 2,
+            "timeout": 5,
+            "type": "http"
+          },
+          "schema_version": 0
+        }
+      ],
+      "mode": "managed",
+      "name": "http_with_header",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_load_balancer_monitor"
+    },
+    {
+      "instances": [
+        {
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "allow_insecure": null,
+            "created_on": "2023-01-01T00:00:00Z",
+            "description": null,
+            "expected_body": "OK",
+            "expected_codes": "200",
+            "follow_redirects": null,
+            "header": {
+              "Authorization": [
+                "Bearer token123"
+              ],
+              "Host": [
+                "api.cf-tf-test.com"
+              ],
+              "User-Agent": [
+                "CloudflareHealthCheck/1.0"
+              ]
+            },
+            "id": "https-with-headers-id",
+            "interval": 30,
+            "method": "GET",
+            "modified_on": "2023-01-01T00:00:00Z",
+            "path": "/api/health",
+            "port": 443,
+            "probe_zone": null,
+            "retries": 3,
+            "timeout": 10,
+            "type": "https"
+          },
+          "schema_version": 0
+        }
+      ],
+      "mode": "managed",
+      "name": "https_with_headers",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_load_balancer_monitor"
+    },
+    {
+      "instances": [
+        {
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "allow_insecure": null,
+            "created_on": "2023-01-01T00:00:00Z",
+            "description": null,
+            "expected_body": null,
+            "expected_codes": null,
+            "follow_redirects": null,
+            "id": "tcp-monitor-id",
+            "interval": 60,
+            "method": "connection_established",
+            "modified_on": "2023-01-01T00:00:00Z",
+            "port": 8080,
+            "probe_zone": null,
+            "retries": 2,
+            "timeout": 5,
+            "type": "tcp"
+          },
+          "schema_version": 0
+        }
+      ],
+      "mode": "managed",
+      "name": "tcp",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_load_balancer_monitor"
+    },
+    {
+      "instances": [
+        {
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "allow_insecure": false,
+            "consecutive_down": 3,
+            "consecutive_up": 2,
+            "created_on": "2023-01-01T00:00:00Z",
+            "description": "Comprehensive test monitor",
+            "expected_body": "healthy",
+            "expected_codes": "2xx,3xx",
+            "follow_redirects": true,
+            "header": {
+              "Host": [
+                "status.cf-tf-test.com"
+              ],
+              "X-Custom-Header": [
+                "custom-value"
+              ]
+            },
+            "id": "maximal-monitor-id",
+            "interval": 120,
+            "method": "POST",
+            "modified_on": "2023-01-01T00:00:00Z",
+            "path": "/status",
+            "port": 8443,
+            "probe_zone": "cf-tf-test.com",
+            "retries": 5,
+            "timeout": 15,
+            "type": "https"
+          },
+          "schema_version": 0
+        }
+      ],
+      "mode": "managed",
+      "name": "maximal",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_load_balancer_monitor"
+    },
+    {
+      "instances": [
+        {
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "allow_insecure": null,
+            "created_on": "2023-01-01T00:00:00Z",
+            "description": "API server health check",
+            "expected_body": null,
+            "expected_codes": null,
+            "follow_redirects": null,
+            "header": {
+              "Host": [
+                "api.cftftest.cf-tf-test.com"
+              ]
+            },
+            "id": "map-api-monitor-id",
+            "interval": 60,
+            "method": "GET",
+            "modified_on": "2023-01-01T00:00:00Z",
+            "path": "/api/status",
+            "port": 8443,
+            "probe_zone": null,
+            "retries": 2,
+            "timeout": 5,
+            "type": "https"
+          },
+          "index_key": "api",
+          "schema_version": 0
+        },
+        {
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "allow_insecure": null,
+            "created_on": "2023-01-01T00:00:00Z",
+            "description": "Cache server health check",
+            "expected_body": null,
+            "expected_codes": null,
+            "follow_redirects": null,
+            "header": {
+              "Host": [
+                "cache.cftftest.cf-tf-test.com"
+              ]
+            },
+            "id": "map-cache-monitor-id",
+            "interval": 60,
+            "method": "GET",
+            "modified_on": "2023-01-01T00:00:00Z",
+            "path": "/ping",
+            "port": 80,
+            "probe_zone": null,
+            "retries": 2,
+            "timeout": 5,
+            "type": "http"
+          },
+          "index_key": "cache",
+          "schema_version": 0
+        },
+        {
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "allow_insecure": null,
+            "created_on": "2023-01-01T00:00:00Z",
+            "description": "Web server health check",
+            "expected_body": null,
+            "expected_codes": null,
+            "follow_redirects": null,
+            "header": {
+              "Host": [
+                "web.cftftest.cf-tf-test.com"
+              ]
+            },
+            "id": "map-web-monitor-id",
+            "interval": 60,
+            "method": "GET",
+            "modified_on": "2023-01-01T00:00:00Z",
+            "path": "/health",
+            "port": 443,
+            "probe_zone": null,
+            "retries": 2,
+            "timeout": 5,
+            "type": "https"
+          },
+          "index_key": "web",
+          "schema_version": 0
+        }
+      ],
+      "mode": "managed",
+      "name": "map_monitors",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_load_balancer_monitor"
+    },
+    {
+      "instances": [
+        {
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "allow_insecure": null,
+            "created_on": "2023-01-01T00:00:00Z",
+            "description": "cftftest-monitor-alpha",
+            "expected_body": null,
+            "expected_codes": null,
+            "follow_redirects": null,
+            "id": "set-alpha-monitor-id",
+            "interval": 60,
+            "method": "GET",
+            "modified_on": "2023-01-01T00:00:00Z",
+            "path": "/healthz",
+            "probe_zone": null,
+            "retries": 2,
+            "timeout": 5,
+            "type": "http"
+          },
+          "index_key": "alpha",
+          "schema_version": 0
+        },
+        {
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "allow_insecure": null,
+            "created_on": "2023-01-01T00:00:00Z",
+            "description": "cftftest-monitor-beta",
+            "expected_body": null,
+            "expected_codes": null,
+            "follow_redirects": null,
+            "id": "set-beta-monitor-id",
+            "interval": 60,
+            "method": "GET",
+            "modified_on": "2023-01-01T00:00:00Z",
+            "path": "/healthz",
+            "probe_zone": null,
+            "retries": 2,
+            "timeout": 5,
+            "type": "http"
+          },
+          "index_key": "beta",
+          "schema_version": 0
+        },
+        {
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "allow_insecure": null,
+            "created_on": "2023-01-01T00:00:00Z",
+            "description": "cftftest-monitor-delta",
+            "expected_body": null,
+            "expected_codes": null,
+            "follow_redirects": null,
+            "id": "set-delta-monitor-id",
+            "interval": 60,
+            "method": "GET",
+            "modified_on": "2023-01-01T00:00:00Z",
+            "path": "/healthz",
+            "probe_zone": null,
+            "retries": 2,
+            "timeout": 5,
+            "type": "http"
+          },
+          "index_key": "delta",
+          "schema_version": 0
+        },
+        {
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "allow_insecure": null,
+            "created_on": "2023-01-01T00:00:00Z",
+            "description": "cftftest-monitor-gamma",
+            "expected_body": null,
+            "expected_codes": null,
+            "follow_redirects": null,
+            "id": "set-gamma-monitor-id",
+            "interval": 60,
+            "method": "GET",
+            "modified_on": "2023-01-01T00:00:00Z",
+            "path": "/healthz",
+            "probe_zone": null,
+            "retries": 2,
+            "timeout": 5,
+            "type": "http"
+          },
+          "index_key": "gamma",
+          "schema_version": 0
+        }
+      ],
+      "mode": "managed",
+      "name": "set_monitors",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_load_balancer_monitor"
+    },
+    {
+      "instances": [
+        {
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "allow_insecure": null,
+            "created_on": "2023-01-01T00:00:00Z",
+            "description": "cftftest-monitor-0",
+            "expected_body": null,
+            "expected_codes": null,
+            "follow_redirects": null,
+            "id": "counted-0-monitor-id",
+            "interval": 30,
+            "method": "GET",
+            "modified_on": "2023-01-01T00:00:00Z",
+            "path": "/health0",
+            "port": 8080,
+            "probe_zone": null,
+            "retries": 2,
+            "timeout": 5,
+            "type": "http"
+          },
+          "index_key": 0,
+          "schema_version": 0
+        },
+        {
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "allow_insecure": null,
+            "created_on": "2023-01-01T00:00:00Z",
+            "description": "cftftest-monitor-1",
+            "expected_body": null,
+            "expected_codes": null,
+            "follow_redirects": null,
+            "id": "counted-1-monitor-id",
+            "interval": 40,
+            "method": "GET",
+            "modified_on": "2023-01-01T00:00:00Z",
+            "path": "/health1",
+            "port": 8081,
+            "probe_zone": null,
+            "retries": 2,
+            "timeout": 5,
+            "type": "http"
+          },
+          "index_key": 1,
+          "schema_version": 0
+        },
+        {
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "allow_insecure": null,
+            "created_on": "2023-01-01T00:00:00Z",
+            "description": "cftftest-monitor-2",
+            "expected_body": null,
+            "expected_codes": null,
+            "follow_redirects": null,
+            "id": "counted-2-monitor-id",
+            "interval": 50,
+            "method": "GET",
+            "modified_on": "2023-01-01T00:00:00Z",
+            "path": "/health2",
+            "port": 8082,
+            "probe_zone": null,
+            "retries": 2,
+            "timeout": 5,
+            "type": "http"
+          },
+          "index_key": 2,
+          "schema_version": 0
+        }
+      ],
+      "mode": "managed",
+      "name": "counted",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_load_balancer_monitor"
+    },
+    {
+      "instances": [
+        {
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "allow_insecure": null,
+            "created_on": "2023-01-01T00:00:00Z",
+            "description": "cftftest-conditional-enabled",
+            "expected_body": null,
+            "expected_codes": null,
+            "follow_redirects": null,
+            "id": "conditional-enabled-id",
+            "interval": 60,
+            "method": "GET",
+            "modified_on": "2023-01-01T00:00:00Z",
+            "path": "/enabled",
+            "probe_zone": null,
+            "retries": 2,
+            "timeout": 5,
+            "type": "http"
+          },
+          "index_key": 0,
+          "schema_version": 0
+        }
+      ],
+      "mode": "managed",
+      "name": "conditional_enabled",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_load_balancer_monitor"
+    },
+    {
+      "instances": [
+        {
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "allow_insecure": null,
+            "created_on": "2023-01-01T00:00:00Z",
+            "description": "cftftest-function-test",
+            "expected_body": null,
+            "expected_codes": null,
+            "follow_redirects": null,
+            "header": {
+              "Host": [
+                "cftftest.cf-tf-test.com"
+              ]
+            },
+            "id": "with-functions-id",
+            "interval": 60,
+            "method": "GET",
+            "modified_on": "2023-01-01T00:00:00Z",
+            "path": "/check",
+            "probe_zone": null,
+            "retries": 2,
+            "timeout": 5,
+            "type": "https"
+          },
+          "schema_version": 0
+        }
+      ],
+      "mode": "managed",
+      "name": "with_functions",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_load_balancer_monitor"
+    },
+    {
+      "instances": [
+        {
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "allow_insecure": null,
+            "created_on": "2023-01-01T00:00:00Z",
+            "description": "cftftest-lifecycle-test",
+            "expected_body": null,
+            "expected_codes": null,
+            "follow_redirects": null,
+            "id": "with-lifecycle-id",
+            "interval": 60,
+            "method": "GET",
+            "modified_on": "2023-01-01T00:00:00Z",
+            "path": "/lifecycle",
+            "probe_zone": null,
+            "retries": 2,
+            "timeout": 5,
+            "type": "http"
+          },
+          "schema_version": 0
+        }
+      ],
+      "mode": "managed",
+      "name": "with_lifecycle",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_load_balancer_monitor"
+    },
+    {
+      "instances": [
+        {
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "allow_insecure": null,
+            "created_on": "2023-01-01T00:00:00Z",
+            "description": null,
+            "expected_body": null,
+            "expected_codes": null,
+            "follow_redirects": null,
+            "id": "empty-optionals-id",
+            "interval": 60,
+            "method": "GET",
+            "modified_on": "2023-01-01T00:00:00Z",
+            "probe_zone": null,
+            "retries": 2,
+            "timeout": 5,
+            "type": "http"
+          },
+          "schema_version": 0
+        }
+      ],
+      "mode": "managed",
+      "name": "empty_optionals",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_load_balancer_monitor"
+    },
+    {
+      "instances": [
+        {
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "allow_insecure": null,
+            "created_on": "2023-01-01T00:00:00Z",
+            "description": null,
+            "expected_body": null,
+            "expected_codes": null,
+            "follow_redirects": null,
+            "id": "smtp-monitor-id",
+            "interval": 60,
+            "modified_on": "2023-01-01T00:00:00Z",
+            "port": 25,
+            "probe_zone": null,
+            "retries": 3,
+            "timeout": 10,
+            "type": "smtp"
+          },
+          "schema_version": 0
+        }
+      ],
+      "mode": "managed",
+      "name": "smtp",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_load_balancer_monitor"
+    },
+    {
+      "instances": [
+        {
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "allow_insecure": null,
+            "created_on": "2023-01-01T00:00:00Z",
+            "description": null,
+            "expected_body": null,
+            "expected_codes": null,
+            "follow_redirects": null,
+            "id": "udp-icmp-monitor-id",
+            "interval": 30,
+            "modified_on": "2023-01-01T00:00:00Z",
+            "port": 53,
+            "probe_zone": null,
+            "retries": 2,
+            "timeout": 5,
+            "type": "udp_icmp"
+          },
+          "schema_version": 0
+        }
+      ],
+      "mode": "managed",
+      "name": "udp_icmp",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_load_balancer_monitor"
+    },
+    {
+      "instances": [
+        {
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "allow_insecure": null,
+            "created_on": "2023-01-01T00:00:00Z",
+            "description": null,
+            "expected_body": null,
+            "expected_codes": null,
+            "follow_redirects": null,
+            "id": "icmp-ping-monitor-id",
+            "interval": 60,
+            "modified_on": "2023-01-01T00:00:00Z",
+            "probe_zone": null,
+            "retries": 2,
+            "timeout": 5,
+            "type": "icmp_ping"
+          },
+          "schema_version": 0
+        }
+      ],
+      "mode": "managed",
+      "name": "icmp_ping",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_load_balancer_monitor"
+    },
+    {
+      "instances": [
+        {
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "allow_insecure": null,
+            "created_on": "2023-01-01T00:00:00Z",
+            "description": null,
+            "expected_body": null,
+            "expected_codes": null,
+            "follow_redirects": null,
+            "header": {
+              "Accept": [
+                "application/json",
+                "application/xml",
+                "text/html"
+              ],
+              "Accept-Language": [
+                "en-US",
+                "en",
+                "fr"
+              ]
+            },
+            "id": "multi-value-header-id",
+            "interval": 60,
+            "method": "GET",
+            "modified_on": "2023-01-01T00:00:00Z",
+            "path": "/multi",
+            "probe_zone": null,
+            "retries": 2,
+            "timeout": 5,
+            "type": "https"
+          },
+          "schema_version": 0
+        }
+      ],
+      "mode": "managed",
+      "name": "multi_value_header",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_load_balancer_monitor"
+    },
+    {
+      "instances": [
+        {
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "allow_insecure": null,
+            "created_on": "2023-01-01T00:00:00Z",
+            "description": "Monitor for account f037e56e89293a057740de681ac9abbe",
+            "expected_body": null,
+            "expected_codes": null,
+            "follow_redirects": null,
+            "id": "with-interpolation-id",
+            "interval": 60,
+            "method": "GET",
+            "modified_on": "2023-01-01T00:00:00Z",
+            "path": "/check",
+            "probe_zone": null,
+            "retries": 2,
+            "timeout": 5,
+            "type": "http"
+          },
+          "schema_version": 0
+        }
+      ],
+      "mode": "managed",
+      "name": "with_interpolation",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_load_balancer_monitor"
+    },
+    {
+      "instances": [
+        {
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "allow_insecure": null,
+            "created_on": "2023-01-01T00:00:00Z",
+            "description": "Test: Special \u0026 chars \u003c\u003e in \"description\"",
+            "expected_body": "Status: OK | Ready: true",
+            "expected_codes": null,
+            "follow_redirects": null,
+            "header": {
+              "X-API-Key": [
+                "key_with-dashes.and_underscores"
+              ]
+            },
+            "id": "special-chars-id",
+            "interval": 60,
+            "method": "GET",
+            "modified_on": "2023-01-01T00:00:00Z",
+            "path": "/api/v2/status?detailed=true\u0026format=json",
+            "probe_zone": null,
+            "retries": 2,
+            "timeout": 5,
+            "type": "https"
+          },
+          "schema_version": 0
+        }
+      ],
+      "mode": "managed",
+      "name": "special_chars",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_load_balancer_monitor"
+    },
+    {
+      "instances": [
+        {
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "allow_insecure": null,
+            "consecutive_down": 5,
+            "consecutive_up": 3,
+            "created_on": "2023-01-01T00:00:00Z",
+            "description": null,
+            "expected_body": null,
+            "expected_codes": null,
+            "follow_redirects": null,
+            "id": "consecutive-values-id",
+            "interval": 45,
+            "method": "GET",
+            "modified_on": "2023-01-01T00:00:00Z",
+            "path": "/check",
+            "probe_zone": null,
+            "retries": 4,
+            "timeout": 8,
+            "type": "http"
+          },
+          "schema_version": 0
+        }
+      ],
+      "mode": "managed",
+      "name": "consecutive_values",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_load_balancer_monitor"
+    },
+    {
+      "instances": [
+        {
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "allow_insecure": null,
+            "created_on": "2023-01-01T00:00:00Z",
+            "description": null,
+            "expected_body": null,
+            "expected_codes": null,
+            "follow_redirects": null,
+            "header": {
+              "Host": [
+                "cftftest.cf-tf-test.com"
+              ]
+            },
+            "id": "with-probe-zone-id",
+            "interval": 60,
+            "method": "GET",
+            "modified_on": "2023-01-01T00:00:00Z",
+            "path": "/health",
+            "probe_zone": "cftftest.cf-tf-test.com",
+            "retries": 2,
+            "timeout": 5,
+            "type": "https"
+          },
+          "schema_version": 0
+        }
+      ],
+      "mode": "managed",
+      "name": "with_probe_zone",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_load_balancer_monitor"
+    }
+  ],
+  "serial": 1,
+  "terraform_version": "1.5.0",
+  "version": 4
+}

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -9,6 +9,7 @@ import (
 	"github.com/cloudflare/tf-migrate/internal/resources/bot_management"
 	"github.com/cloudflare/tf-migrate/internal/resources/dns_record"
 	"github.com/cloudflare/tf-migrate/internal/resources/healthcheck"
+	"github.com/cloudflare/tf-migrate/internal/resources/load_balancer_monitor"
 	"github.com/cloudflare/tf-migrate/internal/resources/logpull_retention"
 	"github.com/cloudflare/tf-migrate/internal/resources/logpush_job"
 	"github.com/cloudflare/tf-migrate/internal/resources/managed_transforms"
@@ -45,6 +46,7 @@ func RegisterAllMigrations() {
 	bot_management.NewV4ToV5Migrator()
 	dns_record.NewV4ToV5Migrator()
 	healthcheck.NewV4ToV5Migrator()
+	load_balancer_monitor.NewV4ToV5Migrator()
 	zone.NewV4ToV5Migrator()
 	zone_dnssec.NewV4ToV5Migrator()
 	logpull_retention.NewV4ToV5Migrator()

--- a/internal/resources/load_balancer_monitor/v4_to_v5.go
+++ b/internal/resources/load_balancer_monitor/v4_to_v5.go
@@ -1,0 +1,211 @@
+package load_balancer_monitor
+
+import (
+	"github.com/hashicorp/hcl/v2/hclwrite"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+
+	"github.com/cloudflare/tf-migrate/internal"
+	"github.com/cloudflare/tf-migrate/internal/transform"
+	tfhcl "github.com/cloudflare/tf-migrate/internal/transform/hcl"
+	"github.com/cloudflare/tf-migrate/internal/transform/state"
+)
+
+// V4ToV5Migrator handles migration of load balancer monitor resources from v4 to v5
+type V4ToV5Migrator struct{}
+
+func NewV4ToV5Migrator() transform.ResourceTransformer {
+	migrator := &V4ToV5Migrator{}
+	// Register with v4 resource name (same as v5 in this case)
+	internal.RegisterMigrator("cloudflare_load_balancer_monitor", "v4", "v5", migrator)
+	return migrator
+}
+
+func (m *V4ToV5Migrator) GetResourceType() string {
+	// Return v5 resource name (unchanged from v4)
+	return "cloudflare_load_balancer_monitor"
+}
+
+func (m *V4ToV5Migrator) CanHandle(resourceType string) bool {
+	return resourceType == "cloudflare_load_balancer_monitor"
+}
+
+func (m *V4ToV5Migrator) Preprocess(content string) string {
+	// No preprocessing needed - all transformations done with HCL helpers
+	return content
+}
+
+func (m *V4ToV5Migrator) TransformConfig(ctx *transform.Context, block *hclwrite.Block) (*transform.TransformResult, error) {
+	body := block.Body()
+
+	// Transform header blocks to map attribute
+	// v4: header { header = "Host" values = ["example.com"] }
+	// v5: header = { "Host" = ["example.com"] }
+	headerTokens, err := m.buildHeaderMapTokens(body)
+	if err != nil {
+		return nil, err
+	}
+	if headerTokens != nil {
+		body.SetAttributeRaw("header", headerTokens)
+		// Remove the old header blocks
+		tfhcl.RemoveBlocksByType(body, "header")
+	}
+
+	return &transform.TransformResult{
+		Blocks:         []*hclwrite.Block{block},
+		RemoveOriginal: false,
+	}, nil
+}
+
+// buildHeaderMapTokens converts v4 header blocks to v5 header map tokens
+// v4: header { header = "Host" values = ["example.com"] }
+// v5: header = { "Host" = ["example.com"] }
+func (m *V4ToV5Migrator) buildHeaderMapTokens(body *hclwrite.Body) (hclwrite.Tokens, error) {
+	// Find all header blocks
+	headerBlocks := tfhcl.FindBlocksByType(body, "header")
+	if len(headerBlocks) == 0 {
+		return nil, nil
+	}
+
+	// Build a list of object attributes for the header map
+	var headerAttrs []hclwrite.ObjectAttrTokens
+
+	for _, block := range headerBlocks {
+		blockBody := block.Body()
+
+		// Get the header name
+		headerAttr := blockBody.GetAttribute("header")
+		if headerAttr == nil {
+			continue
+		}
+
+		// Get the values
+		valuesAttr := blockBody.GetAttribute("values")
+		if valuesAttr == nil {
+			continue
+		}
+
+		// Use the header value as the map key and values as the map value
+		nameTokens := headerAttr.Expr().BuildTokens(nil)
+		valueTokens := valuesAttr.Expr().BuildTokens(nil)
+
+		headerAttrs = append(headerAttrs, hclwrite.ObjectAttrTokens{
+			Name:  nameTokens,
+			Value: valueTokens,
+		})
+	}
+
+	if len(headerAttrs) == 0 {
+		return nil, nil
+	}
+
+	// Create the object tokens for the header map
+	return hclwrite.TokensForObject(headerAttrs), nil
+}
+
+func (m *V4ToV5Migrator) TransformState(ctx *transform.Context, instance gjson.Result, resourcePath, resourceName string) (string, error) {
+	result := instance.String()
+	attrs := instance.Get("attributes")
+
+	if !attrs.Exists() {
+		// Set schema_version even for invalid instances
+		result, _ = sjson.Set(result, "schema_version", 0)
+		return result, nil
+	}
+
+	// Convert numeric fields (TypeInt → Int64Attribute)
+	numericFields := []string{
+		"interval", "port", "retries", "timeout",
+		"consecutive_down", "consecutive_up",
+	}
+
+	for _, field := range numericFields {
+		if fieldVal := attrs.Get(field); fieldVal.Exists() {
+			floatVal := state.ConvertToFloat64(fieldVal)
+			result, _ = sjson.Set(result, "attributes."+field, floatVal)
+		}
+	}
+
+	// Add v5 default values for fields that were optional without defaults in v4
+	// These defaults prevent PATCH operations when migrating
+	result = state.EnsureField(result, "attributes", attrs, "allow_insecure", false)
+	result = state.EnsureField(result, "attributes", attrs, "description", "")
+	result = state.EnsureField(result, "attributes", attrs, "expected_body", "")
+	result = state.EnsureField(result, "attributes", attrs, "expected_codes", "")
+	result = state.EnsureField(result, "attributes", attrs, "follow_redirects", false)
+	result = state.EnsureField(result, "attributes", attrs, "probe_zone", "")
+
+	// Transform header Set to Map
+	// v4: [{"header": "Host", "values": ["example.com"]}, ...]
+	// v5: {"Host": ["example.com"], ...}
+	if header := attrs.Get("header"); header.Exists() && header.IsArray() {
+		headerMap := m.transformHeaderSetToMap(header)
+		if len(headerMap) > 0 {
+			result, _ = sjson.Set(result, "attributes.header", headerMap)
+		} else {
+			// Remove empty header
+			result, _ = sjson.Delete(result, "attributes.header")
+		}
+	}
+
+	// Re-parse attrs after transformations to get updated structure
+	updatedAttrs := gjson.Parse(result).Get("attributes")
+
+	// Transform empty/zero values to null for fields not explicitly set in config
+	// This handles consecutive_down and consecutive_up which have Default: 0 in v4
+	// If they're 0 and not explicitly set in config, they should be removed from state
+	// because v5 treats absence as "use API default" (same as v4's Default: 0)
+	result = transform.TransformEmptyValuesToNull(transform.TransformEmptyValuesToNullOptions{
+		Ctx:              ctx,
+		Result:           result,
+		FieldPath:        "attributes",
+		FieldResult:      updatedAttrs,
+		ResourceName:     resourceName,
+		HCLAttributePath: "",
+		CanHandle:        m.CanHandle,
+	})
+
+	// Set schema_version
+	result, _ = sjson.Set(result, "schema_version", 0)
+
+	return result, nil
+}
+
+// transformHeaderSetToMap converts v4 header Set structure to v5 Map structure
+// v4: [{"header": "Host", "values": ["example.com"]}, {"header": "User-Agent", "values": ["Bot"]}]
+// v5: {"Host": ["example.com"], "User-Agent": ["Bot"]}
+func (m *V4ToV5Migrator) transformHeaderSetToMap(headerSet gjson.Result) map[string][]string {
+	headerMap := make(map[string][]string)
+
+	if !headerSet.IsArray() {
+		return headerMap
+	}
+
+	for _, item := range headerSet.Array() {
+		headerName := item.Get("header").String()
+		values := item.Get("values")
+
+		if headerName == "" || !values.Exists() {
+			continue
+		}
+
+		// Extract values array
+		var valuesList []string
+		if values.IsArray() {
+			for _, val := range values.Array() {
+				valuesList = append(valuesList, val.String())
+			}
+		}
+
+		if len(valuesList) > 0 {
+			headerMap[headerName] = valuesList
+		}
+	}
+
+	return headerMap
+}
+
+func init() {
+	// Register the migrator when the package is imported
+	NewV4ToV5Migrator()
+}

--- a/internal/resources/load_balancer_monitor/v4_to_v5_test.go
+++ b/internal/resources/load_balancer_monitor/v4_to_v5_test.go
@@ -1,0 +1,305 @@
+package load_balancer_monitor
+
+import (
+	"testing"
+
+	"github.com/cloudflare/tf-migrate/internal/testhelpers"
+)
+
+func TestV4ToV5Transformation(t *testing.T) {
+	migrator := NewV4ToV5Migrator()
+
+	t.Run("ConfigTransformation", func(t *testing.T) {
+		tests := []testhelpers.ConfigTestCase{
+			{
+				Name: "Minimal resource",
+				Input: `resource "cloudflare_load_balancer_monitor" "example" {
+  account_id = "abc123"
+}`,
+				Expected: `resource "cloudflare_load_balancer_monitor" "example" {
+  account_id = "abc123"
+}`,
+			},
+			{
+				Name: "Resource with single header",
+				Input: `resource "cloudflare_load_balancer_monitor" "example" {
+  account_id = "abc123"
+
+  header {
+    header = "Host"
+    values = ["cf-tf-test.com"]
+  }
+}`,
+				Expected: `resource "cloudflare_load_balancer_monitor" "example" {
+  account_id = "abc123"
+
+  header = {
+    "Host" = ["cf-tf-test.com"]
+  }
+}`,
+			},
+			{
+				Name: "Resource with multiple headers",
+				Input: `resource "cloudflare_load_balancer_monitor" "example" {
+  account_id = "abc123"
+
+  header {
+    header = "Host"
+    values = ["cf-tf-test.com"]
+  }
+
+  header {
+    header = "User-Agent"
+    values = ["Mozilla/5.0"]
+  }
+}`,
+				Expected: `resource "cloudflare_load_balancer_monitor" "example" {
+  account_id = "abc123"
+
+  header = {
+    "Host"       = ["cf-tf-test.com"]
+    "User-Agent" = ["Mozilla/5.0"]
+  }
+}`,
+			},
+			{
+				Name: "Complete resource with all fields",
+				Input: `resource "cloudflare_load_balancer_monitor" "example" {
+  account_id       = "abc123"
+  type             = "https"
+  interval         = 60
+  retries          = 2
+  timeout          = 5
+  method           = "GET"
+  path             = "/health"
+  expected_codes   = "2xx"
+  expected_body    = "alive"
+  follow_redirects = true
+  allow_insecure   = false
+  description      = "Test monitor"
+  port             = 443
+
+  header {
+    header = "Host"
+    values = ["cf-tf-test.com"]
+  }
+}`,
+				Expected: `resource "cloudflare_load_balancer_monitor" "example" {
+  account_id       = "abc123"
+  type             = "https"
+  interval         = 60
+  retries          = 2
+  timeout          = 5
+  method           = "GET"
+  path             = "/health"
+  expected_codes   = "2xx"
+  expected_body    = "alive"
+  follow_redirects = true
+  allow_insecure   = false
+  description      = "Test monitor"
+  port             = 443
+
+  header = {
+    "Host" = ["cf-tf-test.com"]
+  }
+}`,
+			},
+		}
+
+		testhelpers.RunConfigTransformTests(t, tests, migrator)
+	})
+
+	t.Run("StateTransformation", func(t *testing.T) {
+		tests := []testhelpers.StateTestCase{
+			{
+				Name: "Minimal state",
+				Input: `{
+  "type": "cloudflare_load_balancer_monitor",
+  "name": "example",
+  "attributes": {
+    "account_id": "abc123",
+    "id": "monitor123"
+  }
+}`,
+				Expected: `{
+  "type": "cloudflare_load_balancer_monitor",
+  "name": "example",
+  "attributes": {
+    "account_id": "abc123",
+    "id": "monitor123",
+    "allow_insecure": null,
+    "description": null,
+    "expected_body": null,
+    "expected_codes": null,
+    "follow_redirects": null,
+    "probe_zone": null
+  },
+  "schema_version": 0
+}`,
+			},
+			{
+				Name: "State with numeric conversions",
+				Input: `{
+  "type": "cloudflare_load_balancer_monitor",
+  "name": "example",
+  "attributes": {
+    "account_id": "abc123",
+    "interval": 60,
+    "retries": 2,
+    "timeout": 5,
+    "port": 443,
+    "consecutive_down": 3,
+    "consecutive_up": 2
+  }
+}`,
+				Expected: `{
+  "type": "cloudflare_load_balancer_monitor",
+  "name": "example",
+  "attributes": {
+    "account_id": "abc123",
+    "interval": 60.0,
+    "retries": 2.0,
+    "timeout": 5.0,
+    "port": 443.0,
+    "consecutive_down": 3.0,
+    "consecutive_up": 2.0,
+    "allow_insecure": null,
+    "description": null,
+    "expected_body": null,
+    "expected_codes": null,
+    "follow_redirects": null,
+    "probe_zone": null
+  },
+  "schema_version": 0
+}`,
+			},
+			{
+				Name: "State with header transformation",
+				Input: `{
+  "type": "cloudflare_load_balancer_monitor",
+  "name": "example",
+  "attributes": {
+    "account_id": "abc123",
+    "header": [
+      {
+        "header": "Host",
+        "values": ["cf-tf-test.com"]
+      },
+      {
+        "header": "User-Agent",
+        "values": ["Mozilla/5.0"]
+      }
+    ]
+  }
+}`,
+				Expected: `{
+  "type": "cloudflare_load_balancer_monitor",
+  "name": "example",
+  "attributes": {
+    "account_id": "abc123",
+    "header": {
+      "Host": ["cf-tf-test.com"],
+      "User-Agent": ["Mozilla/5.0"]
+    },
+    "allow_insecure": null,
+    "description": null,
+    "expected_body": null,
+    "expected_codes": null,
+    "follow_redirects": null,
+    "probe_zone": null
+  },
+  "schema_version": 0
+}`,
+			},
+			{
+				Name: "State with empty header array",
+				Input: `{
+  "type": "cloudflare_load_balancer_monitor",
+  "name": "example",
+  "attributes": {
+    "account_id": "abc123",
+    "header": []
+  }
+}`,
+				Expected: `{
+  "type": "cloudflare_load_balancer_monitor",
+  "name": "example",
+  "attributes": {
+    "account_id": "abc123",
+    "allow_insecure": null,
+    "description": null,
+    "expected_body": null,
+    "expected_codes": null,
+    "follow_redirects": null,
+    "probe_zone": null
+  },
+  "schema_version": 0
+}`,
+			},
+			{
+				Name: "Complete state with all fields",
+				Input: `{
+  "type": "cloudflare_load_balancer_monitor",
+  "name": "example",
+  "attributes": {
+    "id": "monitor123",
+    "account_id": "abc123",
+    "type": "https",
+    "interval": 60,
+    "retries": 2,
+    "timeout": 5,
+    "method": "GET",
+    "path": "/health",
+    "expected_codes": "2xx",
+    "expected_body": "alive",
+    "follow_redirects": true,
+    "allow_insecure": false,
+    "description": "Test monitor",
+    "port": 443,
+    "consecutive_down": 3,
+    "consecutive_up": 2,
+    "created_on": "2023-01-01T00:00:00Z",
+    "modified_on": "2023-01-02T00:00:00Z",
+    "header": [
+      {
+        "header": "Host",
+        "values": ["cf-tf-test.com"]
+      }
+    ]
+  }
+}`,
+				Expected: `{
+  "type": "cloudflare_load_balancer_monitor",
+  "name": "example",
+  "attributes": {
+    "id": "monitor123",
+    "account_id": "abc123",
+    "type": "https",
+    "interval": 60.0,
+    "retries": 2.0,
+    "timeout": 5.0,
+    "method": "GET",
+    "path": "/health",
+    "expected_codes": "2xx",
+    "expected_body": "alive",
+    "follow_redirects": true,
+    "allow_insecure": null,
+    "description": "Test monitor",
+    "port": 443.0,
+    "consecutive_down": 3.0,
+    "consecutive_up": 2.0,
+    "created_on": "2023-01-01T00:00:00Z",
+    "modified_on": "2023-01-02T00:00:00Z",
+    "header": {
+      "Host": ["cf-tf-test.com"]
+    },
+    "probe_zone": null
+  },
+  "schema_version": 0
+}`,
+			},
+		}
+
+		testhelpers.RunStateTransformTests(t, tests, migrator)
+	})
+}


### PR DESCRIPTION
Key changes:
  - Header transformation: header { header = "X" values = ["Y"] } → header = { "X" = ["Y"] }
  - Numeric conversions for 6 fields (interval, port, retries, timeout, consecutive_down, consecutive_up)
  - Default value additions (allow_insecure, description, expected_body, expected_codes, follow_redirects, probe_zone)
  - Empty value removal for fields with v4 Default: 0 not explicitly set in config
  - Includes comprehensive unit and integration tests (11 test cases)
