### PR TITLE
(Phase 0) tiered_cache v4->v5 migration port

### DIFF
--- a/e2e/scripts/init
+++ b/e2e/scripts/init
@@ -94,20 +94,40 @@ while IFS= read -r input_dir; do
     rm -rf "$module_dir"
     mkdir -p "$module_dir"
 
-    # Sync all .tf files from testdata
-    tf_files=$(find "$input_dir" -maxdepth 1 -name "*.tf" -type f)
+    # Sync .tf files from testdata, preferring _e2e.tf versions for single-zone resources
+    # First, check for *_e2e.tf files
+    e2e_files=$(find "$input_dir" -maxdepth 1 -name "*_e2e.tf" -type f)
 
-    if [[ -n "$tf_files" ]]; then
+    if [[ -n "$e2e_files" ]]; then
+        # Use e2e-specific files and rename them (remove _e2e suffix)
         while IFS= read -r tf_file; do
             [[ -z "$tf_file" ]] && continue
             filename=$(basename "$tf_file")
-            dest_file="${module_dir}/${filename}"
+            # Remove _e2e suffix from filename
+            dest_filename="${filename/_e2e.tf/.tf}"
+            dest_file="${module_dir}/${dest_filename}"
 
             # Copy file
             cp "$tf_file" "$dest_file"
-            echo -e "  ${GREEN}✓ ${resource_type}/${filename}${NC}"
+            echo -e "  ${GREEN}✓ ${resource_type}/${dest_filename} (from ${filename})${NC}"
             FILE_COUNT=$((FILE_COUNT + 1))
-        done <<< "$tf_files"
+        done <<< "$e2e_files"
+    else
+        # Fall back to regular .tf files
+        tf_files=$(find "$input_dir" -maxdepth 1 -name "*.tf" -type f)
+
+        if [[ -n "$tf_files" ]]; then
+            while IFS= read -r tf_file; do
+                [[ -z "$tf_file" ]] && continue
+                filename=$(basename "$tf_file")
+                dest_file="${module_dir}/${filename}"
+
+                # Copy file
+                cp "$tf_file" "$dest_file"
+                echo -e "  ${GREEN}✓ ${resource_type}/${filename}${NC}"
+                FILE_COUNT=$((FILE_COUNT + 1))
+            done <<< "$tf_files"
+        fi
     fi
 
     # Create versions.tf dynamically for each module

--- a/integration/v4_to_v5/integration_test.go
+++ b/integration/v4_to_v5/integration_test.go
@@ -18,6 +18,7 @@ import (
 	_ "github.com/cloudflare/tf-migrate/internal/resources/pages_project"
 	_ "github.com/cloudflare/tf-migrate/internal/resources/r2_bucket"
 	_ "github.com/cloudflare/tf-migrate/internal/resources/regional_hostname"
+	_ "github.com/cloudflare/tf-migrate/internal/resources/tiered_cache"
 	_ "github.com/cloudflare/tf-migrate/internal/resources/spectrum_application"
 	_ "github.com/cloudflare/tf-migrate/internal/resources/url_normalization_settings"
 	_ "github.com/cloudflare/tf-migrate/internal/resources/workers_kv"

--- a/integration/v4_to_v5/testdata/tiered_cache/expected/terraform.tfstate
+++ b/integration/v4_to_v5/testdata/tiered_cache/expected/terraform.tfstate
@@ -1,0 +1,89 @@
+{
+  "lineage": "test-lineage",
+  "outputs": {},
+  "resources": [
+    {
+      "instances": [
+        {
+          "attributes": {
+            "id": "test-zone-id-smart",
+            "value": "on",
+            "zone_id": "test-zone-id"
+          },
+          "schema_version": 0
+        }
+      ],
+      "mode": "managed",
+      "name": "smart",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_tiered_cache"
+    },
+    {
+      "instances": [
+        {
+          "attributes": {
+            "id": "test-zone-id-generic",
+            "value": "on",
+            "zone_id": "test-zone-id"
+          },
+          "schema_version": 0
+        }
+      ],
+      "mode": "managed",
+      "name": "generic",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_argo_tiered_caching"
+    },
+    {
+      "instances": [
+        {
+          "attributes": {
+            "id": "test-zone-id-off",
+            "value": "off",
+            "zone_id": "test-zone-id"
+          },
+          "schema_version": 0
+        }
+      ],
+      "mode": "managed",
+      "name": "off",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_tiered_cache"
+    },
+    {
+      "instances": [
+        {
+          "attributes": {
+            "id": "test-zone-id-variable",
+            "value": "off",
+            "zone_id": "test-zone-id"
+          },
+          "schema_version": 0
+        }
+      ],
+      "mode": "managed",
+      "name": "variable",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_tiered_cache"
+    },
+    {
+      "instances": [
+        {
+          "attributes": {
+            "id": "test-zone-id-lifecycle",
+            "value": "on",
+            "zone_id": "test-zone-id"
+          },
+          "schema_version": 0
+        }
+      ],
+      "mode": "managed",
+      "name": "lifecycle",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_argo_tiered_caching"
+    }
+  ],
+  "serial": 1,
+  "terraform_version": "1.5.0",
+  "version": 4
+}

--- a/integration/v4_to_v5/testdata/tiered_cache/expected/tiered_cache.tf
+++ b/integration/v4_to_v5/testdata/tiered_cache/expected/tiered_cache.tf
@@ -1,0 +1,50 @@
+variable "cloudflare_account_id" {
+  description = "Cloudflare account ID"
+  type        = string
+}
+
+variable "cloudflare_zone_id" {
+  description = "Cloudflare zone ID"
+  type        = string
+}
+
+variable "cache_type" {
+  type    = string
+  default = "off"
+}
+
+resource "cloudflare_tiered_cache" "smart" {
+  zone_id = var.cloudflare_zone_id
+  value   = "on"
+}
+
+resource "cloudflare_tiered_cache" "off" {
+  zone_id = var.cloudflare_zone_id
+  value   = "off"
+}
+
+
+resource "cloudflare_tiered_cache" "variable" {
+  zone_id = var.cloudflare_zone_id
+  value   = var.cache_type
+}
+
+resource "cloudflare_argo_tiered_caching" "generic" {
+  zone_id = var.cloudflare_zone_id
+  value   = "on"
+}
+moved {
+  from = cloudflare_tiered_cache.generic
+  to   = cloudflare_argo_tiered_caching.generic
+}
+resource "cloudflare_argo_tiered_caching" "lifecycle" {
+  zone_id = var.cloudflare_zone_id
+  value   = "on"
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+moved {
+  from = cloudflare_tiered_cache.lifecycle
+  to   = cloudflare_argo_tiered_caching.lifecycle
+}

--- a/integration/v4_to_v5/testdata/tiered_cache/input/terraform.tfstate
+++ b/integration/v4_to_v5/testdata/tiered_cache/input/terraform.tfstate
@@ -1,0 +1,89 @@
+{
+  "version": 4,
+  "terraform_version": "1.5.0",
+  "serial": 1,
+  "lineage": "test-lineage",
+  "outputs": {},
+  "resources": [
+    {
+      "mode": "managed",
+      "type": "cloudflare_tiered_cache",
+      "name": "smart",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "test-zone-id-smart",
+            "zone_id": "test-zone-id",
+            "cache_type": "smart"
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_tiered_cache",
+      "name": "generic",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "test-zone-id-generic",
+            "zone_id": "test-zone-id",
+            "cache_type": "generic"
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_tiered_cache",
+      "name": "off",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "test-zone-id-off",
+            "zone_id": "test-zone-id",
+            "cache_type": "off"
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_tiered_cache",
+      "name": "variable",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "test-zone-id-variable",
+            "zone_id": "test-zone-id",
+            "cache_type": "off"
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_tiered_cache",
+      "name": "lifecycle",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "test-zone-id-lifecycle",
+            "zone_id": "test-zone-id",
+            "cache_type": "generic"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/integration/v4_to_v5/testdata/tiered_cache/input/tiered_cache.tf
+++ b/integration/v4_to_v5/testdata/tiered_cache/input/tiered_cache.tf
@@ -1,0 +1,43 @@
+variable "cloudflare_account_id" {
+  description = "Cloudflare account ID"
+  type        = string
+}
+
+variable "cloudflare_zone_id" {
+  description = "Cloudflare zone ID"
+  type        = string
+}
+
+variable "cache_type" {
+  type        = string
+  default = "off"
+}
+
+resource "cloudflare_tiered_cache" "smart" {
+  zone_id    = var.cloudflare_zone_id
+  cache_type = "smart"
+}
+
+resource "cloudflare_tiered_cache" "off" {
+  zone_id    = var.cloudflare_zone_id
+  cache_type = "off"
+}
+
+resource "cloudflare_tiered_cache" "generic" {
+  zone_id    = var.cloudflare_zone_id
+  cache_type = "generic"
+}
+
+resource "cloudflare_tiered_cache" "variable" {
+  zone_id    = var.cloudflare_zone_id
+  cache_type = var.cache_type
+}
+
+resource "cloudflare_tiered_cache" "lifecycle" {
+  zone_id    = var.cloudflare_zone_id
+  cache_type = "generic"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}

--- a/integration/v4_to_v5/testdata/tiered_cache/input/tiered_cache_e2e.tf
+++ b/integration/v4_to_v5/testdata/tiered_cache/input/tiered_cache_e2e.tf
@@ -1,0 +1,18 @@
+variable "cloudflare_account_id" {
+  description = "Cloudflare account ID"
+  type        = string
+}
+
+variable "cloudflare_zone_id" {
+  description = "Cloudflare zone ID"
+  type        = string
+}
+
+resource "cloudflare_tiered_cache" "generic_with_lifecycle" {
+  zone_id    = var.cloudflare_zone_id
+  cache_type = "generic"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}

--- a/internal/handlers/state_transform.go
+++ b/internal/handlers/state_transform.go
@@ -138,11 +138,11 @@ func (h *StateTransformHandler) Handle(ctx *transform.Context) (*transform.Conte
 			return true
 		})
 
-		// Check if the migrator stored a dynamic resource type in the context metadata
+		// Check if the migrator stored a dynamic resource type in StateTypeRenames
 		// This handles cases like cloudflare_argo which splits into different types based on instance attributes
-		if ctx.Metadata != nil {
-			metadataKey := fmt.Sprintf("argo_resource_type:%s", resourceName)
-			if dynamicType, ok := ctx.Metadata[metadataKey]; ok {
+		if ctx.StateTypeRenames != nil {
+			stateTypeRenameKey := fmt.Sprintf("%s.%s", resourceType, resourceName)
+			if dynamicType, ok := ctx.StateTypeRenames[stateTypeRenameKey]; ok {
 				if dynamicTypeStr, ok := dynamicType.(string); ok && dynamicTypeStr != "" && dynamicTypeStr != resourceType {
 					resourceTypePath := fmt.Sprintf("resources.%d.type", key.Int())
 					modifiedState, _ = sjson.Set(modifiedState, resourceTypePath, dynamicTypeStr)

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -6,8 +6,8 @@ import (
 	"github.com/cloudflare/tf-migrate/internal/resources/account_member"
 	"github.com/cloudflare/tf-migrate/internal/resources/api_token"
 	"github.com/cloudflare/tf-migrate/internal/resources/argo"
-	"github.com/cloudflare/tf-migrate/internal/resources/custom_pages"
 	"github.com/cloudflare/tf-migrate/internal/resources/bot_management"
+	"github.com/cloudflare/tf-migrate/internal/resources/custom_pages"
 	"github.com/cloudflare/tf-migrate/internal/resources/dns_record"
 	"github.com/cloudflare/tf-migrate/internal/resources/healthcheck"
 	"github.com/cloudflare/tf-migrate/internal/resources/load_balancer_monitor"
@@ -20,6 +20,7 @@ import (
 	"github.com/cloudflare/tf-migrate/internal/resources/r2_bucket"
 	"github.com/cloudflare/tf-migrate/internal/resources/regional_hostname"
 	"github.com/cloudflare/tf-migrate/internal/resources/spectrum_application"
+	"github.com/cloudflare/tf-migrate/internal/resources/tiered_cache"
 	"github.com/cloudflare/tf-migrate/internal/resources/url_normalization_settings"
 	"github.com/cloudflare/tf-migrate/internal/resources/workers_kv"
 	"github.com/cloudflare/tf-migrate/internal/resources/workers_kv_namespace"
@@ -61,6 +62,7 @@ func RegisterAllMigrations() {
 	pages_project.NewV4ToV5Migrator()
 	r2_bucket.NewV4ToV5Migrator()
 	regional_hostname.NewV4ToV5Migrator()
+	tiered_cache.NewV4ToV5Migrator()
 	spectrum_application.NewV4ToV5Migrator()
 	url_normalization_settings.NewV4ToV5Migrator()
 	workers_kv.NewV4ToV5Migrator()

--- a/internal/resources/argo/v4_to_v5.go
+++ b/internal/resources/argo/v4_to_v5.go
@@ -171,13 +171,7 @@ func (m *V4ToV5Migrator) TransformState(ctx *transform.Context, stateJSON gjson.
 	// Set schema_version to 0 for v5
 	result, _ = sjson.Set(result, "schema_version", 0)
 
-	// Store the determined resource type in context metadata for the handler to use
-	// The handler will read this after processing the instance and update the resource-level type
-	metadataKey := fmt.Sprintf("argo_resource_type:%s", resourceName)
-	if ctx.Metadata == nil {
-		ctx.Metadata = make(map[string]interface{})
-	}
-	ctx.Metadata[metadataKey] = targetType
+	transform.SetStateTypeRename(ctx, resourceName, "cloudflare_argo", targetType)
 
 	return result, nil
 }

--- a/internal/resources/tiered_cache/v4_to_v5.go
+++ b/internal/resources/tiered_cache/v4_to_v5.go
@@ -1,0 +1,147 @@
+package tiered_cache
+
+import (
+	"fmt"
+
+	"github.com/cloudflare/tf-migrate/internal"
+	"github.com/cloudflare/tf-migrate/internal/transform"
+	tfhcl "github.com/cloudflare/tf-migrate/internal/transform/hcl"
+	"github.com/cloudflare/tf-migrate/internal/transform/state"
+	"github.com/hashicorp/hcl/v2/hclwrite"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+// V4ToV5Migrator handles the migration of cloudflare_tiered_cache from v4 to v5.
+type V4ToV5Migrator struct{}
+
+// NewV4ToV5Migrator creates a new migrator for cloudflare_tiered_cache v4 to v5.
+func NewV4ToV5Migrator() transform.ResourceTransformer {
+	migrator := &V4ToV5Migrator{}
+	// Register with v4 resource name
+	internal.RegisterMigrator("cloudflare_tiered_cache", "v4", "v5", migrator)
+	return migrator
+}
+
+// GetResourceType returns the v5 resource type this migrator handles.
+func (m *V4ToV5Migrator) GetResourceType() string {
+	return "cloudflare_tiered_cache"
+}
+
+// CanHandle determines if this migrator can handle the given resource type.
+func (m *V4ToV5Migrator) CanHandle(resourceType string) bool {
+	return resourceType == "cloudflare_tiered_cache"
+}
+
+// Preprocess handles string-level transformations before HCL parsing.
+// This transforms cache_type values to prepare for HCL transformation.
+func (m *V4ToV5Migrator) Preprocess(content string) string {
+	return content
+}
+
+// TransformConfig handles configuration file transformations.
+func (m *V4ToV5Migrator) TransformConfig(ctx *transform.Context, block *hclwrite.Block) (*transform.TransformResult, error) {
+	body := block.Body()
+
+	blocks := make([]*hclwrite.Block, 0)
+	removeOriginal := false
+
+	// rename cache_type to value
+	tfhcl.RenameAttribute(body, "cache_type", "value")
+
+	resourceName := tfhcl.GetResourceName(block)
+	value := tfhcl.ExtractStringFromAttribute(body.GetAttribute("value"))
+	if value == "smart" {
+		// cache_type="smart" → value="on"
+		tfhcl.SetAttribute(body, "value", "on")
+		blocks = append(blocks, block)
+	} else if value == "off" {
+		// cache_type="off" → value="off"
+		tfhcl.SetAttribute(body, "value", "off")
+		blocks = append(blocks, block)
+	} else if value == "generic" {
+		newBlock := tfhcl.CreateDerivedBlock(
+			block,
+			"cloudflare_argo_tiered_caching",
+			resourceName,
+			tfhcl.AttributeTransform{
+				Copy:              []string{"zone_id"},
+				Set:               map[string]interface{}{"value": "on"},
+				CopyMetaArguments: true,
+			},
+		)
+
+		movedBlock := tfhcl.CreateMovedBlock(
+			"cloudflare_tiered_cache."+resourceName,
+			"cloudflare_argo_tiered_caching."+resourceName,
+		)
+
+		blocks = append(blocks, newBlock, movedBlock)
+		removeOriginal = true
+	} else {
+		blocks = append(blocks, block)
+	}
+
+	return &transform.TransformResult{
+		Blocks:         blocks,
+		RemoveOriginal: removeOriginal,
+	}, nil
+}
+
+func (m *V4ToV5Migrator) createMovedBlock(fromName, toName, fromType, toType string) *hclwrite.Block {
+	from := fmt.Sprintf("%s.%s", fromType, fromName)
+	to := fmt.Sprintf("%s.%s", toType, toName)
+	return tfhcl.CreateMovedBlock(from, to)
+}
+
+// TransformState handles state file transformations.
+func (m *V4ToV5Migrator) TransformState(ctx *transform.Context, stateJSON gjson.Result, resourcePath, resourceName string) (string, error) {
+	result := stateJSON.String()
+
+	if !stateJSON.Exists() || !stateJSON.Get("attributes").Exists() {
+		return result, nil
+	}
+	attrs := stateJSON.Get("attributes")
+
+	// Check if we have cache_type attribute
+	cacheTypeField := attrs.Get("cache_type")
+	if !cacheTypeField.Exists() {
+		// Already migrated or no cache_type, just set schema version
+		result, _ = sjson.Set(result, "schema_version", 0)
+		return result, nil
+	}
+
+	cacheTypeValue := cacheTypeField.String()
+
+	// Determine target resource type based on cache_type value
+	var targetType string
+
+	// Transform based on cache_type value
+	if cacheTypeValue == "generic" {
+		// Transform to argo_tiered_caching
+		targetType = "cloudflare_argo_tiered_caching"
+		result, _ = sjson.Delete(result, "attributes.cache_type")
+		result, _ = sjson.Set(result, "attributes.value", "on")
+	} else if cacheTypeValue == "smart" {
+		// Keep as tiered_cache, transform smart → on
+		targetType = "cloudflare_tiered_cache"
+		result, _ = sjson.Delete(result, "attributes.cache_type")
+		result, _ = sjson.Set(result, "attributes.value", "on")
+	} else if cacheTypeValue == "off" {
+		// Keep as tiered_cache, cache_type → value (no value change)
+		targetType = "cloudflare_tiered_cache"
+		result, _ = sjson.Delete(result, "attributes.cache_type")
+		result, _ = sjson.Set(result, "attributes.value", "off")
+	} else {
+		// Unknown value (variables, expressions), just rename the field
+		targetType = "cloudflare_tiered_cache"
+		result = state.RenameField(result, "attributes", attrs, "cache_type", "value")
+	}
+
+	// Set schema version to 0
+	result, _ = sjson.Set(result, "schema_version", 0)
+
+	transform.SetStateTypeRename(ctx, resourceName, "cloudflare_tiered_cache", targetType)
+
+	return result, nil
+}

--- a/internal/resources/tiered_cache/v4_to_v5_test.go
+++ b/internal/resources/tiered_cache/v4_to_v5_test.go
@@ -1,0 +1,244 @@
+package tiered_cache
+
+import (
+	"testing"
+
+	"github.com/cloudflare/tf-migrate/internal/testhelpers"
+)
+
+// Config transformation tests
+func TestConfigTransformation(t *testing.T) {
+	migrator := NewV4ToV5Migrator()
+
+	tests := []testhelpers.ConfigTestCase{
+		{
+			Name: "tiered_cache with cache_type=smart",
+			Input: `
+resource "cloudflare_tiered_cache" "example" {
+  zone_id    = "test-zone-id"
+  cache_type = "smart"
+}`,
+			Expected: `
+resource "cloudflare_tiered_cache" "example" {
+  zone_id = "test-zone-id"
+  value   = "on"
+}`,
+		},
+		{
+			Name: "tiered_cache with cache_type=generic creates argo_tiered_caching and moved block",
+			Input: `
+resource "cloudflare_tiered_cache" "example" {
+  zone_id    = "test-zone-id"
+  cache_type = "generic"
+}`,
+			Expected: `
+resource "cloudflare_argo_tiered_caching" "example" {
+  zone_id = "test-zone-id"
+  value   = "on"
+}
+moved {
+  from = cloudflare_tiered_cache.example
+  to   = cloudflare_argo_tiered_caching.example
+}`,
+		},
+		{
+			Name: "tiered_cache with cache_type=off",
+			Input: `
+resource "cloudflare_tiered_cache" "example" {
+  zone_id    = "test-zone-id"
+  cache_type = "off"
+}`,
+			Expected: `
+resource "cloudflare_tiered_cache" "example" {
+  zone_id = "test-zone-id"
+  value   = "off"
+}`,
+		},
+		{
+			Name: "tiered_cache with variable cache_type",
+			Input: `
+resource "cloudflare_tiered_cache" "example" {
+  zone_id    = "test-zone-id"
+  cache_type = var.cache_type_value
+}`,
+			Expected: `
+resource "cloudflare_tiered_cache" "example" {
+  zone_id = "test-zone-id"
+  value   = var.cache_type_value
+}`,
+		},
+		{
+			Name: "multiple tiered_cache resources with mixed types",
+			Input: `
+resource "cloudflare_tiered_cache" "off" {
+  zone_id    = "zone1"
+  cache_type = "off"
+}
+resource "cloudflare_tiered_cache" "smart" {
+  zone_id    = "zone2"
+  cache_type = "smart"
+}
+resource "cloudflare_tiered_cache" "generic" {
+  zone_id    = "zone3"
+  cache_type = "generic"
+}`,
+			Expected: `
+resource "cloudflare_tiered_cache" "off" {
+  zone_id = "zone1"
+  value   = "off"
+}
+resource "cloudflare_tiered_cache" "smart" {
+  zone_id = "zone2"
+  value   = "on"
+}
+resource "cloudflare_argo_tiered_caching" "generic" {
+  zone_id = "zone3"
+  value   = "on"
+}
+moved {
+  from = cloudflare_tiered_cache.generic
+  to   = cloudflare_argo_tiered_caching.generic
+}`,
+		},
+		{
+			Name: "tiered_cache with dynamic cache_type should not generate moved block",
+			Input: `
+resource "cloudflare_tiered_cache" "example" {
+  zone_id    = "test-zone-id"
+  cache_type = var.cache_type
+}`,
+			Expected: `
+resource "cloudflare_tiered_cache" "example" {
+  zone_id = "test-zone-id"
+  value   = var.cache_type
+}`,
+		},
+		{
+			Name: "tiered_cache with cache_type=generic and other attributes",
+			Input: `
+resource "cloudflare_tiered_cache" "example" {
+  zone_id    = cloudflare_zone.example.id
+  cache_type = "generic"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}`,
+			Expected: `
+resource "cloudflare_argo_tiered_caching" "example" {
+  zone_id = cloudflare_zone.example.id
+  value   = "on"
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+moved {
+  from = cloudflare_tiered_cache.example
+  to   = cloudflare_argo_tiered_caching.example
+}`,
+		},
+	}
+
+	testhelpers.RunConfigTransformTests(t, tests, migrator)
+}
+
+// State transformation tests
+func TestStateTransformation(t *testing.T) {
+	migrator := NewV4ToV5Migrator()
+
+	tests := []testhelpers.StateTestCase{
+		{
+			Name: "transforms_tiered_cache_generic_to_argo_tiered_caching",
+			Input: `{
+  "schema_version": 0,
+  "attributes": {
+    "zone_id": "test-zone-id",
+    "cache_type": "generic",
+    "id": "test-id"
+  }
+}`,
+			Expected: `{
+  "schema_version": 0,
+  "attributes": {
+    "zone_id": "test-zone-id",
+    "value": "on",
+    "id": "test-id"
+  }
+}`,
+		},
+		{
+			Name: "transforms_tiered_cache_smart_value",
+			Input: `{
+  "schema_version": 0,
+  "attributes": {
+    "zone_id": "test-zone-id",
+    "cache_type": "smart",
+    "id": "test-id"
+  }
+}`,
+			Expected: `{
+  "schema_version": 0,
+  "attributes": {
+    "zone_id": "test-zone-id",
+    "value": "on",
+    "id": "test-id"
+  }
+}`,
+		},
+		{
+			Name: "transforms_tiered_cache_off_value",
+			Input: `{
+  "schema_version": 0,
+  "attributes": {
+    "zone_id": "test-zone-id",
+    "cache_type": "off",
+    "id": "test-id"
+  }
+}`,
+			Expected: `{
+  "schema_version": 0,
+  "attributes": {
+    "zone_id": "test-zone-id",
+    "value": "off",
+    "id": "test-id"
+  }
+}`,
+		},
+		{
+			Name: "handles_tiered_cache_without_cache_type",
+			Input: `{
+  "schema_version": 0,
+  "attributes": {
+    "zone_id": "test-zone-id",
+    "id": "test-id"
+  }
+}`,
+			Expected: `{
+  "schema_version": 0,
+  "attributes": {
+    "zone_id": "test-zone-id",
+    "id": "test-id"
+  }
+}`,
+		},
+		{
+			Name: "preserves_non_tiered_cache_resources",
+			Input: `{
+  "schema_version": 0,
+  "attributes": {
+    "name": "example.com",
+    "id": "test-id"
+  }
+}`,
+			Expected: `{
+  "schema_version": 0,
+  "attributes": {
+    "name": "example.com",
+    "id": "test-id"
+  }
+}`,
+		},
+	}
+
+	testhelpers.RunStateTransformTests(t, tests, migrator)
+}

--- a/internal/transform/context.go
+++ b/internal/transform/context.go
@@ -1,0 +1,11 @@
+package transform
+
+import "fmt"
+
+func SetStateTypeRename(ctx *Context, resourceName, originalType, targetType string) {
+	stateTypeRenameKey := fmt.Sprintf("%s.%s", originalType, resourceName)
+	if ctx.StateTypeRenames == nil {
+		ctx.StateTypeRenames = make(map[string]interface{})
+	}
+	ctx.StateTypeRenames[stateTypeRenameKey] = targetType
+}

--- a/internal/transform/context_test.go
+++ b/internal/transform/context_test.go
@@ -1,0 +1,91 @@
+package transform
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSetStateTypeRename(t *testing.T) {
+	t.Run("initializes StateTypeRenames map when nil", func(t *testing.T) {
+		ctx := &Context{}
+
+		SetStateTypeRename(ctx, "example", "cloudflare_argo", "cloudflare_argo_smart_routing")
+
+		assert.NotNil(t, ctx.StateTypeRenames)
+		assert.Equal(t, "cloudflare_argo_smart_routing", ctx.StateTypeRenames["cloudflare_argo.example"])
+	})
+
+	t.Run("adds to existing StateTypeRenames map", func(t *testing.T) {
+		ctx := &Context{
+			StateTypeRenames: map[string]interface{}{
+				"existing.key": "existing_value",
+			},
+		}
+
+		SetStateTypeRename(ctx, "example", "cloudflare_argo", "cloudflare_argo_smart_routing")
+
+		assert.Len(t, ctx.StateTypeRenames, 2)
+		assert.Equal(t, "existing_value", ctx.StateTypeRenames["existing.key"])
+		assert.Equal(t, "cloudflare_argo_smart_routing", ctx.StateTypeRenames["cloudflare_argo.example"])
+	})
+
+	t.Run("overwrites existing entry", func(t *testing.T) {
+		ctx := &Context{
+			StateTypeRenames: map[string]interface{}{
+				"cloudflare_argo.example": "cloudflare_argo_smart_routing",
+			},
+		}
+
+		SetStateTypeRename(ctx, "example", "cloudflare_argo", "cloudflare_argo_tiered_caching")
+
+		assert.Len(t, ctx.StateTypeRenames, 1)
+		assert.Equal(t, "cloudflare_argo_tiered_caching", ctx.StateTypeRenames["cloudflare_argo.example"])
+	})
+
+	t.Run("handles multiple different resources", func(t *testing.T) {
+		ctx := &Context{}
+
+		SetStateTypeRename(ctx, "example1", "cloudflare_argo", "cloudflare_argo_smart_routing")
+		SetStateTypeRename(ctx, "example2", "cloudflare_argo", "cloudflare_argo_tiered_caching")
+		SetStateTypeRename(ctx, "generic", "cloudflare_tiered_cache", "cloudflare_argo_tiered_caching")
+
+		assert.Len(t, ctx.StateTypeRenames, 3)
+		assert.Equal(t, "cloudflare_argo_smart_routing", ctx.StateTypeRenames["cloudflare_argo.example1"])
+		assert.Equal(t, "cloudflare_argo_tiered_caching", ctx.StateTypeRenames["cloudflare_argo.example2"])
+		assert.Equal(t, "cloudflare_argo_tiered_caching", ctx.StateTypeRenames["cloudflare_tiered_cache.generic"])
+	})
+
+	t.Run("creates correct key format", func(t *testing.T) {
+		ctx := &Context{}
+
+		SetStateTypeRename(ctx, "my_resource", "cloudflare_example", "cloudflare_new_example")
+
+		_, exists := ctx.StateTypeRenames["cloudflare_example.my_resource"]
+		assert.True(t, exists, "Key should be in format 'originalType.resourceName'")
+	})
+
+	t.Run("handles empty resource name", func(t *testing.T) {
+		ctx := &Context{}
+
+		SetStateTypeRename(ctx, "", "cloudflare_argo", "cloudflare_argo_smart_routing")
+
+		assert.Equal(t, "cloudflare_argo_smart_routing", ctx.StateTypeRenames["cloudflare_argo."])
+	})
+
+	t.Run("handles empty original type", func(t *testing.T) {
+		ctx := &Context{}
+
+		SetStateTypeRename(ctx, "example", "", "cloudflare_argo_smart_routing")
+
+		assert.Equal(t, "cloudflare_argo_smart_routing", ctx.StateTypeRenames[".example"])
+	})
+
+	t.Run("handles empty target type", func(t *testing.T) {
+		ctx := &Context{}
+
+		SetStateTypeRename(ctx, "example", "cloudflare_argo", "")
+
+		assert.Equal(t, "", ctx.StateTypeRenames["cloudflare_argo.example"])
+	})
+}

--- a/internal/transform/transformer.go
+++ b/internal/transform/transformer.go
@@ -9,17 +9,18 @@ import (
 
 // Context carries data through the transformation pipeline
 type Context struct {
-	Content       []byte
-	Filename      string
-	CFGFile       *hclwrite.File
-	CFGFiles      map[string]*hclwrite.File
-	StateJSON     string
-	Diagnostics   hcl.Diagnostics
-	Metadata      map[string]interface{}
-	Resources     []string
-	SourceVersion string             // Source provider version (e.g., "v4")
-	TargetVersion string             // Target provider version (e.g., "v5")
-	APIClient     *cloudflare.Client // Optional: Cloudflare API client for migrations that need to query the API
+	Content          []byte
+	Filename         string
+	CFGFile          *hclwrite.File
+	CFGFiles         map[string]*hclwrite.File
+	StateJSON        string
+	Diagnostics      hcl.Diagnostics
+	Metadata         map[string]interface{}
+	Resources        []string
+	SourceVersion    string             // Source provider version (e.g., "v4")
+	TargetVersion    string             // Target provider version (e.g., "v5")
+	APIClient        *cloudflare.Client // Optional: Cloudflare API client for migrations that need to query the API
+	StateTypeRenames map[string]interface{}
 }
 
 // TransformResult represents the result of a resource transformation


### PR DESCRIPTION
Ports migration of `tiered_cache` from V4->V5. 

A fairly straightforward migration. It changes a `cache_type` attribute to `value`, and then depending on that value it either keeps the resource as `cloudflare_tiered_cache` or transforms it into `cloudflare_argo_tiered_caching`. 

I've also made an update to e2e tests to allow for a `{resource}_e2e.tf" file in the integration test data which if present will be used for e2e tests. 

E2E tests: 
```
  Step 3: Testing v5 configurations                                                         
  Running terraform init in migrated-v4_to_v5/...                                           
  Cleaning v5 .terraform directory for fresh init...                                        
  ✓ Terraform init successful                                                               
  Running terraform plan in v5/...                                                          
  ✓ Terraform plan shows no changes (expected)                                              
  Running terraform apply in v5/...                                                         
  ✓ Terraform apply successful 
```