### PR TITLE
feat(migration): add v4 to v5 migration for zero_trust_access_mtls_hostname_settings

### DIFF
--- a/integration/v4_to_v5/testdata/zero_trust_access_mtls_hostname_settings/expected/terraform.tfstate
+++ b/integration/v4_to_v5/testdata/zero_trust_access_mtls_hostname_settings/expected/terraform.tfstate
@@ -1,0 +1,585 @@
+{
+  "version": 4,
+  "terraform_version": "1.5.0",
+  "serial": 1,
+  "lineage": "test-lineage-zero-trust-access-mtls-hostname-settings",
+  "outputs": {},
+  "resources": [
+    {
+      "mode": "managed",
+      "type": "cloudflare_zero_trust_access_mtls_hostname_settings",
+      "name": "minimal_account",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "f037e56e89293a057740de681ac9abbe",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "settings": [
+              {
+                "hostname": "cftftest-minimal.cf-tf-test.com",
+                "china_network": false,
+                "client_certificate_forwarding": false
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_zero_trust_access_mtls_hostname_settings",
+      "name": "full_account",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "f037e56e89293a057740de681ac9abbe",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "settings": [
+              {
+                "hostname": "cftftest-full.cf-tf-test.com",
+                "china_network": true,
+                "client_certificate_forwarding": true
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_zero_trust_access_mtls_hostname_settings",
+      "name": "multiple_account",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "f037e56e89293a057740de681ac9abbe",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "settings": [
+              {
+                "hostname": "cftftest-api.cf-tf-test.com",
+                "china_network": true,
+                "client_certificate_forwarding": false
+              },
+              {
+                "hostname": "cftftest-web.cf-tf-test.com",
+                "china_network": false,
+                "client_certificate_forwarding": true
+              },
+              {
+                "hostname": "cftftest-admin.cf-tf-test.com",
+                "china_network": false,
+                "client_certificate_forwarding": false
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_zero_trust_access_mtls_hostname_settings",
+      "name": "minimal_zone",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "0da42c8d2132a9ddaf714f9e7c920711",
+            "zone_id": "0da42c8d2132a9ddaf714f9e7c920711",
+            "settings": [
+              {
+                "hostname": "cftftest-zone-minimal.cf-tf-test.com",
+                "china_network": false,
+                "client_certificate_forwarding": false
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_zero_trust_access_mtls_hostname_settings",
+      "name": "multiple_zone",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "0da42c8d2132a9ddaf714f9e7c920711",
+            "zone_id": "0da42c8d2132a9ddaf714f9e7c920711",
+            "settings": [
+              {
+                "hostname": "cftftest-zone-api.cf-tf-test.com",
+                "china_network": true,
+                "client_certificate_forwarding": true
+              },
+              {
+                "hostname": "cftftest-zone-web.cf-tf-test.com",
+                "china_network": false,
+                "client_certificate_forwarding": false
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_zero_trust_access_mtls_hostname_settings",
+      "name": "with_vars",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "f037e56e89293a057740de681ac9abbe",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "settings": [
+              {
+                "hostname": "cftftest-prod.cf-tf-test.com",
+                "china_network": true,
+                "client_certificate_forwarding": false
+              },
+              {
+                "hostname": "cftftest-var-backup.cf-tf-test.com",
+                "china_network": false,
+                "client_certificate_forwarding": false
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_zero_trust_access_mtls_hostname_settings",
+      "name": "from_set",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "index_key": "cftftest-app1.cf-tf-test.com",
+          "schema_version": 0,
+          "attributes": {
+            "id": "f037e56e89293a057740de681ac9abbe",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "settings": [
+              {
+                "hostname": "cftftest-app1.cf-tf-test.com",
+                "china_network": false,
+                "client_certificate_forwarding": true
+              }
+            ]
+          }
+        },
+        {
+          "index_key": "cftftest-app2.cf-tf-test.com",
+          "schema_version": 0,
+          "attributes": {
+            "id": "f037e56e89293a057740de681ac9abbe",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "settings": [
+              {
+                "hostname": "cftftest-app2.cf-tf-test.com",
+                "china_network": false,
+                "client_certificate_forwarding": true
+              }
+            ]
+          }
+        },
+        {
+          "index_key": "cftftest-app3.cf-tf-test.com",
+          "schema_version": 0,
+          "attributes": {
+            "id": "f037e56e89293a057740de681ac9abbe",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "settings": [
+              {
+                "hostname": "cftftest-app3.cf-tf-test.com",
+                "china_network": false,
+                "client_certificate_forwarding": false
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_zero_trust_access_mtls_hostname_settings",
+      "name": "from_map",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "index_key": "development",
+          "schema_version": 0,
+          "attributes": {
+            "id": "f037e56e89293a057740de681ac9abbe",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "settings": [
+              {
+                "hostname": "cftftest-development.cf-tf-test.com",
+                "china_network": false,
+                "client_certificate_forwarding": true
+              }
+            ]
+          }
+        },
+        {
+          "index_key": "production",
+          "schema_version": 0,
+          "attributes": {
+            "id": "f037e56e89293a057740de681ac9abbe",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "settings": [
+              {
+                "hostname": "cftftest-production.cf-tf-test.com",
+                "china_network": true,
+                "client_certificate_forwarding": false
+              }
+            ]
+          }
+        },
+        {
+          "index_key": "staging",
+          "schema_version": 0,
+          "attributes": {
+            "id": "f037e56e89293a057740de681ac9abbe",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "settings": [
+              {
+                "hostname": "cftftest-staging.cf-tf-test.com",
+                "china_network": false,
+                "client_certificate_forwarding": false
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_zero_trust_access_mtls_hostname_settings",
+      "name": "with_count",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "index_key": 0,
+          "schema_version": 0,
+          "attributes": {
+            "id": "f037e56e89293a057740de681ac9abbe",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "settings": [
+              {
+                "hostname": "cftftest-env0.cf-tf-test.com",
+                "china_network": true,
+                "client_certificate_forwarding": true
+              }
+            ]
+          }
+        },
+        {
+          "index_key": 1,
+          "schema_version": 0,
+          "attributes": {
+            "id": "f037e56e89293a057740de681ac9abbe",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "settings": [
+              {
+                "hostname": "cftftest-env1.cf-tf-test.com",
+                "china_network": false,
+                "client_certificate_forwarding": false
+              }
+            ]
+          }
+        },
+        {
+          "index_key": 2,
+          "schema_version": 0,
+          "attributes": {
+            "id": "f037e56e89293a057740de681ac9abbe",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "settings": [
+              {
+                "hostname": "cftftest-env2.cf-tf-test.com",
+                "china_network": false,
+                "client_certificate_forwarding": true
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_zero_trust_access_mtls_hostname_settings",
+      "name": "conditional",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "index_key": 0,
+          "schema_version": 0,
+          "attributes": {
+            "id": "f037e56e89293a057740de681ac9abbe",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "settings": [
+              {
+                "hostname": "cftftest-conditional.cf-tf-test.com",
+                "china_network": true,
+                "client_certificate_forwarding": false
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_zero_trust_access_mtls_hostname_settings",
+      "name": "regional",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "index_key": "ap-southeast",
+          "schema_version": 0,
+          "attributes": {
+            "id": "f037e56e89293a057740de681ac9abbe",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "settings": [
+              {
+                "hostname": "cftftest-ap-southeast.cf-tf-test.com",
+                "china_network": true,
+                "client_certificate_forwarding": false
+              }
+            ]
+          }
+        },
+        {
+          "index_key": "eu-central",
+          "schema_version": 0,
+          "attributes": {
+            "id": "f037e56e89293a057740de681ac9abbe",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "settings": [
+              {
+                "hostname": "cftftest-eu-central.cf-tf-test.com",
+                "china_network": false,
+                "client_certificate_forwarding": true
+              }
+            ]
+          }
+        },
+        {
+          "index_key": "us-east",
+          "schema_version": 0,
+          "attributes": {
+            "id": "f037e56e89293a057740de681ac9abbe",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "settings": [
+              {
+                "hostname": "cftftest-us-east.cf-tf-test.com",
+                "china_network": false,
+                "client_certificate_forwarding": false
+              }
+            ]
+          }
+        },
+        {
+          "index_key": "us-west",
+          "schema_version": 0,
+          "attributes": {
+            "id": "f037e56e89293a057740de681ac9abbe",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "settings": [
+              {
+                "hostname": "cftftest-us-west.cf-tf-test.com",
+                "china_network": false,
+                "client_certificate_forwarding": false
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_zero_trust_access_mtls_hostname_settings",
+      "name": "services",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "f037e56e89293a057740de681ac9abbe",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "settings": [
+              {
+                "hostname": "cftftest-auth.cf-tf-test.com",
+                "china_network": true,
+                "client_certificate_forwarding": true
+              },
+              {
+                "hostname": "cftftest-gateway.cf-tf-test.com",
+                "china_network": false,
+                "client_certificate_forwarding": false
+              },
+              {
+                "hostname": "cftftest-proxy.cf-tf-test.com",
+                "china_network": false,
+                "client_certificate_forwarding": true
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_zero_trust_access_mtls_hostname_settings",
+      "name": "with_lifecycle",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "f037e56e89293a057740de681ac9abbe",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "settings": [
+              {
+                "hostname": "cftftest-lifecycle.cf-tf-test.com",
+                "china_network": true,
+                "client_certificate_forwarding": true
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_zero_trust_access_mtls_hostname_settings",
+      "name": "with_functions",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "f037e56e89293a057740de681ac9abbe",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "settings": [
+              {
+                "hostname": "cftftest-alpha-beta-gamma.cf-tf-test.com",
+                "china_network": true,
+                "client_certificate_forwarding": true
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_zero_trust_access_mtls_hostname_settings",
+      "name": "primary",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "f037e56e89293a057740de681ac9abbe",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "settings": [
+              {
+                "hostname": "cftftest-primary.cf-tf-test.com",
+                "china_network": true,
+                "client_certificate_forwarding": true
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_zero_trust_access_mtls_hostname_settings",
+      "name": "secondary",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "f037e56e89293a057740de681ac9abbe",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "settings": [
+              {
+                "hostname": "cftftest-secondary.cf-tf-test.com",
+                "china_network": false,
+                "client_certificate_forwarding": false
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_zero_trust_access_mtls_hostname_settings",
+      "name": "mixed_china",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "f037e56e89293a057740de681ac9abbe",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "settings": [
+              {
+                "hostname": "cftftest-china-enabled.cf-tf-test.com",
+                "china_network": true,
+                "client_certificate_forwarding": false
+              },
+              {
+                "hostname": "cftftest-china-disabled.cf-tf-test.com",
+                "china_network": false,
+                "client_certificate_forwarding": false
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_zero_trust_access_mtls_hostname_settings",
+      "name": "mixed_forwarding",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "f037e56e89293a057740de681ac9abbe",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "settings": [
+              {
+                "hostname": "cftftest-forward-enabled.cf-tf-test.com",
+                "china_network": false,
+                "client_certificate_forwarding": true
+              },
+              {
+                "hostname": "cftftest-forward-disabled.cf-tf-test.com",
+                "china_network": false,
+                "client_certificate_forwarding": false
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/integration/v4_to_v5/testdata/zero_trust_access_mtls_hostname_settings/expected/zero_trust_access_mtls_hostname_settings.tf
+++ b/integration/v4_to_v5/testdata/zero_trust_access_mtls_hostname_settings/expected/zero_trust_access_mtls_hostname_settings.tf
@@ -1,0 +1,375 @@
+variable "cloudflare_account_id" {
+  description = "Cloudflare account ID"
+  type        = string
+}
+
+variable "cloudflare_zone_id" {
+  description = "Cloudflare zone ID"
+  type        = string
+}
+
+# ========================================
+# Basic Resources (Account-level)
+# ========================================
+
+# Minimal configuration - single settings block
+resource "cloudflare_zero_trust_access_mtls_hostname_settings" "minimal_account" {
+  account_id = var.cloudflare_account_id
+
+  settings = [{
+    hostname                      = "cftftest-minimal.cf-tf-test.com"
+    china_network                 = false
+    client_certificate_forwarding = false
+  }]
+}
+
+# With all fields populated
+resource "cloudflare_zero_trust_access_mtls_hostname_settings" "full_account" {
+  account_id = var.cloudflare_account_id
+
+  settings = [{
+    hostname                      = "cftftest-full.cf-tf-test.com"
+    china_network                 = true
+    client_certificate_forwarding = true
+  }]
+}
+
+# Multiple settings blocks
+resource "cloudflare_zero_trust_access_mtls_hostname_settings" "multiple_account" {
+  account_id = var.cloudflare_account_id
+
+
+
+  settings = [{
+    hostname                      = "cftftest-api.cf-tf-test.com"
+    china_network                 = true
+    client_certificate_forwarding = false
+    }, {
+    hostname                      = "cftftest-web.cf-tf-test.com"
+    china_network                 = false
+    client_certificate_forwarding = true
+    }, {
+    hostname                      = "cftftest-admin.cf-tf-test.com"
+    china_network                 = false
+    client_certificate_forwarding = false
+  }]
+}
+
+# ========================================
+# Basic Resources (Zone-level)
+# ========================================
+
+# Minimal configuration - zone-level
+resource "cloudflare_zero_trust_access_mtls_hostname_settings" "minimal_zone" {
+  zone_id = var.cloudflare_zone_id
+
+  settings = [{
+    hostname                      = "cftftest-zone-minimal.cf-tf-test.com"
+    china_network                 = false
+    client_certificate_forwarding = false
+  }]
+}
+
+# Zone-level with multiple settings
+resource "cloudflare_zero_trust_access_mtls_hostname_settings" "multiple_zone" {
+  zone_id = var.cloudflare_zone_id
+
+
+  settings = [{
+    hostname                      = "cftftest-zone-api.cf-tf-test.com"
+    china_network                 = true
+    client_certificate_forwarding = true
+    }, {
+    hostname                      = "cftftest-zone-web.cf-tf-test.com"
+    china_network                 = false
+    client_certificate_forwarding = false
+  }]
+}
+
+# ========================================
+# Advanced Terraform Patterns
+# ========================================
+
+# Pattern 1: Variable references
+variable "hostname_prefix" {
+  type    = string
+  default = "cftftest-var"
+}
+
+variable "enable_china_network" {
+  type    = bool
+  default = true
+}
+
+variable "enable_cert_forwarding" {
+  type    = bool
+  default = false
+}
+
+# Pattern 2: Local values with expressions
+locals {
+  name_prefix       = "cftftest"
+  base_domain       = "cf-tf-test.com"
+  environment       = "prod"
+  full_hostname     = "${local.name_prefix}-${local.environment}.${local.base_domain}"
+  common_account_id = var.cloudflare_account_id
+}
+
+# Using variables and locals
+resource "cloudflare_zero_trust_access_mtls_hostname_settings" "with_vars" {
+  account_id = local.common_account_id
+
+
+  settings = [{
+    hostname                      = local.full_hostname
+    china_network                 = var.enable_china_network
+    client_certificate_forwarding = var.enable_cert_forwarding
+    }, {
+    hostname                      = "${var.hostname_prefix}-backup.${local.base_domain}"
+    china_network                 = !var.enable_china_network
+    client_certificate_forwarding = !var.enable_cert_forwarding
+  }]
+}
+
+# Pattern 3: for_each with set
+variable "hostnames_set" {
+  type    = set(string)
+  default = ["cftftest-app1.cf-tf-test.com", "cftftest-app2.cf-tf-test.com", "cftftest-app3.cf-tf-test.com"]
+}
+
+resource "cloudflare_zero_trust_access_mtls_hostname_settings" "from_set" {
+  for_each = var.hostnames_set
+
+  account_id = var.cloudflare_account_id
+
+  settings = [{
+    hostname                      = each.value
+    china_network                 = false
+    client_certificate_forwarding = true
+  }]
+}
+
+# Pattern 4: for_each with map
+variable "mtls_configs" {
+  type = map(object({
+    hostname        = string
+    china_network   = bool
+    cert_forwarding = bool
+  }))
+  default = {
+    "production" = {
+      hostname        = "cftftest-production.cf-tf-test.com"
+      china_network   = true
+      cert_forwarding = true
+    }
+    "staging" = {
+      hostname        = "cftftest-staging.cf-tf-test.com"
+      china_network   = false
+      cert_forwarding = false
+    }
+    "development" = {
+      hostname        = "cftftest-development.cf-tf-test.com"
+      china_network   = false
+      cert_forwarding = true
+    }
+  }
+}
+
+resource "cloudflare_zero_trust_access_mtls_hostname_settings" "from_map" {
+  for_each = var.mtls_configs
+
+  account_id = var.cloudflare_account_id
+
+  settings = [{
+    hostname                      = each.value.hostname
+    china_network                 = each.value.china_network
+    client_certificate_forwarding = each.value.cert_forwarding
+  }]
+}
+
+# Pattern 5: count
+variable "environment_count" {
+  type    = number
+  default = 3
+}
+
+resource "cloudflare_zero_trust_access_mtls_hostname_settings" "with_count" {
+  count = var.environment_count
+
+  account_id = var.cloudflare_account_id
+
+  settings = [{
+    hostname                      = "cftftest-env${count.index}.cf-tf-test.com"
+    china_network                 = count.index == 0 ? true : false
+    client_certificate_forwarding = count.index % 2 == 0
+  }]
+}
+
+# Pattern 6: Conditional creation
+variable "create_optional_settings" {
+  type    = bool
+  default = true
+}
+
+resource "cloudflare_zero_trust_access_mtls_hostname_settings" "conditional" {
+  count = var.create_optional_settings ? 1 : 0
+
+  account_id = var.cloudflare_account_id
+
+  settings = [{
+    hostname                      = "cftftest-conditional.cf-tf-test.com"
+    china_network                 = true
+    client_certificate_forwarding = false
+  }]
+}
+
+# Pattern 7: Complex locals with for expression
+locals {
+  regional_hostnames = ["us-east", "us-west", "eu-central", "ap-southeast"]
+  regional_configs = {
+    for region in local.regional_hostnames :
+    region => {
+      hostname = "${local.name_prefix}-${region}.${local.base_domain}"
+      china    = region == "ap-southeast"
+      forward  = contains(["us-east", "eu-central"], region)
+    }
+  }
+}
+
+resource "cloudflare_zero_trust_access_mtls_hostname_settings" "regional" {
+  for_each = local.regional_configs
+
+  account_id = var.cloudflare_account_id
+
+  settings = [{
+    hostname                      = each.value.hostname
+    china_network                 = each.value.china
+    client_certificate_forwarding = each.value.forward
+  }]
+}
+
+# Pattern 8: Multiple settings with dynamic content
+variable "services" {
+  type = list(object({
+    name            = string
+    china_enabled   = bool
+    forward_enabled = bool
+  }))
+  default = [
+    {
+      name            = "auth"
+      china_enabled   = true
+      forward_enabled = true
+    },
+    {
+      name            = "gateway"
+      china_enabled   = false
+      forward_enabled = false
+    },
+    {
+      name            = "proxy"
+      china_enabled   = false
+      forward_enabled = true
+    }
+  ]
+}
+
+resource "cloudflare_zero_trust_access_mtls_hostname_settings" "services" {
+  account_id = var.cloudflare_account_id
+
+  dynamic "settings" {
+    for_each = var.services
+    content {
+      hostname                      = "${local.name_prefix}-${settings.value.name}.${local.base_domain}"
+      china_network                 = settings.value.china_enabled
+      client_certificate_forwarding = settings.value.forward_enabled
+    }
+  }
+}
+
+# Pattern 9: Lifecycle meta-arguments
+resource "cloudflare_zero_trust_access_mtls_hostname_settings" "with_lifecycle" {
+  account_id = var.cloudflare_account_id
+
+
+  lifecycle {
+    create_before_destroy = true
+    ignore_changes        = [settings]
+  }
+  settings = [{
+    hostname                      = "cftftest-lifecycle.cf-tf-test.com"
+    china_network                 = true
+    client_certificate_forwarding = true
+  }]
+}
+
+# Pattern 10: Using Terraform functions
+variable "domain_list" {
+  type    = list(string)
+  default = ["alpha", "beta", "gamma"]
+}
+
+resource "cloudflare_zero_trust_access_mtls_hostname_settings" "with_functions" {
+  account_id = var.cloudflare_account_id
+
+  settings = [{
+    hostname                      = "${local.name_prefix}-${join("-", var.domain_list)}.${local.base_domain}"
+    china_network                 = length(var.domain_list) > 2
+    client_certificate_forwarding = contains(var.domain_list, "alpha")
+  }]
+}
+
+# Pattern 11: Depends_on meta-argument
+resource "cloudflare_zero_trust_access_mtls_hostname_settings" "primary" {
+  account_id = var.cloudflare_account_id
+
+  settings = [{
+    hostname                      = "cftftest-primary.cf-tf-test.com"
+    china_network                 = true
+    client_certificate_forwarding = true
+  }]
+}
+
+resource "cloudflare_zero_trust_access_mtls_hostname_settings" "secondary" {
+  account_id = var.cloudflare_account_id
+
+
+  depends_on = [cloudflare_zero_trust_access_mtls_hostname_settings.primary]
+  settings = [{
+    hostname                      = "cftftest-secondary.cf-tf-test.com"
+    china_network                 = false
+    client_certificate_forwarding = false
+  }]
+}
+
+# Pattern 12: Mixed china_network values in multiple settings
+resource "cloudflare_zero_trust_access_mtls_hostname_settings" "mixed_china" {
+  account_id = var.cloudflare_account_id
+
+
+  settings = [{
+    hostname                      = "cftftest-china-enabled.cf-tf-test.com"
+    china_network                 = true
+    client_certificate_forwarding = false
+    }, {
+    hostname                      = "cftftest-china-disabled.cf-tf-test.com"
+    china_network                 = false
+    client_certificate_forwarding = false
+  }]
+}
+
+# Pattern 13: Mixed cert forwarding values
+resource "cloudflare_zero_trust_access_mtls_hostname_settings" "mixed_forwarding" {
+  account_id = var.cloudflare_account_id
+
+
+  settings = [{
+    hostname                      = "cftftest-forward-enabled.cf-tf-test.com"
+    china_network                 = false
+    client_certificate_forwarding = true
+    }, {
+    hostname                      = "cftftest-forward-disabled.cf-tf-test.com"
+    china_network                 = false
+    client_certificate_forwarding = false
+  }]
+}

--- a/integration/v4_to_v5/testdata/zero_trust_access_mtls_hostname_settings/expected/zero_trust_access_mtls_hostname_settings_e2e.tf
+++ b/integration/v4_to_v5/testdata/zero_trust_access_mtls_hostname_settings/expected/zero_trust_access_mtls_hostname_settings_e2e.tf
@@ -1,0 +1,31 @@
+variable "cloudflare_account_id" {
+  description = "Cloudflare account ID"
+  type        = string
+}
+
+variable "cloudflare_zone_id" {
+  description = "Cloudflare zone ID"
+  type        = string
+}
+
+# Minimal E2E test - account-level with single settings block
+resource "cloudflare_zero_trust_access_mtls_hostname_settings" "e2e_account" {
+  account_id = var.cloudflare_account_id
+
+  settings = [{
+    hostname                      = "tamas.terraform.cfapi.net"
+    china_network                 = false
+    client_certificate_forwarding = false
+  }]
+}
+
+# Minimal E2E test - zone-level with single settings block
+resource "cloudflare_zero_trust_access_mtls_hostname_settings" "e2e_zone" {
+  zone_id = var.cloudflare_zone_id
+
+  settings = [{
+    hostname                      = "tamas.terraform.cfapi.net"
+    china_network                 = false
+    client_certificate_forwarding = true
+  }]
+}

--- a/integration/v4_to_v5/testdata/zero_trust_access_mtls_hostname_settings/expected/zero_trust_access_mtls_hostname_settings_e2e.tf
+++ b/integration/v4_to_v5/testdata/zero_trust_access_mtls_hostname_settings/expected/zero_trust_access_mtls_hostname_settings_e2e.tf
@@ -13,7 +13,7 @@ resource "cloudflare_zero_trust_access_mtls_hostname_settings" "e2e_account" {
   account_id = var.cloudflare_account_id
 
   settings = [{
-    hostname                      = "tamas.terraform.cfapi.net"
+    hostname                      = "e2e.terraform.cfapi.net"
     china_network                 = false
     client_certificate_forwarding = false
   }]
@@ -24,7 +24,7 @@ resource "cloudflare_zero_trust_access_mtls_hostname_settings" "e2e_zone" {
   zone_id = var.cloudflare_zone_id
 
   settings = [{
-    hostname                      = "tamas.terraform.cfapi.net"
+    hostname                      = "e2e.terraform.cfapi.net"
     china_network                 = false
     client_certificate_forwarding = true
   }]

--- a/integration/v4_to_v5/testdata/zero_trust_access_mtls_hostname_settings/input/terraform.tfstate
+++ b/integration/v4_to_v5/testdata/zero_trust_access_mtls_hostname_settings/input/terraform.tfstate
@@ -1,0 +1,538 @@
+{
+  "version": 4,
+  "terraform_version": "1.5.0",
+  "serial": 1,
+  "lineage": "test-lineage-zero-trust-access-mtls-hostname-settings",
+  "outputs": {},
+  "resources": [
+    {
+      "mode": "managed",
+      "type": "cloudflare_zero_trust_access_mtls_hostname_settings",
+      "name": "minimal_account",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "attributes": {
+            "id": "f037e56e89293a057740de681ac9abbe",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "settings": [
+              {
+                "hostname": "cftftest-minimal.cf-tf-test.com",
+                "china_network": false,
+                "client_certificate_forwarding": false
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_zero_trust_access_mtls_hostname_settings",
+      "name": "full_account",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "attributes": {
+            "id": "f037e56e89293a057740de681ac9abbe",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "settings": [
+              {
+                "hostname": "cftftest-full.cf-tf-test.com",
+                "china_network": true,
+                "client_certificate_forwarding": true
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_zero_trust_access_mtls_hostname_settings",
+      "name": "multiple_account",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "attributes": {
+            "id": "f037e56e89293a057740de681ac9abbe",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "settings": [
+              {
+                "hostname": "cftftest-api.cf-tf-test.com",
+                "china_network": true,
+                "client_certificate_forwarding": false
+              },
+              {
+                "hostname": "cftftest-web.cf-tf-test.com",
+                "china_network": false,
+                "client_certificate_forwarding": true
+              },
+              {
+                "hostname": "cftftest-admin.cf-tf-test.com",
+                "china_network": false,
+                "client_certificate_forwarding": false
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_zero_trust_access_mtls_hostname_settings",
+      "name": "minimal_zone",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "attributes": {
+            "id": "0da42c8d2132a9ddaf714f9e7c920711",
+            "zone_id": "0da42c8d2132a9ddaf714f9e7c920711",
+            "settings": [
+              {
+                "hostname": "cftftest-zone-minimal.cf-tf-test.com"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_zero_trust_access_mtls_hostname_settings",
+      "name": "multiple_zone",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "attributes": {
+            "id": "0da42c8d2132a9ddaf714f9e7c920711",
+            "zone_id": "0da42c8d2132a9ddaf714f9e7c920711",
+            "settings": [
+              {
+                "hostname": "cftftest-zone-api.cf-tf-test.com",
+                "china_network": true,
+                "client_certificate_forwarding": true
+              },
+              {
+                "hostname": "cftftest-zone-web.cf-tf-test.com"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_zero_trust_access_mtls_hostname_settings",
+      "name": "with_vars",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "attributes": {
+            "id": "f037e56e89293a057740de681ac9abbe",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "settings": [
+              {
+                "hostname": "cftftest-prod.cf-tf-test.com",
+                "china_network": true,
+                "client_certificate_forwarding": false
+              },
+              {
+                "hostname": "cftftest-var-backup.cf-tf-test.com"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_zero_trust_access_mtls_hostname_settings",
+      "name": "from_set",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "index_key": "cftftest-app1.cf-tf-test.com",
+          "attributes": {
+            "id": "f037e56e89293a057740de681ac9abbe",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "settings": [
+              {
+                "hostname": "cftftest-app1.cf-tf-test.com",
+                "china_network": false,
+                "client_certificate_forwarding": true
+              }
+            ]
+          }
+        },
+        {
+          "index_key": "cftftest-app2.cf-tf-test.com",
+          "attributes": {
+            "id": "f037e56e89293a057740de681ac9abbe",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "settings": [
+              {
+                "hostname": "cftftest-app2.cf-tf-test.com",
+                "china_network": false,
+                "client_certificate_forwarding": true
+              }
+            ]
+          }
+        },
+        {
+          "index_key": "cftftest-app3.cf-tf-test.com",
+          "attributes": {
+            "id": "f037e56e89293a057740de681ac9abbe",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "settings": [
+              {
+                "hostname": "cftftest-app3.cf-tf-test.com"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_zero_trust_access_mtls_hostname_settings",
+      "name": "from_map",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "index_key": "development",
+          "attributes": {
+            "id": "f037e56e89293a057740de681ac9abbe",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "settings": [
+              {
+                "hostname": "cftftest-development.cf-tf-test.com",
+                "china_network": false,
+                "client_certificate_forwarding": true
+              }
+            ]
+          }
+        },
+        {
+          "index_key": "production",
+          "attributes": {
+            "id": "f037e56e89293a057740de681ac9abbe",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "settings": [
+              {
+                "hostname": "cftftest-production.cf-tf-test.com",
+                "china_network": true
+              }
+            ]
+          }
+        },
+        {
+          "index_key": "staging",
+          "attributes": {
+            "id": "f037e56e89293a057740de681ac9abbe",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "settings": [
+              {
+                "hostname": "cftftest-staging.cf-tf-test.com",
+                "china_network": false,
+                "client_certificate_forwarding": false
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_zero_trust_access_mtls_hostname_settings",
+      "name": "with_count",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "index_key": 0,
+          "attributes": {
+            "id": "f037e56e89293a057740de681ac9abbe",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "settings": [
+              {
+                "hostname": "cftftest-env0.cf-tf-test.com",
+                "china_network": true,
+                "client_certificate_forwarding": true
+              }
+            ]
+          }
+        },
+        {
+          "index_key": 1,
+          "attributes": {
+            "id": "f037e56e89293a057740de681ac9abbe",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "settings": [
+              {
+                "hostname": "cftftest-env1.cf-tf-test.com"
+              }
+            ]
+          }
+        },
+        {
+          "index_key": 2,
+          "attributes": {
+            "id": "f037e56e89293a057740de681ac9abbe",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "settings": [
+              {
+                "hostname": "cftftest-env2.cf-tf-test.com",
+                "china_network": false,
+                "client_certificate_forwarding": true
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_zero_trust_access_mtls_hostname_settings",
+      "name": "conditional",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "index_key": 0,
+          "attributes": {
+            "id": "f037e56e89293a057740de681ac9abbe",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "settings": [
+              {
+                "hostname": "cftftest-conditional.cf-tf-test.com",
+                "china_network": true,
+                "client_certificate_forwarding": false
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_zero_trust_access_mtls_hostname_settings",
+      "name": "regional",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "index_key": "ap-southeast",
+          "attributes": {
+            "id": "f037e56e89293a057740de681ac9abbe",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "settings": [
+              {
+                "hostname": "cftftest-ap-southeast.cf-tf-test.com",
+                "china_network": true
+              }
+            ]
+          }
+        },
+        {
+          "index_key": "eu-central",
+          "attributes": {
+            "id": "f037e56e89293a057740de681ac9abbe",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "settings": [
+              {
+                "hostname": "cftftest-eu-central.cf-tf-test.com",
+                "china_network": false,
+                "client_certificate_forwarding": true
+              }
+            ]
+          }
+        },
+        {
+          "index_key": "us-east",
+          "attributes": {
+            "id": "f037e56e89293a057740de681ac9abbe",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "settings": [
+              {
+                "hostname": "cftftest-us-east.cf-tf-test.com"
+              }
+            ]
+          }
+        },
+        {
+          "index_key": "us-west",
+          "attributes": {
+            "id": "f037e56e89293a057740de681ac9abbe",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "settings": [
+              {
+                "hostname": "cftftest-us-west.cf-tf-test.com",
+                "china_network": false,
+                "client_certificate_forwarding": false
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_zero_trust_access_mtls_hostname_settings",
+      "name": "services",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "attributes": {
+            "id": "f037e56e89293a057740de681ac9abbe",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "settings": [
+              {
+                "hostname": "cftftest-auth.cf-tf-test.com",
+                "china_network": true,
+                "client_certificate_forwarding": true
+              },
+              {
+                "hostname": "cftftest-gateway.cf-tf-test.com"
+              },
+              {
+                "hostname": "cftftest-proxy.cf-tf-test.com",
+                "china_network": false,
+                "client_certificate_forwarding": true
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_zero_trust_access_mtls_hostname_settings",
+      "name": "with_lifecycle",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "attributes": {
+            "id": "f037e56e89293a057740de681ac9abbe",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "settings": [
+              {
+                "hostname": "cftftest-lifecycle.cf-tf-test.com",
+                "china_network": true,
+                "client_certificate_forwarding": true
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_zero_trust_access_mtls_hostname_settings",
+      "name": "with_functions",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "attributes": {
+            "id": "f037e56e89293a057740de681ac9abbe",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "settings": [
+              {
+                "hostname": "cftftest-alpha-beta-gamma.cf-tf-test.com",
+                "china_network": true,
+                "client_certificate_forwarding": true
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_zero_trust_access_mtls_hostname_settings",
+      "name": "primary",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "attributes": {
+            "id": "f037e56e89293a057740de681ac9abbe",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "settings": [
+              {
+                "hostname": "cftftest-primary.cf-tf-test.com",
+                "china_network": true,
+                "client_certificate_forwarding": true
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_zero_trust_access_mtls_hostname_settings",
+      "name": "secondary",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "attributes": {
+            "id": "f037e56e89293a057740de681ac9abbe",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "settings": [
+              {
+                "hostname": "cftftest-secondary.cf-tf-test.com"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_zero_trust_access_mtls_hostname_settings",
+      "name": "mixed_china",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "attributes": {
+            "id": "f037e56e89293a057740de681ac9abbe",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "settings": [
+              {
+                "hostname": "cftftest-china-enabled.cf-tf-test.com",
+                "china_network": true,
+                "client_certificate_forwarding": false
+              },
+              {
+                "hostname": "cftftest-china-disabled.cf-tf-test.com",
+                "client_certificate_forwarding": false
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_zero_trust_access_mtls_hostname_settings",
+      "name": "mixed_forwarding",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "attributes": {
+            "id": "f037e56e89293a057740de681ac9abbe",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "settings": [
+              {
+                "hostname": "cftftest-forward-enabled.cf-tf-test.com",
+                "china_network": false,
+                "client_certificate_forwarding": true
+              },
+              {
+                "hostname": "cftftest-forward-disabled.cf-tf-test.com",
+                "china_network": false
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/integration/v4_to_v5/testdata/zero_trust_access_mtls_hostname_settings/input/zero_trust_access_mtls_hostname_settings.tf
+++ b/integration/v4_to_v5/testdata/zero_trust_access_mtls_hostname_settings/input/zero_trust_access_mtls_hostname_settings.tf
@@ -1,0 +1,381 @@
+variable "cloudflare_account_id" {
+  description = "Cloudflare account ID"
+  type        = string
+}
+
+variable "cloudflare_zone_id" {
+  description = "Cloudflare zone ID"
+  type        = string
+}
+
+# ========================================
+# Basic Resources (Account-level)
+# ========================================
+
+# Minimal configuration - single settings block
+resource "cloudflare_zero_trust_access_mtls_hostname_settings" "minimal_account" {
+  account_id = var.cloudflare_account_id
+
+  settings {
+    hostname                      = "cftftest-minimal.cf-tf-test.com"
+    china_network                 = false
+    client_certificate_forwarding = false
+  }
+}
+
+# With all fields populated
+resource "cloudflare_zero_trust_access_mtls_hostname_settings" "full_account" {
+  account_id = var.cloudflare_account_id
+
+  settings {
+    hostname                      = "cftftest-full.cf-tf-test.com"
+    china_network                 = true
+    client_certificate_forwarding = true
+  }
+}
+
+# Multiple settings blocks
+resource "cloudflare_zero_trust_access_mtls_hostname_settings" "multiple_account" {
+  account_id = var.cloudflare_account_id
+
+  settings {
+    hostname                      = "cftftest-api.cf-tf-test.com"
+    china_network                 = true
+    client_certificate_forwarding = false
+  }
+
+  settings {
+    hostname                      = "cftftest-web.cf-tf-test.com"
+    china_network                 = false
+    client_certificate_forwarding = true
+  }
+
+  settings {
+    hostname                      = "cftftest-admin.cf-tf-test.com"
+    china_network                 = false
+    client_certificate_forwarding = false
+  }
+}
+
+# ========================================
+# Basic Resources (Zone-level)
+# ========================================
+
+# Minimal configuration - zone-level
+resource "cloudflare_zero_trust_access_mtls_hostname_settings" "minimal_zone" {
+  zone_id = var.cloudflare_zone_id
+
+  settings {
+    hostname                      = "cftftest-zone-minimal.cf-tf-test.com"
+    china_network                 = false
+    client_certificate_forwarding = false
+  }
+}
+
+# Zone-level with multiple settings
+resource "cloudflare_zero_trust_access_mtls_hostname_settings" "multiple_zone" {
+  zone_id = var.cloudflare_zone_id
+
+  settings {
+    hostname                      = "cftftest-zone-api.cf-tf-test.com"
+    china_network                 = true
+    client_certificate_forwarding = true
+  }
+
+  settings {
+    hostname                      = "cftftest-zone-web.cf-tf-test.com"
+    china_network                 = false
+    client_certificate_forwarding = false
+  }
+}
+
+# ========================================
+# Advanced Terraform Patterns
+# ========================================
+
+# Pattern 1: Variable references
+variable "hostname_prefix" {
+  type    = string
+  default = "cftftest-var"
+}
+
+variable "enable_china_network" {
+  type    = bool
+  default = true
+}
+
+variable "enable_cert_forwarding" {
+  type    = bool
+  default = false
+}
+
+# Pattern 2: Local values with expressions
+locals {
+  name_prefix       = "cftftest"
+  base_domain       = "cf-tf-test.com"
+  environment       = "prod"
+  full_hostname     = "${local.name_prefix}-${local.environment}.${local.base_domain}"
+  common_account_id = var.cloudflare_account_id
+}
+
+# Using variables and locals
+resource "cloudflare_zero_trust_access_mtls_hostname_settings" "with_vars" {
+  account_id = local.common_account_id
+
+  settings {
+    hostname                      = local.full_hostname
+    china_network                 = var.enable_china_network
+    client_certificate_forwarding = var.enable_cert_forwarding
+  }
+
+  settings {
+    hostname                      = "${var.hostname_prefix}-backup.${local.base_domain}"
+    china_network                 = !var.enable_china_network
+    client_certificate_forwarding = !var.enable_cert_forwarding
+  }
+}
+
+# Pattern 3: for_each with set
+variable "hostnames_set" {
+  type    = set(string)
+  default = ["cftftest-app1.cf-tf-test.com", "cftftest-app2.cf-tf-test.com", "cftftest-app3.cf-tf-test.com"]
+}
+
+resource "cloudflare_zero_trust_access_mtls_hostname_settings" "from_set" {
+  for_each = var.hostnames_set
+
+  account_id = var.cloudflare_account_id
+
+  settings {
+    hostname                      = each.value
+    china_network                 = false
+    client_certificate_forwarding = true
+  }
+}
+
+# Pattern 4: for_each with map
+variable "mtls_configs" {
+  type = map(object({
+    hostname              = string
+    china_network         = bool
+    cert_forwarding       = bool
+  }))
+  default = {
+    "production" = {
+      hostname        = "cftftest-production.cf-tf-test.com"
+      china_network   = true
+      cert_forwarding = true
+    }
+    "staging" = {
+      hostname        = "cftftest-staging.cf-tf-test.com"
+      china_network   = false
+      cert_forwarding = false
+    }
+    "development" = {
+      hostname        = "cftftest-development.cf-tf-test.com"
+      china_network   = false
+      cert_forwarding = true
+    }
+  }
+}
+
+resource "cloudflare_zero_trust_access_mtls_hostname_settings" "from_map" {
+  for_each = var.mtls_configs
+
+  account_id = var.cloudflare_account_id
+
+  settings {
+    hostname                      = each.value.hostname
+    china_network                 = each.value.china_network
+    client_certificate_forwarding = each.value.cert_forwarding
+  }
+}
+
+# Pattern 5: count
+variable "environment_count" {
+  type    = number
+  default = 3
+}
+
+resource "cloudflare_zero_trust_access_mtls_hostname_settings" "with_count" {
+  count = var.environment_count
+
+  account_id = var.cloudflare_account_id
+
+  settings {
+    hostname                      = "cftftest-env${count.index}.cf-tf-test.com"
+    china_network                 = count.index == 0 ? true : false
+    client_certificate_forwarding = count.index % 2 == 0
+  }
+}
+
+# Pattern 6: Conditional creation
+variable "create_optional_settings" {
+  type    = bool
+  default = true
+}
+
+resource "cloudflare_zero_trust_access_mtls_hostname_settings" "conditional" {
+  count = var.create_optional_settings ? 1 : 0
+
+  account_id = var.cloudflare_account_id
+
+  settings {
+    hostname                      = "cftftest-conditional.cf-tf-test.com"
+    china_network                 = true
+    client_certificate_forwarding = false
+  }
+}
+
+# Pattern 7: Complex locals with for expression
+locals {
+  regional_hostnames = ["us-east", "us-west", "eu-central", "ap-southeast"]
+  regional_configs = {
+    for region in local.regional_hostnames :
+    region => {
+      hostname = "${local.name_prefix}-${region}.${local.base_domain}"
+      china    = region == "ap-southeast"
+      forward  = contains(["us-east", "eu-central"], region)
+    }
+  }
+}
+
+resource "cloudflare_zero_trust_access_mtls_hostname_settings" "regional" {
+  for_each = local.regional_configs
+
+  account_id = var.cloudflare_account_id
+
+  settings {
+    hostname                      = each.value.hostname
+    china_network                 = each.value.china
+    client_certificate_forwarding = each.value.forward
+  }
+}
+
+# Pattern 8: Multiple settings with dynamic content
+variable "services" {
+  type = list(object({
+    name            = string
+    china_enabled   = bool
+    forward_enabled = bool
+  }))
+  default = [
+    {
+      name            = "auth"
+      china_enabled   = true
+      forward_enabled = true
+    },
+    {
+      name            = "gateway"
+      china_enabled   = false
+      forward_enabled = false
+    },
+    {
+      name            = "proxy"
+      china_enabled   = false
+      forward_enabled = true
+    }
+  ]
+}
+
+resource "cloudflare_zero_trust_access_mtls_hostname_settings" "services" {
+  account_id = var.cloudflare_account_id
+
+  dynamic "settings" {
+    for_each = var.services
+    content {
+      hostname                      = "${local.name_prefix}-${settings.value.name}.${local.base_domain}"
+      china_network                 = settings.value.china_enabled
+      client_certificate_forwarding = settings.value.forward_enabled
+    }
+  }
+}
+
+# Pattern 9: Lifecycle meta-arguments
+resource "cloudflare_zero_trust_access_mtls_hostname_settings" "with_lifecycle" {
+  account_id = var.cloudflare_account_id
+
+  settings {
+    hostname                      = "cftftest-lifecycle.cf-tf-test.com"
+    china_network                 = true
+    client_certificate_forwarding = true
+  }
+
+  lifecycle {
+    create_before_destroy = true
+    ignore_changes        = [settings]
+  }
+}
+
+# Pattern 10: Using Terraform functions
+variable "domain_list" {
+  type    = list(string)
+  default = ["alpha", "beta", "gamma"]
+}
+
+resource "cloudflare_zero_trust_access_mtls_hostname_settings" "with_functions" {
+  account_id = var.cloudflare_account_id
+
+  settings {
+    hostname                      = "${local.name_prefix}-${join("-", var.domain_list)}.${local.base_domain}"
+    china_network                 = length(var.domain_list) > 2
+    client_certificate_forwarding = contains(var.domain_list, "alpha")
+  }
+}
+
+# Pattern 11: Depends_on meta-argument
+resource "cloudflare_zero_trust_access_mtls_hostname_settings" "primary" {
+  account_id = var.cloudflare_account_id
+
+  settings {
+    hostname                      = "cftftest-primary.cf-tf-test.com"
+    china_network                 = true
+    client_certificate_forwarding = true
+  }
+}
+
+resource "cloudflare_zero_trust_access_mtls_hostname_settings" "secondary" {
+  account_id = var.cloudflare_account_id
+
+  settings {
+    hostname                      = "cftftest-secondary.cf-tf-test.com"
+    china_network                 = false
+    client_certificate_forwarding = false
+  }
+
+  depends_on = [cloudflare_zero_trust_access_mtls_hostname_settings.primary]
+}
+
+# Pattern 12: Mixed china_network values in multiple settings
+resource "cloudflare_zero_trust_access_mtls_hostname_settings" "mixed_china" {
+  account_id = var.cloudflare_account_id
+
+  settings {
+    hostname                      = "cftftest-china-enabled.cf-tf-test.com"
+    china_network                 = true
+    client_certificate_forwarding = false
+  }
+
+  settings {
+    hostname                      = "cftftest-china-disabled.cf-tf-test.com"
+    china_network                 = false
+    client_certificate_forwarding = false
+  }
+}
+
+# Pattern 13: Mixed cert forwarding values
+resource "cloudflare_zero_trust_access_mtls_hostname_settings" "mixed_forwarding" {
+  account_id = var.cloudflare_account_id
+
+  settings {
+    hostname                      = "cftftest-forward-enabled.cf-tf-test.com"
+    china_network                 = false
+    client_certificate_forwarding = true
+  }
+
+  settings {
+    hostname                      = "cftftest-forward-disabled.cf-tf-test.com"
+    china_network                 = false
+    client_certificate_forwarding = false
+  }
+}

--- a/integration/v4_to_v5/testdata/zero_trust_access_mtls_hostname_settings/input/zero_trust_access_mtls_hostname_settings_e2e.tf
+++ b/integration/v4_to_v5/testdata/zero_trust_access_mtls_hostname_settings/input/zero_trust_access_mtls_hostname_settings_e2e.tf
@@ -1,0 +1,31 @@
+variable "cloudflare_account_id" {
+  description = "Cloudflare account ID"
+  type        = string
+}
+
+variable "cloudflare_zone_id" {
+  description = "Cloudflare zone ID"
+  type        = string
+}
+
+# Minimal E2E test - account-level with single settings block
+resource "cloudflare_zero_trust_access_mtls_hostname_settings" "e2e_account" {
+  account_id = var.cloudflare_account_id
+
+  settings {
+    hostname                      = "tamas.terraform.cfapi.net"
+    china_network                 = false
+    client_certificate_forwarding = false
+  }
+}
+
+# Minimal E2E test - zone-level with single settings block
+resource "cloudflare_zero_trust_access_mtls_hostname_settings" "e2e_zone" {
+  zone_id = var.cloudflare_zone_id
+
+  settings {
+    hostname                      = "tamas.terraform.cfapi.net"
+    china_network                 = false
+    client_certificate_forwarding = true
+  }
+}

--- a/integration/v4_to_v5/testdata/zero_trust_access_mtls_hostname_settings/input/zero_trust_access_mtls_hostname_settings_e2e.tf
+++ b/integration/v4_to_v5/testdata/zero_trust_access_mtls_hostname_settings/input/zero_trust_access_mtls_hostname_settings_e2e.tf
@@ -13,7 +13,7 @@ resource "cloudflare_zero_trust_access_mtls_hostname_settings" "e2e_account" {
   account_id = var.cloudflare_account_id
 
   settings {
-    hostname                      = "tamas.terraform.cfapi.net"
+    hostname                      = "e2e.terraform.cfapi.net"
     china_network                 = false
     client_certificate_forwarding = false
   }
@@ -24,7 +24,7 @@ resource "cloudflare_zero_trust_access_mtls_hostname_settings" "e2e_zone" {
   zone_id = var.cloudflare_zone_id
 
   settings {
-    hostname                      = "tamas.terraform.cfapi.net"
+    hostname                      = "e2e.terraform.cfapi.net"
     china_network                 = false
     client_certificate_forwarding = true
   }

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cloudflare/tf-migrate/internal/resources/workers_kv"
 	"github.com/cloudflare/tf-migrate/internal/resources/workers_kv_namespace"
 	"github.com/cloudflare/tf-migrate/internal/resources/zero_trust_access_identity_provider"
+	"github.com/cloudflare/tf-migrate/internal/resources/zero_trust_access_mtls_hostname_settings"
 	"github.com/cloudflare/tf-migrate/internal/resources/zero_trust_access_service_token"
 	"github.com/cloudflare/tf-migrate/internal/resources/zero_trust_device_posture_rule"
 	"github.com/cloudflare/tf-migrate/internal/resources/zero_trust_dlp_custom_profile"
@@ -69,6 +70,7 @@ func RegisterAllMigrations() {
 	workers_kv.NewV4ToV5Migrator()
 	workers_kv_namespace.NewV4ToV5Migrator()
 	zero_trust_access_identity_provider.NewV4ToV5Migrator()
+	zero_trust_access_mtls_hostname_settings.NewV4ToV5Migrator()
 	zero_trust_access_service_token.NewV4ToV5Migrator()
 	zero_trust_dlp_custom_profile.NewV4ToV5Migrator()
 	zero_trust_gateway_policy.NewV4ToV5Migrator()

--- a/internal/resources/zero_trust_access_mtls_hostname_settings/v4_to_v5.go
+++ b/internal/resources/zero_trust_access_mtls_hostname_settings/v4_to_v5.go
@@ -1,0 +1,85 @@
+package zero_trust_access_mtls_hostname_settings
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/hcl/v2/hclwrite"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+
+	"github.com/cloudflare/tf-migrate/internal"
+	"github.com/cloudflare/tf-migrate/internal/transform"
+	tfhcl "github.com/cloudflare/tf-migrate/internal/transform/hcl"
+)
+
+type V4ToV5Migrator struct {
+}
+
+func NewV4ToV5Migrator() transform.ResourceTransformer {
+	migrator := &V4ToV5Migrator{}
+	// Register the resource name (same in v4 and v5)
+	internal.RegisterMigrator("cloudflare_zero_trust_access_mtls_hostname_settings", "v4", "v5", migrator)
+	return migrator
+}
+
+func (m *V4ToV5Migrator) GetResourceType() string {
+	// Return the resource name (same in v4 and v5)
+	return "cloudflare_zero_trust_access_mtls_hostname_settings"
+}
+
+func (m *V4ToV5Migrator) CanHandle(resourceType string) bool {
+	// Check for the resource name
+	return resourceType == "cloudflare_zero_trust_access_mtls_hostname_settings"
+}
+
+func (m *V4ToV5Migrator) Preprocess(content string) string {
+	// No preprocessing needed - ConvertBlocksToArrayAttribute handles block to attribute conversion
+	return content
+}
+
+func (m *V4ToV5Migrator) TransformConfig(ctx *transform.Context, block *hclwrite.Block) (*transform.TransformResult, error) {
+	body := block.Body()
+
+	// Convert settings blocks to array attribute
+	// v4: settings { hostname = "..." } (ListNestedBlock - multiple blocks)
+	// v5: settings = [{ hostname = "..." }] (ListNestedAttribute - array of objects)
+	// emptyIfNone: false - settings is required and must have at least 1 item
+	tfhcl.ConvertBlocksToArrayAttribute(body, "settings", false)
+
+	return &transform.TransformResult{
+		Blocks:         []*hclwrite.Block{block},
+		RemoveOriginal: false,
+	}, nil
+}
+
+func (m *V4ToV5Migrator) TransformState(ctx *transform.Context, stateJSON gjson.Result, resourcePath string, resourceName string) (string, error) {
+	result := stateJSON.String()
+
+	// Get the attributes
+	attrs := stateJSON.Get("attributes")
+	if !attrs.Exists() {
+		return result, nil
+	}
+
+	// Handle settings array - add defaults for Optional→Required fields
+	// In v4: china_network and client_certificate_forwarding were Optional
+	// In v5: both became Required
+	if settings := attrs.Get("settings"); settings.Exists() && settings.IsArray() {
+		settingsArray := settings.Array()
+		for i, setting := range settingsArray {
+			// Add china_network default if missing
+			if !setting.Get("china_network").Exists() {
+				result, _ = sjson.Set(result, fmt.Sprintf("attributes.settings.%d.china_network", i), false)
+			}
+			// Add client_certificate_forwarding default if missing
+			if !setting.Get("client_certificate_forwarding").Exists() {
+				result, _ = sjson.Set(result, fmt.Sprintf("attributes.settings.%d.client_certificate_forwarding", i), false)
+			}
+		}
+	}
+
+	// Set schema_version to 0 for v5
+	result, _ = sjson.Set(result, "schema_version", 0)
+
+	return result, nil
+}

--- a/internal/resources/zero_trust_access_mtls_hostname_settings/v4_to_v5_test.go
+++ b/internal/resources/zero_trust_access_mtls_hostname_settings/v4_to_v5_test.go
@@ -1,0 +1,181 @@
+package zero_trust_access_mtls_hostname_settings
+
+import (
+	"testing"
+
+	"github.com/cloudflare/tf-migrate/internal/testhelpers"
+)
+
+func TestV4ToV5Transformation(t *testing.T) {
+	migrator := NewV4ToV5Migrator()
+
+	t.Run("ConfigTransformation", func(t *testing.T) {
+		tests := []testhelpers.ConfigTestCase{
+			{
+				Name: "basic resource with single settings block",
+				Input: `resource "cloudflare_zero_trust_access_mtls_hostname_settings" "example" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+
+  settings {
+    hostname                      = "example.com"
+    china_network                 = true
+    client_certificate_forwarding = false
+  }
+}`,
+				Expected: `resource "cloudflare_zero_trust_access_mtls_hostname_settings" "example" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+
+  settings = [{
+    hostname                      = "example.com"
+    china_network                 = true
+    client_certificate_forwarding = false
+  }]
+}`,
+			},
+			{
+				Name: "multiple settings blocks",
+				Input: `resource "cloudflare_zero_trust_access_mtls_hostname_settings" "example" {
+  zone_id = "0da42c8d2132a9ddaf714f9e7c920711"
+
+  settings {
+    hostname                      = "example.com"
+    china_network                 = true
+    client_certificate_forwarding = false
+  }
+
+  settings {
+    hostname                      = "api.example.com"
+    china_network                 = false
+    client_certificate_forwarding = true
+  }
+}`,
+				Expected: `resource "cloudflare_zero_trust_access_mtls_hostname_settings" "example" {
+  zone_id = "0da42c8d2132a9ddaf714f9e7c920711"
+
+  settings = [{
+    hostname                      = "example.com"
+    china_network                 = true
+    client_certificate_forwarding = false
+    }, {
+    hostname                      = "api.example.com"
+    china_network                 = false
+    client_certificate_forwarding = true
+  }]
+}`,
+			},
+		}
+
+		testhelpers.RunConfigTransformTests(t, tests, migrator)
+	})
+
+	t.Run("StateTransformation", func(t *testing.T) {
+		tests := []testhelpers.StateTestCase{
+			{
+				Name: "basic state with all fields",
+				Input: `{
+  "type": "cloudflare_zero_trust_access_mtls_hostname_settings",
+  "name": "example",
+  "attributes": {
+    "account_id": "f037e56e89293a057740de681ac9abbe",
+    "settings": [
+      {
+        "hostname": "example.com",
+        "china_network": true,
+        "client_certificate_forwarding": false
+      }
+    ]
+  }
+}`,
+				Expected: `{
+  "type": "cloudflare_zero_trust_access_mtls_hostname_settings",
+  "name": "example",
+  "attributes": {
+    "account_id": "f037e56e89293a057740de681ac9abbe",
+    "settings": [
+      {
+        "hostname": "example.com",
+        "china_network": true,
+        "client_certificate_forwarding": false
+      }
+    ]
+  },
+  "schema_version": 0
+}`,
+			},
+			{
+				Name: "state with missing optional fields (v4) - should add defaults",
+				Input: `{
+  "type": "cloudflare_zero_trust_access_mtls_hostname_settings",
+  "name": "example",
+  "attributes": {
+    "zone_id": "0da42c8d2132a9ddaf714f9e7c920711",
+    "settings": [
+      {
+        "hostname": "example.com"
+      }
+    ]
+  }
+}`,
+				Expected: `{
+  "type": "cloudflare_zero_trust_access_mtls_hostname_settings",
+  "name": "example",
+  "attributes": {
+    "zone_id": "0da42c8d2132a9ddaf714f9e7c920711",
+    "settings": [
+      {
+        "hostname": "example.com",
+        "china_network": false,
+        "client_certificate_forwarding": false
+      }
+    ]
+  },
+  "schema_version": 0
+}`,
+			},
+			{
+				Name: "multiple settings items",
+				Input: `{
+  "type": "cloudflare_zero_trust_access_mtls_hostname_settings",
+  "name": "example",
+  "attributes": {
+    "account_id": "f037e56e89293a057740de681ac9abbe",
+    "settings": [
+      {
+        "hostname": "example.com",
+        "china_network": true,
+        "client_certificate_forwarding": false
+      },
+      {
+        "hostname": "api.example.com",
+        "china_network": false,
+        "client_certificate_forwarding": true
+      }
+    ]
+  }
+}`,
+				Expected: `{
+  "type": "cloudflare_zero_trust_access_mtls_hostname_settings",
+  "name": "example",
+  "attributes": {
+    "account_id": "f037e56e89293a057740de681ac9abbe",
+    "settings": [
+      {
+        "hostname": "example.com",
+        "china_network": true,
+        "client_certificate_forwarding": false
+      },
+      {
+        "hostname": "api.example.com",
+        "china_network": false,
+        "client_certificate_forwarding": true
+      }
+    ]
+  },
+  "schema_version": 0
+}`,
+			},
+		}
+
+		testhelpers.RunStateTransformTests(t, tests, migrator)
+	})
+}


### PR DESCRIPTION
Implements migration from provider v4 to v5, converting
      ListNestedBlock to
      ListNestedAttribute syntax (settings { } �<86><92> settings = [{ }]).

      - Add migration implementation and unit tests (7 tests passing)
      - Add integration tests (27 resource instances, all patterns covered)
      - Add minimal E2E test files with real domain (2 resources)
      - Register migration in registry.go
      - Provider tests, sweepers, and documentation already exist