### PR TITLE
feat (workers_script): add v4 to v5 migration support

### DIFF
--- a/integration/v4_to_v5/integration_test.go
+++ b/integration/v4_to_v5/integration_test.go
@@ -23,6 +23,7 @@ import (
 	_ "github.com/cloudflare/tf-migrate/internal/resources/url_normalization_settings"
 	_ "github.com/cloudflare/tf-migrate/internal/resources/workers_kv"
 	_ "github.com/cloudflare/tf-migrate/internal/resources/workers_kv_namespace"
+	_ "github.com/cloudflare/tf-migrate/internal/resources/workers_script"
 	_ "github.com/cloudflare/tf-migrate/internal/resources/zero_trust_access_service_token"
 	_ "github.com/cloudflare/tf-migrate/internal/resources/zero_trust_access_identity_provider"
 	_ "github.com/cloudflare/tf-migrate/internal/resources/zero_trust_dlp_custom_profile"

--- a/integration/v4_to_v5/testdata/workers_script/expected/terraform.tfstate
+++ b/integration/v4_to_v5/testdata/workers_script/expected/terraform.tfstate
@@ -100,7 +100,7 @@
             "account_id": "f037e56e89293a057740de681ac9abbe",
             "script_name": "cftftest-module-false-worker",
             "content": "addEventListener('fetch', event => { event.respondWith(new Response('Hello World')); });",
-            "body_part": "false"
+            "body_part": "worker.js"
           }
         }
       ]
@@ -162,7 +162,7 @@
             "account_id": "f037e56e89293a057740de681ac9abbe",
             "script_name": "cftftest-comprehensive-worker",
             "content": "addEventListener('fetch', event => { event.respondWith(new Response('Hello World')); });",
-            "body_part": "false",
+            "body_part": "worker.js",
             "bindings": [
               {
                 "type": "plain_text",

--- a/integration/v4_to_v5/testdata/workers_script/expected/terraform.tfstate
+++ b/integration/v4_to_v5/testdata/workers_script/expected/terraform.tfstate
@@ -1,0 +1,215 @@
+{
+  "version": 4,
+  "terraform_version": "1.5.0",
+  "serial": 1,
+  "lineage": "test-lineage",
+  "outputs": {},
+  "resources": [
+    {
+      "mode": "managed",
+      "type": "cloudflare_workers_script",
+      "name": "plain_text",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 1,
+          "attributes": {
+            "id": "cftftest-plain-text-worker",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "script_name": "cftftest-plain-text-worker",
+            "content": "addEventListener('fetch', event => { event.respondWith(new Response('Hello World')); });",
+            "bindings": [
+              {
+                "type": "plain_text",
+                "name": "MY_VAR",
+                "text": "my-value"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_workers_script",
+      "name": "queue",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 1,
+          "attributes": {
+            "id": "cftftest-queue-worker",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "script_name": "cftftest-queue-worker",
+            "content": "addEventListener('fetch', event => { event.respondWith(new Response('Hello World')); });",
+            "bindings": [
+              {
+                "type": "queue",
+                "name": "MY_QUEUE",
+                "queue_name": "cftftest-queue"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_workers_script",
+      "name": "multiple_bindings",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 1,
+          "attributes": {
+            "id": "cftftest-multiple-bindings-worker",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "script_name": "cftftest-multiple-bindings-worker",
+            "content": "addEventListener('fetch', event => { event.respondWith(new Response('Hello World')); });",
+            "bindings": [
+              {
+                "type": "plain_text",
+                "name": "VAR_ONE",
+                "text": "value-one"
+              },
+              {
+                "type": "secret_text",
+                "name": "SECRET_ONE",
+                "text": "secret-value-one"
+              },
+              {
+                "type": "kv_namespace",
+                "name": "KV_ONE",
+                "namespace_id": "kv-namespace-id-123"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_workers_script",
+      "name": "module_false",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 1,
+          "attributes": {
+            "id": "cftftest-module-false-worker",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "script_name": "cftftest-module-false-worker",
+            "content": "addEventListener('fetch', event => { event.respondWith(new Response('Hello World')); });",
+            "body_part": "false"
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_workers_script",
+      "name": "placement",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 1,
+          "attributes": {
+            "id": "cftftest-placement-worker",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "script_name": "cftftest-placement-worker",
+            "content": "addEventListener('fetch', event => { event.respondWith(new Response('Hello World')); });",
+            "placement": {
+              "mode": "smart"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_workers_script",
+      "name": "tags",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 1,
+          "attributes": {
+            "id": "cftftest-tags-worker",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "script_name": "cftftest-tags-worker",
+            "content": "addEventListener('fetch', event => { event.respondWith(new Response('Hello World')); });",
+            "bindings": [
+              {
+                "type": "plain_text",
+                "name": "VAR",
+                "text": "value"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_workers_script",
+      "name": "comprehensive",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 1,
+          "attributes": {
+            "id": "cftftest-comprehensive-worker",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "script_name": "cftftest-comprehensive-worker",
+            "content": "addEventListener('fetch', event => { event.respondWith(new Response('Hello World')); });",
+            "body_part": "false",
+            "bindings": [
+              {
+                "type": "plain_text",
+                "name": "PLAIN_VAR",
+                "text": "plain-value"
+              },
+              {
+                "type": "secret_text",
+                "name": "SECRET_VAR",
+                "text": "secret-value"
+              },
+              {
+                "type": "kv_namespace",
+                "name": "KV_NS",
+                "namespace_id": "kv-namespace-id-789"
+              }
+            ],
+            "placement": {
+              "mode": "smart"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_workers_script",
+      "name": "singular_name",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 1,
+          "attributes": {
+            "id": "cftftest-singular-resource",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "script_name": "cftftest-singular-resource",
+            "content": "addEventListener('fetch', event => { event.respondWith(new Response('Hello World')); });",
+            "bindings": [
+              {
+                "type": "plain_text",
+                "name": "SINGULAR",
+                "text": "true"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/integration/v4_to_v5/testdata/workers_script/expected/workers_script.tf
+++ b/integration/v4_to_v5/testdata/workers_script/expected/workers_script.tf
@@ -1,0 +1,585 @@
+variable "cloudflare_account_id" {
+  description = "Cloudflare account ID"
+  type        = string
+}
+
+variable "cloudflare_zone_id" {
+  description = "Cloudflare zone ID"
+  type        = string
+}
+
+# ========================================
+# Dependencies - KV Namespaces
+# ========================================
+
+resource "cloudflare_workers_kv_namespace" "test_kv" {
+  account_id = var.cloudflare_account_id
+  title      = "cftftest-kv-namespace"
+}
+
+resource "cloudflare_workers_kv_namespace" "test_kv_multiple" {
+  count      = 2
+  account_id = var.cloudflare_account_id
+  title      = "cftftest-kv-${count.index}"
+}
+
+# ========================================
+# Dependencies - D1 Databases
+# ========================================
+# TODO: Uncomment when d1_database v4→v5 migration is created
+# D1 bindings also require ES module format which adds complexity
+
+# resource "cloudflare_d1_database" "test_d1" {
+#   account_id = var.cloudflare_account_id
+#   name       = "cftftest-d1-database"
+# }
+
+# ========================================
+# Dependencies - Queues
+# ========================================
+# TODO: Uncomment when queue v4→v5 migration is created
+# The v4 schema uses 'name', v5 uses 'queue_name'
+# Need to create: internal/resources/queue/v4_to_v5.go
+
+# resource "cloudflare_queue" "test_queue" {
+#   account_id = var.cloudflare_account_id
+#   name       = "cftftest-queue"
+# }
+
+# ========================================
+# Dependencies - R2 Buckets
+# ========================================
+
+resource "cloudflare_r2_bucket" "test_r2" {
+  account_id = var.cloudflare_account_id
+  name       = "cftftest-r2-bucket"
+}
+
+# ========================================
+# Local Values
+# ========================================
+
+locals {
+  worker_prefix  = "cftftest"
+  common_content = "addEventListener('fetch', event => { event.respondWith(new Response('Hello World')); });"
+  script_names   = ["worker-1", "worker-2", "worker-3"]
+
+  # Complex expression
+  full_worker_name = "${local.worker_prefix}-main"
+}
+
+# ========================================
+# Variables for Testing
+# ========================================
+
+variable "worker_content" {
+  type    = string
+  default = "addEventListener('fetch', event => { event.respondWith(new Response('Test')); });"
+}
+
+variable "enable_analytics" {
+  type    = bool
+  default = true
+}
+
+# ========================================
+# Pattern 1: Simple worker with plain_text_binding
+# ========================================
+
+resource "cloudflare_workers_script" "plain_text" {
+  account_id = var.cloudflare_account_id
+  content    = local.common_content
+
+  script_name = "cftftest-plain-text-worker"
+  bindings = [
+    {
+      type = "plain_text"
+      name = "MY_VAR"
+      text = "my-value"
+    }
+  ]
+}
+
+# ========================================
+# Pattern 2: Worker with secret_text_binding
+# ========================================
+
+resource "cloudflare_workers_script" "secret_text" {
+  account_id = var.cloudflare_account_id
+  content    = local.common_content
+
+  script_name = "cftftest-secret-text-worker"
+  bindings = [
+    {
+      type = "secret_text"
+      name = "API_KEY"
+      text = "secret-api-key-value"
+    }
+  ]
+}
+
+# ========================================
+# Pattern 3: Worker with kv_namespace_binding
+# ========================================
+
+resource "cloudflare_workers_script" "kv_namespace" {
+  account_id = var.cloudflare_account_id
+  content    = local.common_content
+
+  script_name = "cftftest-kv-worker"
+  bindings = [
+    {
+      type         = "kv_namespace"
+      name         = "MY_KV"
+      namespace_id = cloudflare_workers_kv_namespace.test_kv.id
+    }
+  ]
+}
+
+# ========================================
+# Pattern 5: Worker with r2_bucket_binding
+# ========================================
+
+resource "cloudflare_workers_script" "r2_bucket" {
+  account_id = var.cloudflare_account_id
+  content    = local.common_content
+
+  script_name = "cftftest-r2-worker"
+  bindings = [
+    {
+      type        = "r2_bucket"
+      name        = "MY_BUCKET"
+      bucket_name = cloudflare_r2_bucket.test_r2.name
+    }
+  ]
+}
+
+# ========================================
+# Pattern 7: Worker with analytics_engine_binding
+# ========================================
+
+resource "cloudflare_workers_script" "analytics_engine" {
+  account_id = var.cloudflare_account_id
+  content    = local.common_content
+
+  script_name = "cftftest-analytics-worker"
+  bindings = [
+    {
+      type    = "analytics_engine"
+      name    = "MY_ANALYTICS"
+      dataset = "analytics_dataset"
+    }
+  ]
+}
+
+# ========================================
+# Pattern 8: Worker with queue_binding (binding → name, queue → queue_name)
+# ========================================
+# TODO: Uncomment when queue v4→v5 migration is created
+
+# resource "cloudflare_workers_script" "queue" {
+#   account_id = var.cloudflare_account_id
+#   name       = "cftftest-queue-worker"
+#   content    = local.common_content
+#
+#   queue_binding {
+#     binding = "MY_QUEUE"
+#     queue   = cloudflare_queue.test_queue.name
+#   }
+# }
+
+# ========================================
+# Pattern 9: Worker with multiple bindings (order preservation test)
+# ========================================
+
+resource "cloudflare_workers_script" "multiple_bindings" {
+  account_id = var.cloudflare_account_id
+  content    = local.common_content
+
+
+
+  script_name = "cftftest-multiple-bindings-worker"
+  bindings = [
+    {
+      type = "plain_text"
+      name = "VAR_ONE"
+      text = "value-one"
+      }, {
+      type = "secret_text"
+      name = "SECRET_ONE"
+      text = "secret-value-one"
+      }, {
+      type         = "kv_namespace"
+      name         = "KV_ONE"
+      namespace_id = cloudflare_workers_kv_namespace.test_kv.id
+    }
+  ]
+}
+
+# ========================================
+# Pattern 10: Worker with module = false (becomes body_part)
+# ========================================
+
+resource "cloudflare_workers_script" "module_false" {
+  account_id  = var.cloudflare_account_id
+  content     = local.common_content
+  script_name = "cftftest-module-false-worker"
+  body_part   = "worker.js"
+}
+
+# ========================================
+# Pattern 15: Worker with placement block (becomes object)
+# ========================================
+
+resource "cloudflare_workers_script" "placement" {
+  account_id = var.cloudflare_account_id
+  content    = local.common_content
+
+  script_name = "cftftest-placement-worker"
+  placement = {
+    mode = "smart"
+  }
+}
+
+# ========================================
+# Pattern 16: Worker with tags (should be removed)
+# ========================================
+
+resource "cloudflare_workers_script" "tags" {
+  account_id = var.cloudflare_account_id
+  content    = local.common_content
+
+  script_name = "cftftest-tags-worker"
+  bindings = [
+    {
+      type = "plain_text"
+      name = "VAR"
+      text = "value"
+    }
+  ]
+}
+
+# ========================================
+# Pattern 17: Comprehensive worker with all transformations
+# ========================================
+
+resource "cloudflare_workers_script" "comprehensive" {
+  account_id = var.cloudflare_account_id
+  content    = local.common_content
+
+
+
+
+  script_name = "cftftest-comprehensive-worker"
+  bindings = [
+    {
+      type = "plain_text"
+      name = "PLAIN_VAR"
+      text = "plain-value"
+      }, {
+      type = "secret_text"
+      name = "SECRET_VAR"
+      text = "secret-value"
+      }, {
+      type         = "kv_namespace"
+      name         = "KV_NS"
+      namespace_id = cloudflare_workers_kv_namespace.test_kv.id
+    }
+  ]
+  body_part = "worker.js"
+  placement = {
+    mode = "smart"
+  }
+}
+
+# ========================================
+# Pattern 18: for_each with map
+# ========================================
+
+variable "worker_configs" {
+  type = map(object({
+    content   = string
+    var_value = string
+  }))
+  default = {
+    "worker-a" = {
+      content   = "addEventListener('fetch', e => { e.respondWith(new Response('A')); });"
+      var_value = "value-a"
+    }
+    "worker-b" = {
+      content   = "addEventListener('fetch', e => { e.respondWith(new Response('B')); });"
+      var_value = "value-b"
+    }
+    "worker-c" = {
+      content   = "addEventListener('fetch', e => { e.respondWith(new Response('C')); });"
+      var_value = "value-c"
+    }
+  }
+}
+
+resource "cloudflare_workers_script" "for_each_map" {
+  for_each = var.worker_configs
+
+  account_id = var.cloudflare_account_id
+  content    = each.value.content
+
+  script_name = "cftftest-${each.key}"
+  bindings = [
+    {
+      type = "plain_text"
+      name = "CONFIG_VAR"
+      text = each.value.var_value
+    }
+  ]
+}
+
+# ========================================
+# Pattern 19: for_each with set
+# ========================================
+
+variable "simple_workers" {
+  type    = set(string)
+  default = ["simple-1", "simple-2", "simple-3"]
+}
+
+resource "cloudflare_workers_script" "for_each_set" {
+  for_each = var.simple_workers
+
+  account_id = var.cloudflare_account_id
+  content    = "addEventListener('fetch', e => { e.respondWith(new Response('${each.value}')); });"
+
+  script_name = "cftftest-${each.value}"
+  bindings = [
+    {
+      type = "plain_text"
+      name = "WORKER_NAME"
+      text = each.value
+    }
+  ]
+}
+
+# ========================================
+# Pattern 20: Count-based resources
+# ========================================
+
+variable "replica_count" {
+  type    = number
+  default = 3
+}
+
+resource "cloudflare_workers_script" "count_based" {
+  count = var.replica_count
+
+  account_id = var.cloudflare_account_id
+  content    = local.common_content
+
+
+  script_name = "cftftest-replica-${count.index}"
+  bindings = [
+    {
+      type = "plain_text"
+      name = "REPLICA_ID"
+      text = tostring(count.index)
+      }, {
+      type         = "kv_namespace"
+      name         = "KV"
+      namespace_id = cloudflare_workers_kv_namespace.test_kv_multiple[count.index % 2].id
+    }
+  ]
+}
+
+# ========================================
+# Pattern 21: Conditional resource creation
+# ========================================
+
+resource "cloudflare_workers_script" "conditional" {
+  count = var.enable_analytics ? 1 : 0
+
+  account_id = var.cloudflare_account_id
+  content    = local.common_content
+
+  script_name = "cftftest-conditional-worker"
+  bindings = [
+    {
+      type    = "analytics_engine"
+      name    = "ANALYTICS"
+      dataset = "conditional_dataset"
+    }
+  ]
+}
+
+# ========================================
+# Pattern 22: Resource with lifecycle meta-arguments
+# ========================================
+
+resource "cloudflare_workers_script" "lifecycle" {
+  account_id = var.cloudflare_account_id
+  content    = local.common_content
+
+
+  lifecycle {
+    prevent_destroy       = false
+    create_before_destroy = true
+  }
+  script_name = "cftftest-lifecycle-worker"
+  bindings = [
+    {
+      type = "plain_text"
+      name = "LIFECYCLE_VAR"
+      text = "protected"
+    }
+  ]
+}
+
+# ========================================
+# Pattern 23: Using terraform expressions in bindings
+# ========================================
+
+resource "cloudflare_workers_script" "conditional_binding" {
+  account_id = var.cloudflare_account_id
+  content    = var.enable_analytics ? local.common_content : var.worker_content
+
+
+  script_name = "cftftest-conditional-binding-worker"
+  bindings = [
+    {
+      type = "plain_text"
+      name = "ENABLED"
+      text = var.enable_analytics ? "true" : "false"
+      }, {
+      type         = "kv_namespace"
+      name         = "KV"
+      namespace_id = cloudflare_workers_kv_namespace.test_kv.id
+    }
+  ]
+}
+
+# ========================================
+# Pattern 24: Cross-resource references with dependencies
+# ========================================
+
+resource "cloudflare_workers_script" "dependent" {
+  account_id = var.cloudflare_account_id
+  content    = local.common_content
+
+
+
+
+  # queue_binding commented out - requires queue v4→v5 migration
+  # queue_binding {
+  #   binding = "JOBS"
+  #   queue   = cloudflare_queue.test_queue.name
+  # }
+  script_name = "cftftest-dependent-worker"
+  bindings = [
+    {
+      type         = "kv_namespace"
+      name         = "PRIMARY_KV"
+      namespace_id = cloudflare_workers_kv_namespace.test_kv.id
+      }, {
+      type         = "kv_namespace"
+      name         = "SECONDARY_KV"
+      namespace_id = cloudflare_workers_kv_namespace.test_kv_multiple[0].id
+      }, {
+      type        = "r2_bucket"
+      name        = "STORAGE"
+      bucket_name = cloudflare_r2_bucket.test_r2.name
+    }
+  ]
+}
+
+# ========================================
+# Pattern 25: Worker referencing local values extensively
+# ========================================
+
+resource "cloudflare_workers_script" "local_refs" {
+  account_id = var.cloudflare_account_id
+  content    = local.common_content
+
+  script_name = local.full_worker_name
+  bindings = [
+    {
+      type = "plain_text"
+      name = "PREFIX"
+      text = local.worker_prefix
+    }
+  ]
+}
+
+# ========================================
+# Pattern 26: Singular resource name (cloudflare_worker_script)
+# Tests resource rename: cloudflare_worker_script → cloudflare_workers_script
+# ========================================
+
+resource "cloudflare_workers_script" "singular_name" {
+  account_id = var.cloudflare_account_id
+  content    = local.common_content
+
+  script_name = "cftftest-singular-resource"
+  bindings = [
+    {
+      type = "plain_text"
+      name = "SINGULAR"
+      text = "true"
+    }
+  ]
+}
+
+# ========================================
+# Pattern 27: Complex for_each with list transformation
+# ========================================
+
+variable "environment_configs" {
+  type = list(object({
+    env       = string
+    kv_index  = number
+    use_queue = bool
+  }))
+  default = [
+    {
+      env       = "dev"
+      kv_index  = 0
+      use_queue = true
+    },
+    {
+      env       = "staging"
+      kv_index  = 1
+      use_queue = true
+    },
+    {
+      env       = "prod"
+      kv_index  = 0
+      use_queue = false
+    }
+  ]
+}
+
+resource "cloudflare_workers_script" "environment" {
+  for_each = { for cfg in var.environment_configs : cfg.env => cfg }
+
+  account_id = var.cloudflare_account_id
+  content    = local.common_content
+
+
+
+  # dynamic queue_binding commented out - requires queue v4→v5 migration
+  # dynamic "queue_binding" {
+  #   for_each = each.value.use_queue ? [1] : []
+  #   content {
+  #     binding = "ENV_QUEUE"
+  #     queue   = cloudflare_queue.test_queue.name
+  #   }
+  # }
+  script_name = "cftftest-${each.key}-worker"
+  bindings = [
+    {
+      type = "plain_text"
+      name = "ENVIRONMENT"
+      text = each.value.env
+      }, {
+      type         = "kv_namespace"
+      name         = "ENV_KV"
+      namespace_id = cloudflare_workers_kv_namespace.test_kv_multiple[each.value.kv_index].id
+    }
+  ]
+}

--- a/integration/v4_to_v5/testdata/workers_script/input/terraform.tfstate
+++ b/integration/v4_to_v5/testdata/workers_script/input/terraform.tfstate
@@ -1,0 +1,309 @@
+{
+  "version": 4,
+  "terraform_version": "1.5.0",
+  "serial": 1,
+  "lineage": "test-lineage",
+  "outputs": {},
+  "resources": [
+    {
+      "mode": "managed",
+      "type": "cloudflare_workers_script",
+      "name": "plain_text",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 1,
+          "attributes": {
+            "id": "cftftest-plain-text-worker",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "name": "cftftest-plain-text-worker",
+            "content": "addEventListener('fetch', event => { event.respondWith(new Response('Hello World')); });",
+            "plain_text_binding": [
+              {
+                "name": "MY_VAR",
+                "text": "my-value"
+              }
+            ],
+            "secret_text_binding": [],
+            "kv_namespace_binding": [],
+            "webassembly_binding": [],
+            "service_binding": [],
+            "r2_bucket_binding": [],
+            "analytics_engine_binding": [],
+            "queue_binding": [],
+            "d1_database_binding": [],
+            "hyperdrive_config_binding": [],
+            "module": null,
+            "tags": null,
+            "dispatch_namespace": null
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_workers_script",
+      "name": "queue",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 1,
+          "attributes": {
+            "id": "cftftest-queue-worker",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "name": "cftftest-queue-worker",
+            "content": "addEventListener('fetch', event => { event.respondWith(new Response('Hello World')); });",
+            "plain_text_binding": [],
+            "secret_text_binding": [],
+            "kv_namespace_binding": [],
+            "webassembly_binding": [],
+            "service_binding": [],
+            "r2_bucket_binding": [],
+            "analytics_engine_binding": [],
+            "queue_binding": [
+              {
+                "binding": "MY_QUEUE",
+                "queue": "cftftest-queue"
+              }
+            ],
+            "d1_database_binding": [],
+            "hyperdrive_config_binding": [],
+            "module": null,
+            "tags": null,
+            "dispatch_namespace": null
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_workers_script",
+      "name": "multiple_bindings",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 1,
+          "attributes": {
+            "id": "cftftest-multiple-bindings-worker",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "name": "cftftest-multiple-bindings-worker",
+            "content": "addEventListener('fetch', event => { event.respondWith(new Response('Hello World')); });",
+            "plain_text_binding": [
+              {
+                "name": "VAR_ONE",
+                "text": "value-one"
+              }
+            ],
+            "secret_text_binding": [
+              {
+                "name": "SECRET_ONE",
+                "text": "secret-value-one"
+              }
+            ],
+            "kv_namespace_binding": [
+              {
+                "name": "KV_ONE",
+                "namespace_id": "kv-namespace-id-123"
+              }
+            ],
+            "webassembly_binding": [],
+            "service_binding": [],
+            "r2_bucket_binding": [],
+            "analytics_engine_binding": [],
+            "queue_binding": [],
+            "d1_database_binding": [],
+            "hyperdrive_config_binding": [],
+            "module": null,
+            "tags": null,
+            "dispatch_namespace": null
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_workers_script",
+      "name": "module_false",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 1,
+          "attributes": {
+            "id": "cftftest-module-false-worker",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "name": "cftftest-module-false-worker",
+            "content": "addEventListener('fetch', event => { event.respondWith(new Response('Hello World')); });",
+            "plain_text_binding": [],
+            "secret_text_binding": [],
+            "kv_namespace_binding": [],
+            "webassembly_binding": [],
+            "service_binding": [],
+            "r2_bucket_binding": [],
+            "analytics_engine_binding": [],
+            "queue_binding": [],
+            "d1_database_binding": [],
+            "hyperdrive_config_binding": [],
+            "module": false,
+            "tags": null,
+            "dispatch_namespace": null
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_workers_script",
+      "name": "placement",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 1,
+          "attributes": {
+            "id": "cftftest-placement-worker",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "name": "cftftest-placement-worker",
+            "content": "addEventListener('fetch', event => { event.respondWith(new Response('Hello World')); });",
+            "plain_text_binding": [],
+            "secret_text_binding": [],
+            "kv_namespace_binding": [],
+            "webassembly_binding": [],
+            "service_binding": [],
+            "r2_bucket_binding": [],
+            "analytics_engine_binding": [],
+            "queue_binding": [],
+            "d1_database_binding": [],
+            "hyperdrive_config_binding": [],
+            "module": null,
+            "placement": [
+              {
+                "mode": "smart"
+              }
+            ],
+            "tags": null,
+            "dispatch_namespace": null
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_workers_script",
+      "name": "tags",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 1,
+          "attributes": {
+            "id": "cftftest-tags-worker",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "name": "cftftest-tags-worker",
+            "content": "addEventListener('fetch', event => { event.respondWith(new Response('Hello World')); });",
+            "plain_text_binding": [
+              {
+                "name": "VAR",
+                "text": "value"
+              }
+            ],
+            "secret_text_binding": [],
+            "kv_namespace_binding": [],
+            "webassembly_binding": [],
+            "service_binding": [],
+            "r2_bucket_binding": [],
+            "analytics_engine_binding": [],
+            "queue_binding": [],
+            "d1_database_binding": [],
+            "hyperdrive_config_binding": [],
+            "module": null,
+            "tags": ["test", "migration"],
+            "dispatch_namespace": null
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_workers_script",
+      "name": "comprehensive",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 1,
+          "attributes": {
+            "id": "cftftest-comprehensive-worker",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "name": "cftftest-comprehensive-worker",
+            "content": "addEventListener('fetch', event => { event.respondWith(new Response('Hello World')); });",
+            "plain_text_binding": [
+              {
+                "name": "PLAIN_VAR",
+                "text": "plain-value"
+              }
+            ],
+            "secret_text_binding": [
+              {
+                "name": "SECRET_VAR",
+                "text": "secret-value"
+              }
+            ],
+            "kv_namespace_binding": [
+              {
+                "name": "KV_NS",
+                "namespace_id": "kv-namespace-id-789"
+              }
+            ],
+            "webassembly_binding": [],
+            "service_binding": [],
+            "r2_bucket_binding": [],
+            "analytics_engine_binding": [],
+            "queue_binding": [],
+            "d1_database_binding": [],
+            "hyperdrive_config_binding": [],
+            "module": false,
+            "placement": [
+              {
+                "mode": "smart"
+              }
+            ],
+            "tags": ["comprehensive", "test"],
+            "dispatch_namespace": null
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_worker_script",
+      "name": "singular_name",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 1,
+          "attributes": {
+            "id": "cftftest-singular-resource",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "name": "cftftest-singular-resource",
+            "content": "addEventListener('fetch', event => { event.respondWith(new Response('Hello World')); });",
+            "plain_text_binding": [
+              {
+                "name": "SINGULAR",
+                "text": "true"
+              }
+            ],
+            "secret_text_binding": [],
+            "kv_namespace_binding": [],
+            "webassembly_binding": [],
+            "service_binding": [],
+            "r2_bucket_binding": [],
+            "analytics_engine_binding": [],
+            "queue_binding": [],
+            "d1_database_binding": [],
+            "hyperdrive_config_binding": [],
+            "module": null,
+            "tags": null,
+            "dispatch_namespace": null
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/integration/v4_to_v5/testdata/workers_script/input/workers_script.tf
+++ b/integration/v4_to_v5/testdata/workers_script/input/workers_script.tf
@@ -1,0 +1,533 @@
+variable "cloudflare_account_id" {
+  description = "Cloudflare account ID"
+  type        = string
+}
+
+variable "cloudflare_zone_id" {
+  description = "Cloudflare zone ID"
+  type        = string
+}
+
+# ========================================
+# Dependencies - KV Namespaces
+# ========================================
+
+resource "cloudflare_workers_kv_namespace" "test_kv" {
+  account_id = var.cloudflare_account_id
+  title      = "cftftest-kv-namespace"
+}
+
+resource "cloudflare_workers_kv_namespace" "test_kv_multiple" {
+  count      = 2
+  account_id = var.cloudflare_account_id
+  title      = "cftftest-kv-${count.index}"
+}
+
+# ========================================
+# Dependencies - D1 Databases
+# ========================================
+# TODO: Uncomment when d1_database v4→v5 migration is created
+# D1 bindings also require ES module format which adds complexity
+
+# resource "cloudflare_d1_database" "test_d1" {
+#   account_id = var.cloudflare_account_id
+#   name       = "cftftest-d1-database"
+# }
+
+# ========================================
+# Dependencies - Queues
+# ========================================
+# TODO: Uncomment when queue v4→v5 migration is created
+# The v4 schema uses 'name', v5 uses 'queue_name'
+# Need to create: internal/resources/queue/v4_to_v5.go
+
+# resource "cloudflare_queue" "test_queue" {
+#   account_id = var.cloudflare_account_id
+#   name       = "cftftest-queue"
+# }
+
+# ========================================
+# Dependencies - R2 Buckets
+# ========================================
+
+resource "cloudflare_r2_bucket" "test_r2" {
+  account_id = var.cloudflare_account_id
+  name       = "cftftest-r2-bucket"
+}
+
+# ========================================
+# Local Values
+# ========================================
+
+locals {
+  worker_prefix = "cftftest"
+  common_content = "addEventListener('fetch', event => { event.respondWith(new Response('Hello World')); });"
+  script_names = ["worker-1", "worker-2", "worker-3"]
+
+  # Complex expression
+  full_worker_name = "${local.worker_prefix}-main"
+}
+
+# ========================================
+# Variables for Testing
+# ========================================
+
+variable "worker_content" {
+  type    = string
+  default = "addEventListener('fetch', event => { event.respondWith(new Response('Test')); });"
+}
+
+variable "enable_analytics" {
+  type    = bool
+  default = true
+}
+
+# ========================================
+# Pattern 1: Simple worker with plain_text_binding
+# ========================================
+
+resource "cloudflare_workers_script" "plain_text" {
+  account_id = var.cloudflare_account_id
+  name       = "cftftest-plain-text-worker"
+  content    = local.common_content
+
+  plain_text_binding {
+    name = "MY_VAR"
+    text = "my-value"
+  }
+}
+
+# ========================================
+# Pattern 2: Worker with secret_text_binding
+# ========================================
+
+resource "cloudflare_workers_script" "secret_text" {
+  account_id = var.cloudflare_account_id
+  name       = "cftftest-secret-text-worker"
+  content    = local.common_content
+
+  secret_text_binding {
+    name = "API_KEY"
+    text = "secret-api-key-value"
+  }
+}
+
+# ========================================
+# Pattern 3: Worker with kv_namespace_binding
+# ========================================
+
+resource "cloudflare_workers_script" "kv_namespace" {
+  account_id = var.cloudflare_account_id
+  name       = "cftftest-kv-worker"
+  content    = local.common_content
+
+  kv_namespace_binding {
+    name         = "MY_KV"
+    namespace_id = cloudflare_workers_kv_namespace.test_kv.id
+  }
+}
+
+# ========================================
+# Pattern 5: Worker with r2_bucket_binding
+# ========================================
+
+resource "cloudflare_workers_script" "r2_bucket" {
+  account_id = var.cloudflare_account_id
+  name       = "cftftest-r2-worker"
+  content    = local.common_content
+
+  r2_bucket_binding {
+    name        = "MY_BUCKET"
+    bucket_name = cloudflare_r2_bucket.test_r2.name
+  }
+}
+
+# ========================================
+# Pattern 7: Worker with analytics_engine_binding
+# ========================================
+
+resource "cloudflare_workers_script" "analytics_engine" {
+  account_id = var.cloudflare_account_id
+  name       = "cftftest-analytics-worker"
+  content    = local.common_content
+
+  analytics_engine_binding {
+    name    = "MY_ANALYTICS"
+    dataset = "analytics_dataset"
+  }
+}
+
+# ========================================
+# Pattern 8: Worker with queue_binding (binding → name, queue → queue_name)
+# ========================================
+# TODO: Uncomment when queue v4→v5 migration is created
+
+# resource "cloudflare_workers_script" "queue" {
+#   account_id = var.cloudflare_account_id
+#   name       = "cftftest-queue-worker"
+#   content    = local.common_content
+#
+#   queue_binding {
+#     binding = "MY_QUEUE"
+#     queue   = cloudflare_queue.test_queue.name
+#   }
+# }
+
+# ========================================
+# Pattern 9: Worker with multiple bindings (order preservation test)
+# ========================================
+
+resource "cloudflare_workers_script" "multiple_bindings" {
+  account_id = var.cloudflare_account_id
+  name       = "cftftest-multiple-bindings-worker"
+  content    = local.common_content
+
+  plain_text_binding {
+    name = "VAR_ONE"
+    text = "value-one"
+  }
+
+  secret_text_binding {
+    name = "SECRET_ONE"
+    text = "secret-value-one"
+  }
+
+  kv_namespace_binding {
+    name         = "KV_ONE"
+    namespace_id = cloudflare_workers_kv_namespace.test_kv.id
+  }
+}
+
+# ========================================
+# Pattern 10: Worker with module = false (becomes body_part)
+# ========================================
+
+resource "cloudflare_workers_script" "module_false" {
+  account_id = var.cloudflare_account_id
+  name       = "cftftest-module-false-worker"
+  content    = local.common_content
+  module     = false
+}
+
+# ========================================
+# Pattern 15: Worker with placement block (becomes object)
+# ========================================
+
+resource "cloudflare_workers_script" "placement" {
+  account_id = var.cloudflare_account_id
+  name       = "cftftest-placement-worker"
+  content    = local.common_content
+
+  placement {
+    mode = "smart"
+  }
+}
+
+# ========================================
+# Pattern 16: Worker with tags (should be removed)
+# ========================================
+
+resource "cloudflare_workers_script" "tags" {
+  account_id = var.cloudflare_account_id
+  name       = "cftftest-tags-worker"
+  content    = local.common_content
+  tags       = ["test", "migration"]
+
+  plain_text_binding {
+    name = "VAR"
+    text = "value"
+  }
+}
+
+# ========================================
+# Pattern 17: Comprehensive worker with all transformations
+# ========================================
+
+resource "cloudflare_workers_script" "comprehensive" {
+  account_id = var.cloudflare_account_id
+  name       = "cftftest-comprehensive-worker"
+  content    = local.common_content
+  module     = false
+  tags       = ["comprehensive", "test"]
+
+  plain_text_binding {
+    name = "PLAIN_VAR"
+    text = "plain-value"
+  }
+
+  secret_text_binding {
+    name = "SECRET_VAR"
+    text = "secret-value"
+  }
+
+  kv_namespace_binding {
+    name         = "KV_NS"
+    namespace_id = cloudflare_workers_kv_namespace.test_kv.id
+  }
+
+  placement {
+    mode = "smart"
+  }
+}
+
+# ========================================
+# Pattern 18: for_each with map
+# ========================================
+
+variable "worker_configs" {
+  type = map(object({
+    content = string
+    var_value = string
+  }))
+  default = {
+    "worker-a" = {
+      content   = "addEventListener('fetch', e => { e.respondWith(new Response('A')); });"
+      var_value = "value-a"
+    }
+    "worker-b" = {
+      content   = "addEventListener('fetch', e => { e.respondWith(new Response('B')); });"
+      var_value = "value-b"
+    }
+    "worker-c" = {
+      content   = "addEventListener('fetch', e => { e.respondWith(new Response('C')); });"
+      var_value = "value-c"
+    }
+  }
+}
+
+resource "cloudflare_workers_script" "for_each_map" {
+  for_each = var.worker_configs
+
+  account_id = var.cloudflare_account_id
+  name       = "cftftest-${each.key}"
+  content    = each.value.content
+
+  plain_text_binding {
+    name = "CONFIG_VAR"
+    text = each.value.var_value
+  }
+}
+
+# ========================================
+# Pattern 19: for_each with set
+# ========================================
+
+variable "simple_workers" {
+  type = set(string)
+  default = ["simple-1", "simple-2", "simple-3"]
+}
+
+resource "cloudflare_workers_script" "for_each_set" {
+  for_each = var.simple_workers
+
+  account_id = var.cloudflare_account_id
+  name       = "cftftest-${each.value}"
+  content    = "addEventListener('fetch', e => { e.respondWith(new Response('${each.value}')); });"
+
+  plain_text_binding {
+    name = "WORKER_NAME"
+    text = each.value
+  }
+}
+
+# ========================================
+# Pattern 20: Count-based resources
+# ========================================
+
+variable "replica_count" {
+  type    = number
+  default = 3
+}
+
+resource "cloudflare_workers_script" "count_based" {
+  count = var.replica_count
+
+  account_id = var.cloudflare_account_id
+  name       = "cftftest-replica-${count.index}"
+  content    = local.common_content
+
+  plain_text_binding {
+    name = "REPLICA_ID"
+    text = tostring(count.index)
+  }
+
+  kv_namespace_binding {
+    name         = "KV"
+    namespace_id = cloudflare_workers_kv_namespace.test_kv_multiple[count.index % 2].id
+  }
+}
+
+# ========================================
+# Pattern 21: Conditional resource creation
+# ========================================
+
+resource "cloudflare_workers_script" "conditional" {
+  count = var.enable_analytics ? 1 : 0
+
+  account_id = var.cloudflare_account_id
+  name       = "cftftest-conditional-worker"
+  content    = local.common_content
+
+  analytics_engine_binding {
+    name    = "ANALYTICS"
+    dataset = "conditional_dataset"
+  }
+}
+
+# ========================================
+# Pattern 22: Resource with lifecycle meta-arguments
+# ========================================
+
+resource "cloudflare_workers_script" "lifecycle" {
+  account_id = var.cloudflare_account_id
+  name       = "cftftest-lifecycle-worker"
+  content    = local.common_content
+
+  plain_text_binding {
+    name = "LIFECYCLE_VAR"
+    text = "protected"
+  }
+
+  lifecycle {
+    prevent_destroy       = false
+    create_before_destroy = true
+  }
+}
+
+# ========================================
+# Pattern 23: Using terraform expressions in bindings
+# ========================================
+
+resource "cloudflare_workers_script" "conditional_binding" {
+  account_id = var.cloudflare_account_id
+  name       = "cftftest-conditional-binding-worker"
+  content    = var.enable_analytics ? local.common_content : var.worker_content
+
+  plain_text_binding {
+    name = "ENABLED"
+    text = var.enable_analytics ? "true" : "false"
+  }
+
+  kv_namespace_binding {
+    name         = "KV"
+    namespace_id = cloudflare_workers_kv_namespace.test_kv.id
+  }
+}
+
+# ========================================
+# Pattern 24: Cross-resource references with dependencies
+# ========================================
+
+resource "cloudflare_workers_script" "dependent" {
+  account_id = var.cloudflare_account_id
+  name       = "cftftest-dependent-worker"
+  content    = local.common_content
+
+  kv_namespace_binding {
+    name         = "PRIMARY_KV"
+    namespace_id = cloudflare_workers_kv_namespace.test_kv.id
+  }
+
+  kv_namespace_binding {
+    name         = "SECONDARY_KV"
+    namespace_id = cloudflare_workers_kv_namespace.test_kv_multiple[0].id
+  }
+
+  r2_bucket_binding {
+    name        = "STORAGE"
+    bucket_name = cloudflare_r2_bucket.test_r2.name
+  }
+
+  # queue_binding commented out - requires queue v4→v5 migration
+  # queue_binding {
+  #   binding = "JOBS"
+  #   queue   = cloudflare_queue.test_queue.name
+  # }
+}
+
+# ========================================
+# Pattern 25: Worker referencing local values extensively
+# ========================================
+
+resource "cloudflare_workers_script" "local_refs" {
+  account_id = var.cloudflare_account_id
+  name       = local.full_worker_name
+  content    = local.common_content
+
+  plain_text_binding {
+    name = "PREFIX"
+    text = local.worker_prefix
+  }
+}
+
+# ========================================
+# Pattern 26: Singular resource name (cloudflare_worker_script)
+# Tests resource rename: cloudflare_worker_script → cloudflare_workers_script
+# ========================================
+
+resource "cloudflare_worker_script" "singular_name" {
+  account_id = var.cloudflare_account_id
+  name       = "cftftest-singular-resource"
+  content    = local.common_content
+
+  plain_text_binding {
+    name = "SINGULAR"
+    text = "true"
+  }
+}
+
+# ========================================
+# Pattern 27: Complex for_each with list transformation
+# ========================================
+
+variable "environment_configs" {
+  type = list(object({
+    env       = string
+    kv_index  = number
+    use_queue = bool
+  }))
+  default = [
+    {
+      env       = "dev"
+      kv_index  = 0
+      use_queue = true
+    },
+    {
+      env       = "staging"
+      kv_index  = 1
+      use_queue = true
+    },
+    {
+      env       = "prod"
+      kv_index  = 0
+      use_queue = false
+    }
+  ]
+}
+
+resource "cloudflare_workers_script" "environment" {
+  for_each = { for cfg in var.environment_configs : cfg.env => cfg }
+
+  account_id = var.cloudflare_account_id
+  name       = "cftftest-${each.key}-worker"
+  content    = local.common_content
+
+  plain_text_binding {
+    name = "ENVIRONMENT"
+    text = each.value.env
+  }
+
+  kv_namespace_binding {
+    name         = "ENV_KV"
+    namespace_id = cloudflare_workers_kv_namespace.test_kv_multiple[each.value.kv_index].id
+  }
+
+  # dynamic queue_binding commented out - requires queue v4→v5 migration
+  # dynamic "queue_binding" {
+  #   for_each = each.value.use_queue ? [1] : []
+  #   content {
+  #     binding = "ENV_QUEUE"
+  #     queue   = cloudflare_queue.test_queue.name
+  #   }
+  # }
+}

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cloudflare/tf-migrate/internal/resources/url_normalization_settings"
 	"github.com/cloudflare/tf-migrate/internal/resources/workers_kv"
 	"github.com/cloudflare/tf-migrate/internal/resources/workers_kv_namespace"
+	"github.com/cloudflare/tf-migrate/internal/resources/workers_script"
 	"github.com/cloudflare/tf-migrate/internal/resources/zero_trust_access_identity_provider"
 	"github.com/cloudflare/tf-migrate/internal/resources/zero_trust_access_mtls_hostname_settings"
 	"github.com/cloudflare/tf-migrate/internal/resources/zero_trust_access_service_token"
@@ -73,6 +74,7 @@ func RegisterAllMigrations() {
 	url_normalization_settings.NewV4ToV5Migrator()
 	workers_kv.NewV4ToV5Migrator()
 	workers_kv_namespace.NewV4ToV5Migrator()
+	workers_script.NewV4ToV5Migrator()
 	zero_trust_access_identity_provider.NewV4ToV5Migrator()
 	zero_trust_access_mtls_hostname_settings.NewV4ToV5Migrator()
 	zero_trust_access_service_token.NewV4ToV5Migrator()

--- a/internal/resources/page_rule/v4_to_v5.go
+++ b/internal/resources/page_rule/v4_to_v5.go
@@ -56,7 +56,7 @@ func (m *V4ToV5Migrator) TransformConfig(ctx *transform.Context, block *hclwrite
 		actionsBody := actionsBlock.Body()
 
 		// Step 1a: Remove deprecated fields
-		tfhcl.RemoveAttributes(actionsBody, "minify", "disable_railgun")
+		tfhcl.RemoveAttributes(actionsBody, "minify", "disable_railgun", "server_side_exclude")
 
 		// Step 1b: Transform cache_ttl_by_status (TypeSet blocks → MapAttribute)
 		// MUST do this BEFORE converting actions block, while blocks still exist
@@ -74,6 +74,12 @@ func (m *V4ToV5Migrator) TransformConfig(ctx *transform.Context, block *hclwrite
 		// Must process deepest blocks first, then parent
 		if cacheKeyBlock := tfhcl.FindBlockByType(actionsBody, "cache_key_fields"); cacheKeyBlock != nil {
 			cacheKeyBody := cacheKeyBlock.Body()
+
+			// Remove deprecated "ignore" field from query_string before conversion
+			if queryStringBlock := tfhcl.FindBlockByType(cacheKeyBody, "query_string"); queryStringBlock != nil {
+				queryStringBody := queryStringBlock.Body()
+				tfhcl.RemoveAttributes(queryStringBody, "ignore")
+			}
 
 			// Convert deepest nested blocks first (TypeList MaxItems:1 → SingleNestedAttribute)
 			tfhcl.ConvertSingleBlockToAttribute(cacheKeyBody, "cookie", "cookie")
@@ -132,9 +138,14 @@ func (m *V4ToV5Migrator) TransformState(ctx *transform.Context, stateJSON gjson.
 			// 3a. Remove deprecated fields
 			result, _ = sjson.Delete(result, "attributes.actions.minify")
 			result, _ = sjson.Delete(result, "attributes.actions.disable_railgun")
+			result, _ = sjson.Delete(result, "attributes.actions.server_side_exclude")
 
 			// 3b. Transform nested MaxItems:1 arrays to objects
 			result = m.transformActionsNestedArrays(result, attrs.Get("actions"))
+
+			// 3b2. Remove deprecated "ignore" field from cache_key_fields.query_string
+			// This must be done after transformActionsNestedArrays converts the arrays to objects
+			result, _ = sjson.Delete(result, "attributes.actions.cache_key_fields.query_string.ignore")
 
 			// 3c. Transform cache_ttl_by_status array → map
 			result = m.transformCacheTTLByStatusState(result, attrs.Get("actions"))

--- a/internal/resources/workers_script/v4_to_v5.go
+++ b/internal/resources/workers_script/v4_to_v5.go
@@ -31,7 +31,6 @@ func (m *V4ToV5Migrator) CanHandle(resourceType string) bool {
 }
 
 func (m *V4ToV5Migrator) Preprocess(content string) string {
-	// No preprocessing needed - all transformations can be done with HCL helpers
 	return content
 }
 
@@ -268,7 +267,7 @@ func quoteValue(value string) string {
 	if len(value) == 0 {
 		return "\"\""
 	}
-	if (value[0] == '"' && value[len(value)-1] == '"') {
+	if value[0] == '"' && value[len(value)-1] == '"' {
 		return value
 	}
 	if len(value) >= 4 && value[0:4] == "var." {
@@ -456,10 +455,11 @@ func (m *V4ToV5Migrator) transformStateModule(result string, attrs gjson.Result)
 		moduleBool := moduleAttr.Bool()
 
 		// Add main_module if true, body_part if false
+		// Use a default filename since we don't have the actual filename
 		if moduleBool {
-			result, _ = sjson.Set(result, "attributes.main_module", "true")
+			result, _ = sjson.Set(result, "attributes.main_module", "worker.js")
 		} else {
-			result, _ = sjson.Set(result, "attributes.body_part", "false")
+			result, _ = sjson.Set(result, "attributes.body_part", "worker.js")
 		}
 	}
 

--- a/internal/resources/workers_script/v4_to_v5.go
+++ b/internal/resources/workers_script/v4_to_v5.go
@@ -1,0 +1,487 @@
+package workers_script
+
+import (
+	"github.com/hashicorp/hcl/v2/hclwrite"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+
+	"github.com/cloudflare/tf-migrate/internal"
+	"github.com/cloudflare/tf-migrate/internal/transform"
+	tfhcl "github.com/cloudflare/tf-migrate/internal/transform/hcl"
+	"github.com/cloudflare/tf-migrate/internal/transform/state"
+)
+
+type V4ToV5Migrator struct {
+}
+
+func NewV4ToV5Migrator() transform.ResourceTransformer {
+	migrator := &V4ToV5Migrator{}
+	// Register with both v4 resource names (plural and singular forms)
+	internal.RegisterMigrator("cloudflare_workers_script", "v4", "v5", migrator)
+	internal.RegisterMigrator("cloudflare_worker_script", "v4", "v5", migrator)
+	return migrator
+}
+
+func (m *V4ToV5Migrator) GetResourceType() string {
+	return "cloudflare_workers_script"
+}
+
+func (m *V4ToV5Migrator) CanHandle(resourceType string) bool {
+	return resourceType == "cloudflare_workers_script" || resourceType == "cloudflare_worker_script"
+}
+
+func (m *V4ToV5Migrator) Preprocess(content string) string {
+	// No preprocessing needed - all transformations can be done with HCL helpers
+	return content
+}
+
+// GetResourceRename implements the ResourceRenamer interface
+// Handles both cloudflare_worker_script (singular) and cloudflare_workers_script (plural)
+func (m *V4ToV5Migrator) GetResourceRename() (string, string) {
+	return "cloudflare_worker_script", "cloudflare_workers_script"
+}
+
+func (m *V4ToV5Migrator) TransformConfig(ctx *transform.Context, block *hclwrite.Block) (*transform.TransformResult, error) {
+	body := block.Body()
+
+	// Handle resource rename: cloudflare_worker_script → cloudflare_workers_script
+	tfhcl.RenameResourceType(block, "cloudflare_worker_script", "cloudflare_workers_script")
+
+	// Rename field: name → script_name
+	tfhcl.RenameAttribute(body, "name", "script_name")
+
+	// Remove deprecated fields
+	// tags - not supported in v5
+	tfhcl.RemoveAttributes(body, "tags")
+
+	// Transform bindings: Convert 10 different binding blocks + dispatch_namespace attr → unified bindings list
+	m.transformBindings(body)
+
+	// Transform module boolean → main_module/body_part string
+	m.transformModule(body)
+
+	// Transform placement block → object attribute
+	m.transformPlacement(body)
+
+	return &transform.TransformResult{
+		Blocks:         []*hclwrite.Block{block},
+		RemoveOriginal: false,
+	}, nil
+}
+
+// transformBindings converts v4 binding blocks and dispatch_namespace attribute to v5 unified bindings list
+func (m *V4ToV5Migrator) transformBindings(body *hclwrite.Body) {
+	var bindingObjects []string
+
+	// Map of v4 block types to v5 binding types
+	bindingTypeMap := map[string]string{
+		"plain_text_binding":        "plain_text",
+		"secret_text_binding":       "secret_text",
+		"kv_namespace_binding":      "kv_namespace",
+		"webassembly_binding":       "wasm_module",
+		"service_binding":           "service",
+		"r2_bucket_binding":         "r2_bucket",
+		"analytics_engine_binding":  "analytics_engine",
+		"queue_binding":             "queue",
+		"d1_database_binding":       "d1",
+		"hyperdrive_config_binding": "hyperdrive",
+	}
+
+	// Process blocks in document order to preserve binding order
+	for _, block := range body.Blocks() {
+		if v5BindingType, ok := bindingTypeMap[block.Type()]; ok {
+			bindingObj := m.convertBindingBlockToObject(block, v5BindingType)
+			if bindingObj != "" {
+				bindingObjects = append(bindingObjects, bindingObj)
+			}
+		}
+	}
+
+	// Handle dispatch_namespace attribute conversion
+	if dispatchAttr := body.GetAttribute("dispatch_namespace"); dispatchAttr != nil {
+		dispatchValue := tfhcl.ExtractStringFromAttribute(dispatchAttr)
+		if dispatchValue != "" {
+			bindingObj := "{\n    type = \"dispatch_namespace\"\n    namespace = " + quoteValue(dispatchValue) + "\n  }"
+			bindingObjects = append(bindingObjects, bindingObj)
+		}
+		body.RemoveAttribute("dispatch_namespace")
+	}
+
+	// Create unified bindings list if we have any bindings
+	if len(bindingObjects) > 0 {
+		bindingsValue := "[\n  " + joinBindings(bindingObjects) + "\n]"
+		// Use SetAttributeFromExpressionString to set the bindings array
+		tfhcl.SetAttributeFromExpressionString(body, "bindings", bindingsValue)
+	}
+
+	// Remove all v4 binding blocks
+	for blockType := range bindingTypeMap {
+		removeBlocks(body, blockType)
+	}
+}
+
+// convertBindingBlockToObject converts a v4 binding block to a v5 binding object string
+func (m *V4ToV5Migrator) convertBindingBlockToObject(block *hclwrite.Block, bindingType string) string {
+	blockBody := block.Body()
+	var attrs []string
+
+	// Always add type first
+	attrs = append(attrs, "type = \""+bindingType+"\"")
+
+	// Handle attribute renames based on binding type
+	switch bindingType {
+	case "wasm_module":
+		// webassembly_binding: module → part
+		if attr := blockBody.GetAttribute("name"); attr != nil {
+			attrs = append(attrs, "name = "+exprToString(attr.Expr()))
+		}
+		if attr := blockBody.GetAttribute("module"); attr != nil {
+			attrs = append(attrs, "part = "+exprToString(attr.Expr()))
+		}
+	case "queue":
+		// queue_binding: binding → name, queue → queue_name
+		if attr := blockBody.GetAttribute("binding"); attr != nil {
+			attrs = append(attrs, "name = "+exprToString(attr.Expr()))
+		}
+		if attr := blockBody.GetAttribute("queue"); attr != nil {
+			attrs = append(attrs, "queue_name = "+exprToString(attr.Expr()))
+		}
+	case "d1":
+		// d1_database_binding: database_id → id
+		if attr := blockBody.GetAttribute("name"); attr != nil {
+			attrs = append(attrs, "name = "+exprToString(attr.Expr()))
+		}
+		if attr := blockBody.GetAttribute("database_id"); attr != nil {
+			attrs = append(attrs, "id = "+exprToString(attr.Expr()))
+		}
+	case "hyperdrive":
+		// hyperdrive_config_binding: binding → name, id stays
+		if attr := blockBody.GetAttribute("binding"); attr != nil {
+			attrs = append(attrs, "name = "+exprToString(attr.Expr()))
+		}
+		if attr := blockBody.GetAttribute("id"); attr != nil {
+			attrs = append(attrs, "id = "+exprToString(attr.Expr()))
+		}
+	default:
+		// All other binding types: copy attributes in consistent order (name first, then others)
+		if attr := blockBody.GetAttribute("name"); attr != nil {
+			attrs = append(attrs, "name = "+exprToString(attr.Expr()))
+		}
+		// Add remaining attributes (except name which we already added)
+		for attrName, attr := range blockBody.Attributes() {
+			if attrName != "name" {
+				attrs = append(attrs, attrName+" = "+exprToString(attr.Expr()))
+			}
+		}
+	}
+
+	return "{\n    " + joinAttributes(attrs) + "\n  }"
+}
+
+// transformModule converts module boolean to main_module or body_part string
+func (m *V4ToV5Migrator) transformModule(body *hclwrite.Body) {
+	moduleAttr := body.GetAttribute("module")
+	if moduleAttr == nil {
+		return
+	}
+
+	// Extract the boolean value
+	moduleValue, ok := tfhcl.ExtractBoolFromAttribute(moduleAttr)
+	if !ok {
+		// If it's a variable reference, we can't transform it statically
+		// Leave it as-is and let the user handle it manually
+		return
+	}
+
+	// Remove the module attribute
+	body.RemoveAttribute("module")
+
+	// Add main_module if true, body_part if false
+	// Use a default filename since we don't have the actual filename
+	if moduleValue {
+		body.SetAttributeRaw("main_module", tfhcl.TokensForSimpleValue("worker.js"))
+	} else {
+		body.SetAttributeRaw("body_part", tfhcl.TokensForSimpleValue("worker.js"))
+	}
+}
+
+// transformPlacement converts placement block to object attribute
+func (m *V4ToV5Migrator) transformPlacement(body *hclwrite.Body) {
+	var placementBlock *hclwrite.Block
+	for _, block := range body.Blocks() {
+		if block.Type() == "placement" {
+			placementBlock = block
+			break
+		}
+	}
+
+	if placementBlock == nil {
+		return
+	}
+
+	placementBody := placementBlock.Body()
+
+	// Extract the mode attribute
+	if modeAttr := placementBody.GetAttribute("mode"); modeAttr != nil {
+		modeValue := exprToString(modeAttr.Expr())
+		// Create object syntax: placement = { mode = "smart" }
+		placementObj := "{\n    mode = " + modeValue + "\n  }"
+		tfhcl.SetAttributeFromExpressionString(body, "placement", placementObj)
+	}
+
+	// Remove the placement block
+	removeBlocks(body, "placement")
+}
+
+// Helper functions
+
+// exprToString converts an HCL expression to its string representation
+func exprToString(expr *hclwrite.Expression) string {
+	if expr == nil {
+		return ""
+	}
+	tokens := expr.BuildTokens(nil)
+	var result []byte
+	for _, token := range tokens {
+		result = append(result, token.Bytes...)
+	}
+	return string(result)
+}
+
+// removeBlocks removes all blocks of a given type from a body
+func removeBlocks(body *hclwrite.Body, blockType string) {
+	// We need to collect blocks first then remove them
+	// to avoid modifying the collection while iterating
+	var blocksToRemove []*hclwrite.Block
+	for _, block := range body.Blocks() {
+		if block.Type() == blockType {
+			blocksToRemove = append(blocksToRemove, block)
+		}
+	}
+	for _, block := range blocksToRemove {
+		body.RemoveBlock(block)
+	}
+}
+
+func quoteValue(value string) string {
+	// If already quoted or is a variable reference, return as-is
+	if len(value) == 0 {
+		return "\"\""
+	}
+	if (value[0] == '"' && value[len(value)-1] == '"') {
+		return value
+	}
+	if len(value) >= 4 && value[0:4] == "var." {
+		return value
+	}
+	return "\"" + value + "\""
+}
+
+func joinBindings(bindings []string) string {
+	if len(bindings) == 0 {
+		return ""
+	}
+	result := bindings[0]
+	for i := 1; i < len(bindings); i++ {
+		result += ", " + bindings[i]
+	}
+	return result
+}
+
+func joinAttributes(attrs []string) string {
+	if len(attrs) == 0 {
+		return ""
+	}
+	result := attrs[0]
+	for i := 1; i < len(attrs); i++ {
+		result += "\n    " + attrs[i]
+	}
+	return result
+}
+
+func (m *V4ToV5Migrator) TransformState(ctx *transform.Context, stateJSON gjson.Result, resourcePath, resourceName string) (string, error) {
+	result := stateJSON.String()
+
+	if !stateJSON.Exists() || !stateJSON.Get("attributes").Exists() {
+		return result, nil
+	}
+
+	attrs := stateJSON.Get("attributes")
+
+	// Rename field: name → script_name
+	result = state.RenameField(result, "attributes", attrs, "name", "script_name")
+
+	// Remove deprecated fields
+	// tags - not supported in v5
+	result = state.RemoveFields(result, "attributes", attrs, "tags")
+
+	// Transform bindings: Convert 10 different binding arrays + dispatch_namespace to unified bindings array
+	result = m.transformStateBindings(result, attrs)
+
+	// Transform module boolean → main_module/body_part string
+	result = m.transformStateModule(result, attrs)
+
+	// Transform placement if needed
+	result = m.transformStatePlacement(result, attrs)
+
+	// Set schema_version to 1 to match provider schema version
+	// This prevents the provider from running state upgraders since tf-migrate
+	// already produces the final v5 format
+	result, _ = sjson.Set(result, "schema_version", 1)
+
+	return result, nil
+}
+
+// transformStateBindings converts v4 binding arrays and dispatch_namespace to v5 unified bindings array
+func (m *V4ToV5Migrator) transformStateBindings(result string, attrs gjson.Result) string {
+	var bindings []interface{}
+
+	// Array of binding types in consistent order (same as config)
+	bindingTypes := []struct {
+		v4ArrayName   string
+		v5BindingType string
+	}{
+		{"plain_text_binding", "plain_text"},
+		{"secret_text_binding", "secret_text"},
+		{"kv_namespace_binding", "kv_namespace"},
+		{"webassembly_binding", "wasm_module"},
+		{"service_binding", "service"},
+		{"r2_bucket_binding", "r2_bucket"},
+		{"analytics_engine_binding", "analytics_engine"},
+		{"queue_binding", "queue"},
+		{"d1_database_binding", "d1"},
+		{"hyperdrive_config_binding", "hyperdrive"},
+	}
+
+	// Process each binding array type in order
+	for _, bt := range bindingTypes {
+		bindingArray := attrs.Get(bt.v4ArrayName)
+		if bindingArray.Exists() && bindingArray.IsArray() {
+			for _, bindingItem := range bindingArray.Array() {
+				binding := m.convertStateBindingToObject(bindingItem, bt.v5BindingType)
+				if binding != nil {
+					bindings = append(bindings, binding)
+				}
+			}
+		}
+	}
+
+	// Handle dispatch_namespace attribute conversion
+	if dispatchNS := attrs.Get("dispatch_namespace"); dispatchNS.Exists() {
+		if dispatchNS.Type != gjson.Null && dispatchNS.String() != "" {
+			binding := map[string]interface{}{
+				"type":      "dispatch_namespace",
+				"namespace": dispatchNS.String(),
+			}
+			bindings = append(bindings, binding)
+		}
+		// Always delete the attribute whether it was null or had a value
+		result, _ = sjson.Delete(result, "attributes.dispatch_namespace")
+	}
+
+	// Set unified bindings array if we have any bindings
+	if len(bindings) > 0 {
+		result, _ = sjson.Set(result, "attributes.bindings", bindings)
+	}
+
+	// Remove all v4 binding arrays
+	for _, bt := range bindingTypes {
+		result, _ = sjson.Delete(result, "attributes."+bt.v4ArrayName)
+	}
+
+	return result
+}
+
+// convertStateBindingToObject converts a v4 binding object to v5 format with attribute renames
+func (m *V4ToV5Migrator) convertStateBindingToObject(bindingItem gjson.Result, bindingType string) map[string]interface{} {
+	binding := map[string]interface{}{
+		"type": bindingType,
+	}
+
+	// Handle attribute renames based on binding type
+	switch bindingType {
+	case "wasm_module":
+		// webassembly_binding: module → part
+		if name := bindingItem.Get("name"); name.Exists() {
+			binding["name"] = name.Value()
+		}
+		if module := bindingItem.Get("module"); module.Exists() {
+			binding["part"] = module.Value()
+		}
+	case "queue":
+		// queue_binding: binding → name, queue → queue_name
+		if bindingName := bindingItem.Get("binding"); bindingName.Exists() {
+			binding["name"] = bindingName.Value()
+		}
+		if queueName := bindingItem.Get("queue"); queueName.Exists() {
+			binding["queue_name"] = queueName.Value()
+		}
+	case "d1":
+		// d1_database_binding: database_id → id
+		if name := bindingItem.Get("name"); name.Exists() {
+			binding["name"] = name.Value()
+		}
+		if databaseID := bindingItem.Get("database_id"); databaseID.Exists() {
+			binding["id"] = databaseID.Value()
+		}
+	case "hyperdrive":
+		// hyperdrive_config_binding: binding → name
+		if bindingName := bindingItem.Get("binding"); bindingName.Exists() {
+			binding["name"] = bindingName.Value()
+		}
+		if id := bindingItem.Get("id"); id.Exists() {
+			binding["id"] = id.Value()
+		}
+	default:
+		// All other binding types: copy fields as-is
+		bindingItem.ForEach(func(key, value gjson.Result) bool {
+			binding[key.String()] = value.Value()
+			return true
+		})
+	}
+
+	return binding
+}
+
+// transformStateModule converts module boolean to main_module or body_part string
+func (m *V4ToV5Migrator) transformStateModule(result string, attrs gjson.Result) string {
+	moduleAttr := attrs.Get("module")
+	if !moduleAttr.Exists() {
+		return result
+	}
+
+	// Only process if not null
+	if moduleAttr.Type != gjson.Null {
+		// Get the boolean value
+		moduleBool := moduleAttr.Bool()
+
+		// Add main_module if true, body_part if false
+		if moduleBool {
+			result, _ = sjson.Set(result, "attributes.main_module", "true")
+		} else {
+			result, _ = sjson.Set(result, "attributes.body_part", "false")
+		}
+	}
+
+	// Always remove the module attribute whether it was null or had a value
+	result, _ = sjson.Delete(result, "attributes.module")
+
+	return result
+}
+
+// transformStatePlacement converts placement array to object if needed
+func (m *V4ToV5Migrator) transformStatePlacement(result string, attrs gjson.Result) string {
+	// Use helper to transform placement from array to object
+	// Empty arrays will be removed, non-empty arrays will be unwrapped to objects
+	result = state.TransformFieldArrayToObject(
+		result,
+		"attributes",
+		attrs,
+		"placement",
+		state.ArrayToObjectOptions{
+			EnsureObjectExists: false, // Remove empty arrays instead of creating empty objects
+		},
+	)
+
+	return result
+}

--- a/internal/resources/workers_script/v4_to_v5_test.go
+++ b/internal/resources/workers_script/v4_to_v5_test.go
@@ -1,0 +1,852 @@
+package workers_script
+
+import (
+	"testing"
+
+	"github.com/cloudflare/tf-migrate/internal/testhelpers"
+)
+
+func TestWorkerScriptConfigTransform_BasicRename(t *testing.T) {
+	migrator := NewV4ToV5Migrator()
+
+	tests := []testhelpers.ConfigTestCase{
+		{
+			Name: "resource type rename - singular to plural",
+			Input: `resource "cloudflare_worker_script" "example" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+  name       = "my-worker"
+  content    = "addEventListener('fetch', event => { event.respondWith(new Response('Hello')); });"
+}`,
+			Expected: `resource "cloudflare_workers_script" "example" {
+  account_id  = "f037e56e89293a057740de681ac9abbe"
+  content     = "addEventListener('fetch', event => { event.respondWith(new Response('Hello')); });"
+  script_name = "my-worker"
+}`,
+		},
+		{
+			Name: "field rename - name to script_name",
+			Input: `resource "cloudflare_workers_script" "example" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+  name       = "test-worker"
+  content    = "addEventListener('fetch', event => { event.respondWith(new Response('Hello')); });"
+}`,
+			Expected: `resource "cloudflare_workers_script" "example" {
+  account_id  = "f037e56e89293a057740de681ac9abbe"
+  content     = "addEventListener('fetch', event => { event.respondWith(new Response('Hello')); });"
+  script_name = "test-worker"
+}`,
+		},
+		{
+			Name: "remove tags field",
+			Input: `resource "cloudflare_workers_script" "example" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+  name       = "my-worker"
+  content    = "addEventListener('fetch', event => { event.respondWith(new Response('Hello')); });"
+  tags       = ["production", "api"]
+}`,
+			Expected: `resource "cloudflare_workers_script" "example" {
+  account_id  = "f037e56e89293a057740de681ac9abbe"
+  content     = "addEventListener('fetch', event => { event.respondWith(new Response('Hello')); });"
+  script_name = "my-worker"
+}`,
+		},
+	}
+
+	testhelpers.RunConfigTransformTests(t, tests, migrator)
+}
+
+func TestWorkerScriptStateTransform_BasicRename(t *testing.T) {
+	migrator := NewV4ToV5Migrator()
+
+	tests := []testhelpers.StateTestCase{
+		{
+			Name: "field rename - name to script_name",
+			Input: `{
+  "schema_version": 1,
+  "attributes": {
+    "account_id": "f037e56e89293a057740de681ac9abbe",
+    "name": "my-worker",
+    "content": "addEventListener('fetch', event => { event.respondWith(new Response('Hello')); });"
+  }
+}`,
+			Expected: `{
+  "schema_version": 0,
+  "attributes": {
+    "account_id": "f037e56e89293a057740de681ac9abbe",
+    "script_name": "my-worker",
+    "content": "addEventListener('fetch', event => { event.respondWith(new Response('Hello')); });"
+  }
+}`,
+		},
+		{
+			Name: "remove tags field",
+			Input: `{
+  "schema_version": 1,
+  "attributes": {
+    "account_id": "f037e56e89293a057740de681ac9abbe",
+    "name": "my-worker",
+    "content": "addEventListener('fetch', event => { event.respondWith(new Response('Hello')); });",
+    "tags": ["production", "api"]
+  }
+}`,
+			Expected: `{
+  "schema_version": 0,
+  "attributes": {
+    "account_id": "f037e56e89293a057740de681ac9abbe",
+    "script_name": "my-worker",
+    "content": "addEventListener('fetch', event => { event.respondWith(new Response('Hello')); });"
+  }
+}`,
+		},
+	}
+
+	testhelpers.RunStateTransformTests(t, tests, migrator)
+}
+
+func TestWorkerScriptStateTransform_Bindings(t *testing.T) {
+	migrator := NewV4ToV5Migrator()
+
+	tests := []testhelpers.StateTestCase{
+		{
+			Name: "plain_text_binding array conversion",
+			Input: `{
+  "schema_version": 1,
+  "attributes": {
+    "account_id": "f037e56e89293a057740de681ac9abbe",
+    "name": "my-worker",
+    "content": "addEventListener('fetch', event => { event.respondWith(new Response('Hello')); });",
+    "plain_text_binding": [
+      {
+        "name": "MY_VAR",
+        "text": "my-value"
+      }
+    ]
+  }
+}`,
+			Expected: `{
+  "schema_version": 0,
+  "attributes": {
+    "account_id": "f037e56e89293a057740de681ac9abbe",
+    "script_name": "my-worker",
+    "content": "addEventListener('fetch', event => { event.respondWith(new Response('Hello')); });",
+    "bindings": [
+      {
+        "type": "plain_text",
+        "name": "MY_VAR",
+        "text": "my-value"
+      }
+    ]
+  }
+}`,
+		},
+		{
+			Name: "kv_namespace_binding array conversion",
+			Input: `{
+  "schema_version": 1,
+  "attributes": {
+    "account_id": "f037e56e89293a057740de681ac9abbe",
+    "name": "my-worker",
+    "content": "addEventListener('fetch', event => { event.respondWith(new Response('Hello')); });",
+    "kv_namespace_binding": [
+      {
+        "name": "MY_KV",
+        "namespace_id": "abc123"
+      }
+    ]
+  }
+}`,
+			Expected: `{
+  "schema_version": 0,
+  "attributes": {
+    "account_id": "f037e56e89293a057740de681ac9abbe",
+    "script_name": "my-worker",
+    "content": "addEventListener('fetch', event => { event.respondWith(new Response('Hello')); });",
+    "bindings": [
+      {
+        "type": "kv_namespace",
+        "name": "MY_KV",
+        "namespace_id": "abc123"
+      }
+    ]
+  }
+}`,
+		},
+		{
+			Name: "webassembly_binding to wasm_module with attribute rename",
+			Input: `{
+  "schema_version": 1,
+  "attributes": {
+    "account_id": "f037e56e89293a057740de681ac9abbe",
+    "name": "my-worker",
+    "content": "addEventListener('fetch', event => { event.respondWith(new Response('Hello')); });",
+    "webassembly_binding": [
+      {
+        "name": "WASM",
+        "module": "base64content"
+      }
+    ]
+  }
+}`,
+			Expected: `{
+  "schema_version": 0,
+  "attributes": {
+    "account_id": "f037e56e89293a057740de681ac9abbe",
+    "script_name": "my-worker",
+    "content": "addEventListener('fetch', event => { event.respondWith(new Response('Hello')); });",
+    "bindings": [
+      {
+        "type": "wasm_module",
+        "name": "WASM",
+        "part": "base64content"
+      }
+    ]
+  }
+}`,
+		},
+		{
+			Name: "queue_binding with attribute renames",
+			Input: `{
+  "schema_version": 1,
+  "attributes": {
+    "account_id": "f037e56e89293a057740de681ac9abbe",
+    "name": "my-worker",
+    "content": "addEventListener('fetch', event => { event.respondWith(new Response('Hello')); });",
+    "queue_binding": [
+      {
+        "binding": "MY_QUEUE",
+        "queue": "my-queue"
+      }
+    ]
+  }
+}`,
+			Expected: `{
+  "schema_version": 0,
+  "attributes": {
+    "account_id": "f037e56e89293a057740de681ac9abbe",
+    "script_name": "my-worker",
+    "content": "addEventListener('fetch', event => { event.respondWith(new Response('Hello')); });",
+    "bindings": [
+      {
+        "type": "queue",
+        "name": "MY_QUEUE",
+        "queue_name": "my-queue"
+      }
+    ]
+  }
+}`,
+		},
+		{
+			Name: "d1_database_binding with attribute rename",
+			Input: `{
+  "schema_version": 1,
+  "attributes": {
+    "account_id": "f037e56e89293a057740de681ac9abbe",
+    "name": "my-worker",
+    "content": "addEventListener('fetch', event => { event.respondWith(new Response('Hello')); });",
+    "d1_database_binding": [
+      {
+        "name": "MY_DB",
+        "database_id": "db-uuid-123"
+      }
+    ]
+  }
+}`,
+			Expected: `{
+  "schema_version": 0,
+  "attributes": {
+    "account_id": "f037e56e89293a057740de681ac9abbe",
+    "script_name": "my-worker",
+    "content": "addEventListener('fetch', event => { event.respondWith(new Response('Hello')); });",
+    "bindings": [
+      {
+        "type": "d1",
+        "name": "MY_DB",
+        "id": "db-uuid-123"
+      }
+    ]
+  }
+}`,
+		},
+		{
+			Name: "hyperdrive_config_binding with attribute rename",
+			Input: `{
+  "schema_version": 1,
+  "attributes": {
+    "account_id": "f037e56e89293a057740de681ac9abbe",
+    "name": "my-worker",
+    "content": "addEventListener('fetch', event => { event.respondWith(new Response('Hello')); });",
+    "hyperdrive_config_binding": [
+      {
+        "binding": "HYPERDRIVE",
+        "id": "hyperdrive-uuid-123"
+      }
+    ]
+  }
+}`,
+			Expected: `{
+  "schema_version": 0,
+  "attributes": {
+    "account_id": "f037e56e89293a057740de681ac9abbe",
+    "script_name": "my-worker",
+    "content": "addEventListener('fetch', event => { event.respondWith(new Response('Hello')); });",
+    "bindings": [
+      {
+        "type": "hyperdrive",
+        "name": "HYPERDRIVE",
+        "id": "hyperdrive-uuid-123"
+      }
+    ]
+  }
+}`,
+		},
+		{
+			Name: "dispatch_namespace attribute conversion",
+			Input: `{
+  "schema_version": 1,
+  "attributes": {
+    "account_id": "f037e56e89293a057740de681ac9abbe",
+    "name": "my-worker",
+    "content": "addEventListener('fetch', event => { event.respondWith(new Response('Hello')); });",
+    "dispatch_namespace": "my-namespace"
+  }
+}`,
+			Expected: `{
+  "schema_version": 0,
+  "attributes": {
+    "account_id": "f037e56e89293a057740de681ac9abbe",
+    "script_name": "my-worker",
+    "content": "addEventListener('fetch', event => { event.respondWith(new Response('Hello')); });",
+    "bindings": [
+      {
+        "type": "dispatch_namespace",
+        "namespace": "my-namespace"
+      }
+    ]
+  }
+}`,
+		},
+		{
+			Name: "multiple bindings of different types",
+			Input: `{
+  "schema_version": 1,
+  "attributes": {
+    "account_id": "f037e56e89293a057740de681ac9abbe",
+    "name": "my-worker",
+    "content": "addEventListener('fetch', event => { event.respondWith(new Response('Hello')); });",
+    "plain_text_binding": [
+      {
+        "name": "VAR1",
+        "text": "value1"
+      }
+    ],
+    "kv_namespace_binding": [
+      {
+        "name": "KV1",
+        "namespace_id": "kv-123"
+      }
+    ],
+    "d1_database_binding": [
+      {
+        "name": "DB1",
+        "database_id": "db-456"
+      }
+    ]
+  }
+}`,
+			Expected: `{
+  "schema_version": 0,
+  "attributes": {
+    "account_id": "f037e56e89293a057740de681ac9abbe",
+    "script_name": "my-worker",
+    "content": "addEventListener('fetch', event => { event.respondWith(new Response('Hello')); });",
+    "bindings": [
+      {
+        "type": "plain_text",
+        "name": "VAR1",
+        "text": "value1"
+      },
+      {
+        "type": "kv_namespace",
+        "name": "KV1",
+        "namespace_id": "kv-123"
+      },
+      {
+        "type": "d1",
+        "name": "DB1",
+        "id": "db-456"
+      }
+    ]
+  }
+}`,
+		},
+	}
+
+	testhelpers.RunStateTransformTests(t, tests, migrator)
+}
+
+func TestWorkerScriptStateTransform_Module(t *testing.T) {
+	migrator := NewV4ToV5Migrator()
+
+	tests := []testhelpers.StateTestCase{
+		{
+			Name: "module = true becomes main_module",
+			Input: `{
+  "schema_version": 1,
+  "attributes": {
+    "account_id": "f037e56e89293a057740de681ac9abbe",
+    "name": "my-worker",
+    "content": "export default { fetch() { return new Response('Hello'); } };",
+    "module": true
+  }
+}`,
+			Expected: `{
+  "schema_version": 0,
+  "attributes": {
+    "account_id": "f037e56e89293a057740de681ac9abbe",
+    "script_name": "my-worker",
+    "content": "export default { fetch() { return new Response('Hello'); } };",
+    "main_module": "worker.js"
+  }
+}`,
+		},
+		{
+			Name: "module = false becomes body_part",
+			Input: `{
+  "schema_version": 1,
+  "attributes": {
+    "account_id": "f037e56e89293a057740de681ac9abbe",
+    "name": "my-worker",
+    "content": "addEventListener('fetch', event => { event.respondWith(new Response('Hello')); });",
+    "module": false
+  }
+}`,
+			Expected: `{
+  "schema_version": 0,
+  "attributes": {
+    "account_id": "f037e56e89293a057740de681ac9abbe",
+    "script_name": "my-worker",
+    "content": "addEventListener('fetch', event => { event.respondWith(new Response('Hello')); });",
+    "body_part": "worker.js"
+  }
+}`,
+		},
+	}
+
+	testhelpers.RunStateTransformTests(t, tests, migrator)
+}
+
+func TestWorkerScriptStateTransform_Comprehensive(t *testing.T) {
+	migrator := NewV4ToV5Migrator()
+
+	tests := []testhelpers.StateTestCase{
+		{
+			Name: "comprehensive transformation with all features",
+			Input: `{
+  "schema_version": 1,
+  "attributes": {
+    "account_id": "f037e56e89293a057740de681ac9abbe",
+    "name": "comprehensive-worker",
+    "content": "export default { fetch() { return new Response('Hello'); } };",
+    "module": true,
+    "dispatch_namespace": "my-namespace",
+    "tags": ["production", "api"],
+    "plain_text_binding": [
+      {
+        "name": "API_KEY",
+        "text": "test-key"
+      }
+    ],
+    "kv_namespace_binding": [
+      {
+        "name": "KV_STORE",
+        "namespace_id": "kv-123"
+      }
+    ]
+  }
+}`,
+			Expected: `{
+  "schema_version": 0,
+  "attributes": {
+    "account_id": "f037e56e89293a057740de681ac9abbe",
+    "script_name": "comprehensive-worker",
+    "content": "export default { fetch() { return new Response('Hello'); } };",
+    "main_module": "worker.js",
+    "bindings": [
+      {
+        "type": "plain_text",
+        "name": "API_KEY",
+        "text": "test-key"
+      },
+      {
+        "type": "kv_namespace",
+        "name": "KV_STORE",
+        "namespace_id": "kv-123"
+      },
+      {
+        "type": "dispatch_namespace",
+        "namespace": "my-namespace"
+      }
+    ]
+  }
+}`,
+		},
+	}
+
+	testhelpers.RunStateTransformTests(t, tests, migrator)
+}
+
+func TestWorkerScriptConfigTransform_Bindings(t *testing.T) {
+	migrator := NewV4ToV5Migrator()
+
+	tests := []testhelpers.ConfigTestCase{
+		{
+			Name: "plain_text_binding conversion",
+			Input: `resource "cloudflare_workers_script" "example" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+  name       = "my-worker"
+  content    = "addEventListener('fetch', event => { event.respondWith(new Response('Hello')); });"
+
+  plain_text_binding {
+    name = "MY_VAR"
+    text = "my-value"
+  }
+}`,
+			Expected: `resource "cloudflare_workers_script" "example" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+  content    = "addEventListener('fetch', event => { event.respondWith(new Response('Hello')); });"
+
+  script_name = "my-worker"
+  bindings = [
+    {
+      type = "plain_text"
+      name = "MY_VAR"
+      text = "my-value"
+    }
+  ]
+}`,
+		},
+		{
+			Name: "kv_namespace_binding conversion",
+			Input: `resource "cloudflare_workers_script" "example" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+  name       = "my-worker"
+  content    = "addEventListener('fetch', event => { event.respondWith(new Response('Hello')); });"
+
+  kv_namespace_binding {
+    name         = "MY_KV"
+    namespace_id = "abc123"
+  }
+}`,
+			Expected: `resource "cloudflare_workers_script" "example" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+  content    = "addEventListener('fetch', event => { event.respondWith(new Response('Hello')); });"
+
+  script_name = "my-worker"
+  bindings = [
+    {
+      type         = "kv_namespace"
+      name         = "MY_KV"
+      namespace_id = "abc123"
+    }
+  ]
+}`,
+		},
+		{
+			Name: "webassembly_binding to wasm_module with attribute rename",
+			Input: `resource "cloudflare_workers_script" "example" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+  name       = "my-worker"
+  content    = "addEventListener('fetch', event => { event.respondWith(new Response('Hello')); });"
+
+  webassembly_binding {
+    name   = "WASM"
+    module = "base64content"
+  }
+}`,
+			Expected: `resource "cloudflare_workers_script" "example" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+  content    = "addEventListener('fetch', event => { event.respondWith(new Response('Hello')); });"
+
+  script_name = "my-worker"
+  bindings = [
+    {
+      type = "wasm_module"
+      name = "WASM"
+      part = "base64content"
+    }
+  ]
+}`,
+		},
+		{
+			Name: "queue_binding with attribute renames",
+			Input: `resource "cloudflare_workers_script" "example" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+  name       = "my-worker"
+  content    = "addEventListener('fetch', event => { event.respondWith(new Response('Hello')); });"
+
+  queue_binding {
+    binding = "MY_QUEUE"
+    queue   = "my-queue"
+  }
+}`,
+			Expected: `resource "cloudflare_workers_script" "example" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+  content    = "addEventListener('fetch', event => { event.respondWith(new Response('Hello')); });"
+
+  script_name = "my-worker"
+  bindings = [
+    {
+      type       = "queue"
+      name       = "MY_QUEUE"
+      queue_name = "my-queue"
+    }
+  ]
+}`,
+		},
+		{
+			Name: "d1_database_binding with attribute rename",
+			Input: `resource "cloudflare_workers_script" "example" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+  name       = "my-worker"
+  content    = "addEventListener('fetch', event => { event.respondWith(new Response('Hello')); });"
+
+  d1_database_binding {
+    name        = "MY_DB"
+    database_id = "db-uuid-123"
+  }
+}`,
+			Expected: `resource "cloudflare_workers_script" "example" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+  content    = "addEventListener('fetch', event => { event.respondWith(new Response('Hello')); });"
+
+  script_name = "my-worker"
+  bindings = [
+    {
+      type = "d1"
+      name = "MY_DB"
+      id   = "db-uuid-123"
+    }
+  ]
+}`,
+		},
+		{
+			Name: "hyperdrive_config_binding with attribute rename",
+			Input: `resource "cloudflare_workers_script" "example" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+  name       = "my-worker"
+  content    = "addEventListener('fetch', event => { event.respondWith(new Response('Hello')); });"
+
+  hyperdrive_config_binding {
+    binding = "HYPERDRIVE"
+    id      = "hyperdrive-uuid-123"
+  }
+}`,
+			Expected: `resource "cloudflare_workers_script" "example" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+  content    = "addEventListener('fetch', event => { event.respondWith(new Response('Hello')); });"
+
+  script_name = "my-worker"
+  bindings = [
+    {
+      type = "hyperdrive"
+      name = "HYPERDRIVE"
+      id   = "hyperdrive-uuid-123"
+    }
+  ]
+}`,
+		},
+		{
+			Name: "dispatch_namespace attribute conversion",
+			Input: `resource "cloudflare_workers_script" "example" {
+  account_id         = "f037e56e89293a057740de681ac9abbe"
+  name               = "my-worker"
+  content            = "addEventListener('fetch', event => { event.respondWith(new Response('Hello')); });"
+  dispatch_namespace = "my-namespace"
+}`,
+			Expected: `resource "cloudflare_workers_script" "example" {
+  account_id  = "f037e56e89293a057740de681ac9abbe"
+  content     = "addEventListener('fetch', event => { event.respondWith(new Response('Hello')); });"
+  script_name = "my-worker"
+  bindings = [
+    {
+      type      = "dispatch_namespace"
+      namespace = "my-namespace"
+    }
+  ]
+}`,
+		},
+		{
+			Name: "multiple bindings of different types",
+			Input: `resource "cloudflare_workers_script" "example" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+  name       = "my-worker"
+  content    = "addEventListener('fetch', event => { event.respondWith(new Response('Hello')); });"
+
+  plain_text_binding {
+    name = "VAR1"
+    text = "value1"
+  }
+
+  kv_namespace_binding {
+    name         = "KV1"
+    namespace_id = "kv-123"
+  }
+
+  d1_database_binding {
+    name        = "DB1"
+    database_id = "db-456"
+  }
+}`,
+			Expected: `resource "cloudflare_workers_script" "example" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+  content    = "addEventListener('fetch', event => { event.respondWith(new Response('Hello')); });"
+
+  script_name = "my-worker"
+  bindings = [
+    {
+      type = "plain_text"
+      name = "VAR1"
+      text = "value1"
+    }, {
+      type         = "kv_namespace"
+      name         = "KV1"
+      namespace_id = "kv-123"
+    }, {
+      type = "d1"
+      name = "DB1"
+      id   = "db-456"
+    }
+  ]
+}`,
+		},
+	}
+
+	testhelpers.RunConfigTransformTests(t, tests, migrator)
+}
+
+func TestWorkerScriptConfigTransform_Module(t *testing.T) {
+	migrator := NewV4ToV5Migrator()
+
+	tests := []testhelpers.ConfigTestCase{
+		{
+			Name: "module = true becomes main_module",
+			Input: `resource "cloudflare_workers_script" "example" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+  name       = "my-worker"
+  content    = "export default { fetch() { return new Response('Hello'); } };"
+  module     = true
+}`,
+			Expected: `resource "cloudflare_workers_script" "example" {
+  account_id  = "f037e56e89293a057740de681ac9abbe"
+  content     = "export default { fetch() { return new Response('Hello'); } };"
+  script_name = "my-worker"
+  main_module = "worker.js"
+}`,
+		},
+		{
+			Name: "module = false becomes body_part",
+			Input: `resource "cloudflare_workers_script" "example" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+  name       = "my-worker"
+  content    = "addEventListener('fetch', event => { event.respondWith(new Response('Hello')); });"
+  module     = false
+}`,
+			Expected: `resource "cloudflare_workers_script" "example" {
+  account_id  = "f037e56e89293a057740de681ac9abbe"
+  content     = "addEventListener('fetch', event => { event.respondWith(new Response('Hello')); });"
+  script_name = "my-worker"
+  body_part   = "worker.js"
+}`,
+		},
+	}
+
+	testhelpers.RunConfigTransformTests(t, tests, migrator)
+}
+
+func TestWorkerScriptConfigTransform_Placement(t *testing.T) {
+	migrator := NewV4ToV5Migrator()
+
+	tests := []testhelpers.ConfigTestCase{
+		{
+			Name: "placement block to object attribute",
+			Input: `resource "cloudflare_workers_script" "example" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+  name       = "my-worker"
+  content    = "addEventListener('fetch', event => { event.respondWith(new Response('Hello')); });"
+
+  placement {
+    mode = "smart"
+  }
+}`,
+			Expected: `resource "cloudflare_workers_script" "example" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+  content    = "addEventListener('fetch', event => { event.respondWith(new Response('Hello')); });"
+
+  script_name = "my-worker"
+  placement = {
+    mode = "smart"
+  }
+}`,
+		},
+	}
+
+	testhelpers.RunConfigTransformTests(t, tests, migrator)
+}
+
+func TestWorkerScriptConfigTransform_Comprehensive(t *testing.T) {
+	migrator := NewV4ToV5Migrator()
+
+	tests := []testhelpers.ConfigTestCase{
+		{
+			Name: "comprehensive transformation with all features",
+			Input: `resource "cloudflare_workers_script" "comprehensive" {
+  account_id         = "f037e56e89293a057740de681ac9abbe"
+  name               = "comprehensive-worker"
+  content            = "export default { fetch() { return new Response('Hello'); } };"
+  module             = true
+  dispatch_namespace = "my-namespace"
+  tags               = ["production", "api"]
+
+  plain_text_binding {
+    name = "API_KEY"
+    text = "test-key"
+  }
+
+  kv_namespace_binding {
+    name         = "KV_STORE"
+    namespace_id = "kv-123"
+  }
+
+  placement {
+    mode = "smart"
+  }
+}`,
+			Expected: `resource "cloudflare_workers_script" "comprehensive" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+  content    = "export default { fetch() { return new Response('Hello'); } };"
+
+  script_name = "comprehensive-worker"
+  bindings = [
+    {
+      type = "plain_text"
+      name = "API_KEY"
+      text = "test-key"
+    }, {
+      type         = "kv_namespace"
+      name         = "KV_STORE"
+      namespace_id = "kv-123"
+    }, {
+      type      = "dispatch_namespace"
+      namespace = "my-namespace"
+    }
+  ]
+  main_module = "worker.js"
+  placement = {
+    mode = "smart"
+  }
+}`,
+		},
+	}
+
+	testhelpers.RunConfigTransformTests(t, tests, migrator)
+}

--- a/internal/resources/workers_script/v4_to_v5_test.go
+++ b/internal/resources/workers_script/v4_to_v5_test.go
@@ -70,7 +70,7 @@ func TestWorkerScriptStateTransform_BasicRename(t *testing.T) {
   }
 }`,
 			Expected: `{
-  "schema_version": 0,
+  "schema_version": 1,
   "attributes": {
     "account_id": "f037e56e89293a057740de681ac9abbe",
     "script_name": "my-worker",
@@ -90,7 +90,7 @@ func TestWorkerScriptStateTransform_BasicRename(t *testing.T) {
   }
 }`,
 			Expected: `{
-  "schema_version": 0,
+  "schema_version": 1,
   "attributes": {
     "account_id": "f037e56e89293a057740de681ac9abbe",
     "script_name": "my-worker",
@@ -124,7 +124,7 @@ func TestWorkerScriptStateTransform_Bindings(t *testing.T) {
   }
 }`,
 			Expected: `{
-  "schema_version": 0,
+  "schema_version": 1,
   "attributes": {
     "account_id": "f037e56e89293a057740de681ac9abbe",
     "script_name": "my-worker",
@@ -156,7 +156,7 @@ func TestWorkerScriptStateTransform_Bindings(t *testing.T) {
   }
 }`,
 			Expected: `{
-  "schema_version": 0,
+  "schema_version": 1,
   "attributes": {
     "account_id": "f037e56e89293a057740de681ac9abbe",
     "script_name": "my-worker",
@@ -188,7 +188,7 @@ func TestWorkerScriptStateTransform_Bindings(t *testing.T) {
   }
 }`,
 			Expected: `{
-  "schema_version": 0,
+  "schema_version": 1,
   "attributes": {
     "account_id": "f037e56e89293a057740de681ac9abbe",
     "script_name": "my-worker",
@@ -220,7 +220,7 @@ func TestWorkerScriptStateTransform_Bindings(t *testing.T) {
   }
 }`,
 			Expected: `{
-  "schema_version": 0,
+  "schema_version": 1,
   "attributes": {
     "account_id": "f037e56e89293a057740de681ac9abbe",
     "script_name": "my-worker",
@@ -252,7 +252,7 @@ func TestWorkerScriptStateTransform_Bindings(t *testing.T) {
   }
 }`,
 			Expected: `{
-  "schema_version": 0,
+  "schema_version": 1,
   "attributes": {
     "account_id": "f037e56e89293a057740de681ac9abbe",
     "script_name": "my-worker",
@@ -284,7 +284,7 @@ func TestWorkerScriptStateTransform_Bindings(t *testing.T) {
   }
 }`,
 			Expected: `{
-  "schema_version": 0,
+  "schema_version": 1,
   "attributes": {
     "account_id": "f037e56e89293a057740de681ac9abbe",
     "script_name": "my-worker",
@@ -311,7 +311,7 @@ func TestWorkerScriptStateTransform_Bindings(t *testing.T) {
   }
 }`,
 			Expected: `{
-  "schema_version": 0,
+  "schema_version": 1,
   "attributes": {
     "account_id": "f037e56e89293a057740de681ac9abbe",
     "script_name": "my-worker",
@@ -354,7 +354,7 @@ func TestWorkerScriptStateTransform_Bindings(t *testing.T) {
   }
 }`,
 			Expected: `{
-  "schema_version": 0,
+  "schema_version": 1,
   "attributes": {
     "account_id": "f037e56e89293a057740de681ac9abbe",
     "script_name": "my-worker",
@@ -400,7 +400,7 @@ func TestWorkerScriptStateTransform_Module(t *testing.T) {
   }
 }`,
 			Expected: `{
-  "schema_version": 0,
+  "schema_version": 1,
   "attributes": {
     "account_id": "f037e56e89293a057740de681ac9abbe",
     "script_name": "my-worker",
@@ -421,7 +421,7 @@ func TestWorkerScriptStateTransform_Module(t *testing.T) {
   }
 }`,
 			Expected: `{
-  "schema_version": 0,
+  "schema_version": 1,
   "attributes": {
     "account_id": "f037e56e89293a057740de681ac9abbe",
     "script_name": "my-worker",
@@ -465,7 +465,7 @@ func TestWorkerScriptStateTransform_Comprehensive(t *testing.T) {
   }
 }`,
 			Expected: `{
-  "schema_version": 0,
+  "schema_version": 1,
   "attributes": {
     "account_id": "f037e56e89293a057740de681ac9abbe",
     "script_name": "comprehensive-worker",


### PR DESCRIPTION
Adds support for phase 0 resource, workers_script. 

Updates:
- All `*name*_binding`, `dispatch_namespace` blocks are all being covered by one `binding` block with corresponding types.
- `placement` goes from block to attribute. 
- `module` bool → main_module/body_part strings (conditional logic)
- `tags` should be removed