### PR TITLE
feat(snippet): add v4 to v5 migration for snippet

### DIFF
--- a/integration/v4_to_v5/testdata/snippet/expected/snippet.tf
+++ b/integration/v4_to_v5/testdata/snippet/expected/snippet.tf
@@ -1,0 +1,278 @@
+# Comprehensive snippet integration test data
+
+variable "cloudflare_account_id" {
+  description = "Cloudflare account ID"
+  type        = string
+}
+
+variable "cloudflare_zone_id" {
+  description = "Cloudflare zone ID"
+  type        = string
+}
+
+locals {
+  name_prefix = "cftftest"
+  zone_id     = "abc123def456"
+}
+
+variable "snippet_name" {
+  type    = string
+  default = "test_snippet"
+}
+
+variable "main_module_file" {
+  type    = string
+  default = "index.js"
+}
+
+# Test 1: Minimal snippet with single file
+resource "cloudflare_snippet" "minimal" {
+  zone_id = var.cloudflare_zone_id
+
+  snippet_name = "${local.name_prefix}_minimal"
+  files = [{
+    name    = "main.js"
+    content = <<-EOT
+      export default {
+        async fetch(request, env, ctx) {
+          const response = await fetch(request);
+          const newHeaders = new Headers(response.headers);
+          
+          // Your custom logic here
+          newHeaders.set("x-snippet-type", "inline-terraform-string");
+
+          return new Response(response.body, {
+            status: response.status,
+            statusText: response.statusText,
+            headers: newHeaders,
+          });
+        }
+      };
+    EOT
+  }]
+  metadata = {
+    main_module = "main.js"
+  }
+}
+
+# Test 2: Snippet with multiple files
+resource "cloudflare_snippet" "multi_file" {
+  zone_id = var.cloudflare_zone_id
+
+
+
+  snippet_name = "${local.name_prefix}_multi"
+  files = [{
+    name    = "index.js"
+    content = "export default { fetch() { return new Response('Hello'); } }"
+    }, {
+    name    = "utils.js"
+    content = "export function helper() { return 42; }"
+    }, {
+    name    = "config.js"
+    content = "export default {\"key\": \"value\"};"
+  }]
+  metadata = {
+    main_module = "index.js"
+  }
+}
+
+# Test 3: Snippet with special characters in content
+resource "cloudflare_snippet" "special_chars" {
+  zone_id = var.cloudflare_zone_id
+
+  snippet_name = "${local.name_prefix}_special"
+  files = [{
+    name    = "special.js"
+    content = "export default { fetch() { const msg = \"Hello, \\\"World\\\"!\"; return new Response(msg); } }"
+  }]
+  metadata = {
+    main_module = "special.js"
+  }
+}
+
+# Test 4: Snippet using count
+resource "cloudflare_snippet" "with_count" {
+  count   = 3
+  zone_id = var.cloudflare_zone_id
+
+  snippet_name = "${local.name_prefix}_count_${count.index}"
+  files = [{
+    name    = "main.js"
+    content = "export default { fetch(r) { console.log('Index: ${count.index}'); return fetch(r); } }"
+  }]
+  metadata = {
+    main_module = "main.js"
+  }
+}
+
+# Test 5: Snippet using for_each with set
+resource "cloudflare_snippet" "with_for_each_set" {
+  for_each = toset(["api", "web", "worker"])
+
+  zone_id = var.cloudflare_zone_id
+
+  snippet_name = "${local.name_prefix}_${each.value}"
+  files = [{
+    name    = "${each.value}.js"
+    content = "export default { fetch(r) { return fetch(r); } }; // Snippet for ${each.value}"
+  }]
+  metadata = {
+    main_module = "${each.value}.js"
+  }
+}
+
+# Test 6: Snippet using for_each with map
+resource "cloudflare_snippet" "with_for_each_map" {
+  for_each = {
+    prod    = "production.js"
+    staging = "staging.js"
+    dev     = "development.js"
+  }
+
+  zone_id = var.cloudflare_zone_id
+
+  snippet_name = "${local.name_prefix}_${each.key}"
+  files = [{
+    name    = each.value
+    content = "export default { fetch(r) { return fetch(r); } }; // Environment: ${each.key}"
+  }]
+  metadata = {
+    main_module = each.value
+  }
+}
+
+# Test 7: Snippet with conditional (ternary operator)
+resource "cloudflare_snippet" "conditional" {
+  zone_id = var.cloudflare_zone_id
+
+  snippet_name = "${local.name_prefix}_conditional"
+  files = [{
+    name    = var.snippet_name != "" ? "custom.js" : "default.js"
+    content = "export default { fetch(r) { return fetch(r); } }; ${var.snippet_name != "" ? "// Custom" : "// Default"}"
+  }]
+  metadata = {
+    main_module = var.snippet_name != "" ? "custom.js" : "default.js"
+  }
+}
+
+# Test 8: Snippet with multiline content
+resource "cloudflare_snippet" "multiline" {
+  zone_id = var.cloudflare_zone_id
+
+  snippet_name = "${local.name_prefix}_multiline"
+  files = [{
+    name    = "app.js"
+    content = <<-EOT
+      export default {
+        async fetch(request) {
+          return new Response('Hello World!');
+        }
+      }
+    EOT
+  }]
+  metadata = {
+    main_module = "app.js"
+  }
+}
+
+# Test 9: Snippet with jsonencode function
+resource "cloudflare_snippet" "with_jsonencode" {
+  zone_id = var.cloudflare_zone_id
+
+  snippet_name = "${local.name_prefix}_json"
+  files = [{
+    name    = "index.js"
+    content = "const config = ${jsonencode({ key = "value", debug = true })}; export default { fetch(r) { return new Response(JSON.stringify(config)); } }"
+  }]
+  metadata = {
+    main_module = "index.js"
+  }
+}
+
+# Test 10: Snippet with interpolation in all fields
+resource "cloudflare_snippet" "interpolated" {
+  zone_id = "${var.cloudflare_zone_id}"
+
+  snippet_name = "${local.name_prefix}_interpolated"
+  files = [{
+    name    = "${var.main_module_file}"
+    content = "export default { fetch(r) { return fetch(r); } }; // ${var.snippet_name}"
+  }]
+  metadata = {
+    main_module = "${var.main_module_file}"
+  }
+}
+
+# Test 11: Snippet with lifecycle meta-argument
+resource "cloudflare_snippet" "with_lifecycle" {
+  zone_id = var.cloudflare_zone_id
+
+
+  lifecycle {
+    create_before_destroy = true
+    ignore_changes        = [files]
+  }
+  snippet_name = "${local.name_prefix}_lifecycle"
+  files = [{
+    name    = "main.js"
+    content = "export default { fetch(r) { return fetch(r); } }; // Lifecycle test"
+  }]
+  metadata = {
+    main_module = "main.js"
+  }
+}
+
+# Test 12: Snippet with depends_on
+resource "cloudflare_snippet" "with_depends_on" {
+  depends_on = [cloudflare_snippet.minimal]
+
+  zone_id = var.cloudflare_zone_id
+
+  snippet_name = "${local.name_prefix}_depends"
+  files = [{
+    name    = "dependent.js"
+    content = "export default { fetch(r) { return fetch(r); } }; // Depends on minimal snippet"
+  }]
+  metadata = {
+    main_module = "dependent.js"
+  }
+}
+
+# Test 13: Snippet with long content
+resource "cloudflare_snippet" "long_content" {
+  zone_id = var.cloudflare_zone_id
+
+  snippet_name = "${local.name_prefix}_long"
+  files = [{
+    name    = "worker.js"
+    content = <<-EOT
+      // This is a comprehensive worker script
+      export default {
+        async fetch(request, env, ctx) {
+          const url = new URL(request.url);
+
+          // Handle different routes
+          switch (url.pathname) {
+            case '/api':
+              return handleAPI(request);
+            case '/health':
+              return new Response('OK', { status: 200 });
+            default:
+              return new Response('Not Found', { status: 404 });
+          }
+        }
+      }
+
+      async function handleAPI(request) {
+        const data = await request.json();
+        return new Response(JSON.stringify(data), {
+          headers: { 'Content-Type': 'application/json' }
+        });
+      }
+    EOT
+  }]
+  metadata = {
+    main_module = "worker.js"
+  }
+}

--- a/integration/v4_to_v5/testdata/snippet/expected/terraform.tfstate
+++ b/integration/v4_to_v5/testdata/snippet/expected/terraform.tfstate
@@ -1,0 +1,434 @@
+{
+  "lineage": "test-lineage",
+  "outputs": {},
+  "resources": [
+    {
+      "instances": [
+        {
+          "attributes": {
+            "zone_id": "abc123def456",
+            "snippet_name": "cftftest_minimal",
+            "files": [
+              {
+                "name": "main.js",
+                "content": "export default {\n  async fetch(request, env, ctx) {\n    const response = await fetch(request);\n    const newHeaders = new Headers(response.headers);\n    \n    // Your custom logic here\n    newHeaders.set(\"x-snippet-type\", \"inline-terraform-string\");\n\n    return new Response(response.body, {\n      status: response.status,\n      statusText: response.statusText,\n      headers: newHeaders,\n    });\n  }\n};\n"
+              }
+            ],
+            "metadata": {
+              "main_module": "main.js"
+            }
+          },
+          "schema_version": 0
+        }
+      ],
+      "mode": "managed",
+      "name": "minimal",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_snippet"
+    },
+    {
+      "instances": [
+        {
+          "attributes": {
+            "zone_id": "abc123def456",
+            "snippet_name": "cftftest_multi",
+            "files": [
+              {
+                "name": "index.js",
+                "content": "export default { fetch() { return new Response('Hello'); } }"
+              },
+              {
+                "name": "utils.js",
+                "content": "export function helper() { return 42; }"
+              },
+              {
+                "name": "config.js",
+                "content": "export default {\"key\": \"value\"};"
+              }
+            ],
+            "metadata": {
+              "main_module": "index.js"
+            }
+          },
+          "schema_version": 0
+        }
+      ],
+      "mode": "managed",
+      "name": "multi_file",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_snippet"
+    },
+    {
+      "instances": [
+        {
+          "attributes": {
+            "zone_id": "abc123def456",
+            "snippet_name": "cftftest_special",
+            "files": [
+              {
+                "name": "special.js",
+                "content": "export default { fetch() { const msg = \"Hello, \\\"World\\\"!\"; return new Response(msg); } }"
+              }
+            ],
+            "metadata": {
+              "main_module": "special.js"
+            }
+          },
+          "schema_version": 0
+        }
+      ],
+      "mode": "managed",
+      "name": "special_chars",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_snippet"
+    },
+    {
+      "instances": [
+        {
+          "attributes": {
+            "zone_id": "abc123def456",
+            "snippet_name": "cftftest_count_0",
+            "files": [
+              {
+                "name": "main.js",
+                "content": "export default { fetch(r) { console.log('Index: 0'); return fetch(r); } }"
+              }
+            ],
+            "metadata": {
+              "main_module": "main.js"
+            }
+          },
+          "index_key": 0,
+          "schema_version": 0
+        },
+        {
+          "attributes": {
+            "zone_id": "abc123def456",
+            "snippet_name": "cftftest_count_1",
+            "files": [
+              {
+                "name": "main.js",
+                "content": "export default { fetch(r) { console.log('Index: 1'); return fetch(r); } }"
+              }
+            ],
+            "metadata": {
+              "main_module": "main.js"
+            }
+          },
+          "index_key": 1,
+          "schema_version": 0
+        },
+        {
+          "attributes": {
+            "zone_id": "abc123def456",
+            "snippet_name": "cftftest_count_2",
+            "files": [
+              {
+                "name": "main.js",
+                "content": "export default { fetch(r) { console.log('Index: 2'); return fetch(r); } }"
+              }
+            ],
+            "metadata": {
+              "main_module": "main.js"
+            }
+          },
+          "index_key": 2,
+          "schema_version": 0
+        }
+      ],
+      "mode": "managed",
+      "name": "with_count",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_snippet"
+    },
+    {
+      "instances": [
+        {
+          "attributes": {
+            "zone_id": "abc123def456",
+            "snippet_name": "cftftest_api",
+            "files": [
+              {
+                "name": "api.js",
+                "content": "export default { fetch(r) { return fetch(r); } }; // Snippet for api"
+              }
+            ],
+            "metadata": {
+              "main_module": "api.js"
+            }
+          },
+          "index_key": "api",
+          "schema_version": 0
+        },
+        {
+          "attributes": {
+            "zone_id": "abc123def456",
+            "snippet_name": "cftftest_web",
+            "files": [
+              {
+                "name": "web.js",
+                "content": "export default { fetch(r) { return fetch(r); } }; // Snippet for web"
+              }
+            ],
+            "metadata": {
+              "main_module": "web.js"
+            }
+          },
+          "index_key": "web",
+          "schema_version": 0
+        },
+        {
+          "attributes": {
+            "zone_id": "abc123def456",
+            "snippet_name": "cftftest_worker",
+            "files": [
+              {
+                "name": "worker.js",
+                "content": "export default { fetch(r) { return fetch(r); } }; // Snippet for worker"
+              }
+            ],
+            "metadata": {
+              "main_module": "worker.js"
+            }
+          },
+          "index_key": "worker",
+          "schema_version": 0
+        }
+      ],
+      "mode": "managed",
+      "name": "with_for_each_set",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_snippet"
+    },
+    {
+      "instances": [
+        {
+          "attributes": {
+            "zone_id": "abc123def456",
+            "snippet_name": "cftftest_dev",
+            "files": [
+              {
+                "name": "development.js",
+                "content": "export default { fetch(r) { return fetch(r); } }; // Environment: dev"
+              }
+            ],
+            "metadata": {
+              "main_module": "development.js"
+            }
+          },
+          "index_key": "dev",
+          "schema_version": 0
+        },
+        {
+          "attributes": {
+            "zone_id": "abc123def456",
+            "snippet_name": "cftftest_prod",
+            "files": [
+              {
+                "name": "production.js",
+                "content": "export default { fetch(r) { return fetch(r); } }; // Environment: prod"
+              }
+            ],
+            "metadata": {
+              "main_module": "production.js"
+            }
+          },
+          "index_key": "prod",
+          "schema_version": 0
+        },
+        {
+          "attributes": {
+            "zone_id": "abc123def456",
+            "snippet_name": "cftftest_staging",
+            "files": [
+              {
+                "name": "staging.js",
+                "content": "export default { fetch(r) { return fetch(r); } }; // Environment: staging"
+              }
+            ],
+            "metadata": {
+              "main_module": "staging.js"
+            }
+          },
+          "index_key": "staging",
+          "schema_version": 0
+        }
+      ],
+      "mode": "managed",
+      "name": "with_for_each_map",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_snippet"
+    },
+    {
+      "instances": [
+        {
+          "attributes": {
+            "zone_id": "abc123def456",
+            "snippet_name": "cftftest_conditional",
+            "files": [
+              {
+                "name": "custom.js",
+                "content": "export default { fetch(r) { return fetch(r); } }; // Custom"
+              }
+            ],
+            "metadata": {
+              "main_module": "custom.js"
+            }
+          },
+          "schema_version": 0
+        }
+      ],
+      "mode": "managed",
+      "name": "conditional",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_snippet"
+    },
+    {
+      "instances": [
+        {
+          "attributes": {
+            "zone_id": "abc123def456",
+            "snippet_name": "cftftest_multiline",
+            "files": [
+              {
+                "name": "app.js",
+                "content": "export default {\n  async fetch(request) {\n    return new Response('Hello World!');\n  }\n}\n"
+              }
+            ],
+            "metadata": {
+              "main_module": "app.js"
+            }
+          },
+          "schema_version": 0
+        }
+      ],
+      "mode": "managed",
+      "name": "multiline",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_snippet"
+    },
+    {
+      "instances": [
+        {
+          "attributes": {
+            "zone_id": "abc123def456",
+            "snippet_name": "cftftest_json",
+            "files": [
+              {
+                "name": "index.js",
+                "content": "const config = {\"debug\":true,\"key\":\"value\"}; export default { fetch(r) { return new Response(JSON.stringify(config)); } }"
+              }
+            ],
+            "metadata": {
+              "main_module": "index.js"
+            }
+          },
+          "schema_version": 0
+        }
+      ],
+      "mode": "managed",
+      "name": "with_jsonencode",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_snippet"
+    },
+    {
+      "instances": [
+        {
+          "attributes": {
+            "zone_id": "abc123def456",
+            "snippet_name": "cftftest_interpolated",
+            "files": [
+              {
+                "name": "index.js",
+                "content": "export default { fetch(r) { return fetch(r); } }; // test_snippet"
+              }
+            ],
+            "metadata": {
+              "main_module": "index.js"
+            }
+          },
+          "schema_version": 0
+        }
+      ],
+      "mode": "managed",
+      "name": "interpolated",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_snippet"
+    },
+    {
+      "instances": [
+        {
+          "attributes": {
+            "zone_id": "abc123def456",
+            "snippet_name": "cftftest_lifecycle",
+            "files": [
+              {
+                "name": "main.js",
+                "content": "export default { fetch(r) { return fetch(r); } }; // Lifecycle test"
+              }
+            ],
+            "metadata": {
+              "main_module": "main.js"
+            }
+          },
+          "schema_version": 0
+        }
+      ],
+      "mode": "managed",
+      "name": "with_lifecycle",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_snippet"
+    },
+    {
+      "instances": [
+        {
+          "attributes": {
+            "zone_id": "abc123def456",
+            "snippet_name": "cftftest_depends",
+            "files": [
+              {
+                "name": "dependent.js",
+                "content": "export default { fetch(r) { return fetch(r); } }; // Depends on minimal snippet"
+              }
+            ],
+            "metadata": {
+              "main_module": "dependent.js"
+            }
+          },
+          "schema_version": 0
+        }
+      ],
+      "mode": "managed",
+      "name": "with_depends_on",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_snippet"
+    },
+    {
+      "instances": [
+        {
+          "attributes": {
+            "zone_id": "abc123def456",
+            "snippet_name": "cftftest_long",
+            "files": [
+              {
+                "name": "worker.js",
+                "content": "// This is a comprehensive worker script\nexport default {\n  async fetch(request, env, ctx) {\n    const url = new URL(request.url);\n\n    // Handle different routes\n    switch (url.pathname) {\n      case '/api':\n        return handleAPI(request);\n      case '/health':\n        return new Response('OK', { status: 200 });\n      default:\n        return new Response('Not Found', { status: 404 });\n    }\n  }\n}\n\nasync function handleAPI(request) {\n  const data = await request.json();\n  return new Response(JSON.stringify(data), {\n    headers: { 'Content-Type': 'application/json' }\n  });\n}\n"
+              }
+            ],
+            "metadata": {
+              "main_module": "worker.js"
+            }
+          },
+          "schema_version": 0
+        }
+      ],
+      "mode": "managed",
+      "name": "long_content",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_snippet"
+    }
+  ],
+  "serial": 1,
+  "terraform_version": "1.5.0",
+  "version": 4
+}

--- a/integration/v4_to_v5/testdata/snippet/input/snippet.tf
+++ b/integration/v4_to_v5/testdata/snippet/input/snippet.tf
@@ -1,0 +1,254 @@
+# Comprehensive snippet integration test data
+
+variable "cloudflare_account_id" {
+  description = "Cloudflare account ID"
+  type        = string
+}
+
+variable "cloudflare_zone_id" {
+  description = "Cloudflare zone ID"
+  type        = string
+}
+
+locals {
+  name_prefix = "cftftest"
+  zone_id     = "abc123def456"
+}
+
+variable "snippet_name" {
+  type    = string
+  default = "test_snippet"
+}
+
+variable "main_module_file" {
+  type    = string
+  default = "index.js"
+}
+
+# Test 1: Minimal snippet with single file
+resource "cloudflare_snippet" "minimal" {
+  zone_id     = var.cloudflare_zone_id
+  name        = "${local.name_prefix}_minimal"
+  main_module = "main.js"
+
+  files {
+    name    = "main.js"
+    content = <<-EOT
+      export default {
+        async fetch(request, env, ctx) {
+          const response = await fetch(request);
+          const newHeaders = new Headers(response.headers);
+          
+          // Your custom logic here
+          newHeaders.set("x-snippet-type", "inline-terraform-string");
+
+          return new Response(response.body, {
+            status: response.status,
+            statusText: response.statusText,
+            headers: newHeaders,
+          });
+        }
+      };
+    EOT
+  }
+}
+
+# Test 2: Snippet with multiple files
+resource "cloudflare_snippet" "multi_file" {
+  zone_id     = var.cloudflare_zone_id
+  name        = "${local.name_prefix}_multi"
+  main_module = "index.js"
+
+  files {
+    name    = "index.js"
+    content = "export default { fetch() { return new Response('Hello'); } }"
+  }
+
+  files {
+    name    = "utils.js"
+    content = "export function helper() { return 42; }"
+  }
+
+  files {
+    name    = "config.js"
+    content = "export default {\"key\": \"value\"};"
+  }
+}
+
+# Test 3: Snippet with special characters in content
+resource "cloudflare_snippet" "special_chars" {
+  zone_id     = var.cloudflare_zone_id
+  name        = "${local.name_prefix}_special"
+  main_module = "special.js"
+
+  files {
+    name    = "special.js"
+  content = "export default { fetch() { const msg = \"Hello, \\\"World\\\"!\"; return new Response(msg); } }"  
+  }
+}
+
+# Test 4: Snippet using count
+resource "cloudflare_snippet" "with_count" {
+  count       = 3
+  zone_id     = var.cloudflare_zone_id
+  name        = "${local.name_prefix}_count_${count.index}"
+  main_module = "main.js"
+
+  files {
+    name    = "main.js"
+    content = "export default { fetch(r) { console.log('Index: ${count.index}'); return fetch(r); } }"  
+  }
+}
+
+# Test 5: Snippet using for_each with set
+resource "cloudflare_snippet" "with_for_each_set" {
+  for_each = toset(["api", "web", "worker"])
+
+  zone_id     = var.cloudflare_zone_id
+  name        = "${local.name_prefix}_${each.value}"
+  main_module = "${each.value}.js"
+
+  files {
+    name    = "${each.value}.js"
+    content = "export default { fetch(r) { return fetch(r); } }; // Snippet for ${each.value}"
+  }
+}
+
+# Test 6: Snippet using for_each with map
+resource "cloudflare_snippet" "with_for_each_map" {
+  for_each = {
+    prod    = "production.js"
+    staging = "staging.js"
+    dev     = "development.js"
+  }
+
+  zone_id     = var.cloudflare_zone_id
+  name        = "${local.name_prefix}_${each.key}"
+  main_module = each.value
+
+  files {
+    name    = each.value
+    content = "export default { fetch(r) { return fetch(r); } }; // Environment: ${each.key}"
+  }
+}
+
+# Test 7: Snippet with conditional (ternary operator)
+resource "cloudflare_snippet" "conditional" {
+  zone_id     = var.cloudflare_zone_id
+  name        = "${local.name_prefix}_conditional"
+  main_module = var.snippet_name != "" ? "custom.js" : "default.js"
+
+  files {
+    name    = var.snippet_name != "" ? "custom.js" : "default.js"
+    content = "export default { fetch(r) { return fetch(r); } }; ${var.snippet_name != "" ? "// Custom" : "// Default"}"
+  }
+}
+
+# Test 8: Snippet with multiline content
+resource "cloudflare_snippet" "multiline" {
+  zone_id     = var.cloudflare_zone_id
+  name        = "${local.name_prefix}_multiline"
+  main_module = "app.js"
+
+  files {
+    name = "app.js"
+    content = <<-EOT
+      export default {
+        async fetch(request) {
+          return new Response('Hello World!');
+        }
+      }
+    EOT
+  }
+}
+
+# Test 9: Snippet with jsonencode function
+resource "cloudflare_snippet" "with_jsonencode" {
+  zone_id     = var.cloudflare_zone_id
+  name        = "${local.name_prefix}_json"
+  main_module = "index.js"
+
+  files {
+    name    = "index.js"
+    content = "const config = ${jsonencode({ key = "value", debug = true })}; export default { fetch(r) { return new Response(JSON.stringify(config)); } }"
+  }
+}
+
+# Test 10: Snippet with interpolation in all fields
+resource "cloudflare_snippet" "interpolated" {
+  zone_id     = "${var.cloudflare_zone_id}"
+  name        = "${local.name_prefix}_interpolated"
+  main_module = "${var.main_module_file}"
+
+  files {
+    name    = "${var.main_module_file}"
+    content = "export default { fetch(r) { return fetch(r); } }; // ${var.snippet_name}"
+  }
+}
+
+# Test 11: Snippet with lifecycle meta-argument
+resource "cloudflare_snippet" "with_lifecycle" {
+  zone_id     = var.cloudflare_zone_id
+  name        = "${local.name_prefix}_lifecycle"
+  main_module = "main.js"
+
+  files {
+    name    = "main.js"
+    content = "export default { fetch(r) { return fetch(r); } }; // Lifecycle test"
+  }
+
+  lifecycle {
+    create_before_destroy = true
+    ignore_changes        = [files]
+  }
+}
+
+# Test 12: Snippet with depends_on
+resource "cloudflare_snippet" "with_depends_on" {
+  depends_on = [cloudflare_snippet.minimal]
+
+  zone_id     = var.cloudflare_zone_id
+  name        = "${local.name_prefix}_depends"
+  main_module = "dependent.js"
+
+  files {
+    name    = "dependent.js"
+    content = "export default { fetch(r) { return fetch(r); } }; // Depends on minimal snippet"
+  }
+}
+
+# Test 13: Snippet with long content
+resource "cloudflare_snippet" "long_content" {
+  zone_id     = var.cloudflare_zone_id
+  name        = "${local.name_prefix}_long"
+  main_module = "worker.js"
+
+  files {
+    name = "worker.js"
+    content = <<-EOT
+      // This is a comprehensive worker script
+      export default {
+        async fetch(request, env, ctx) {
+          const url = new URL(request.url);
+
+          // Handle different routes
+          switch (url.pathname) {
+            case '/api':
+              return handleAPI(request);
+            case '/health':
+              return new Response('OK', { status: 200 });
+            default:
+              return new Response('Not Found', { status: 404 });
+          }
+        }
+      }
+
+      async function handleAPI(request) {
+        const data = await request.json();
+        return new Response(JSON.stringify(data), {
+          headers: { 'Content-Type': 'application/json' }
+        });
+      }
+    EOT
+  }
+}

--- a/integration/v4_to_v5/testdata/snippet/input/terraform.tfstate
+++ b/integration/v4_to_v5/testdata/snippet/input/terraform.tfstate
@@ -1,0 +1,396 @@
+{
+  "version": 4,
+  "terraform_version": "1.5.0",
+  "serial": 1,
+  "lineage": "test-lineage",
+  "outputs": {},
+  "resources": [
+    {
+      "mode": "managed",
+      "type": "cloudflare_snippet",
+      "name": "minimal",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "zone_id": "abc123def456",
+            "name": "cftftest_minimal",
+            "main_module": "main.js",
+            "files": [
+              {
+                "name": "main.js",
+                "content": "export default {\n  async fetch(request, env, ctx) {\n    const response = await fetch(request);\n    const newHeaders = new Headers(response.headers);\n    \n    // Your custom logic here\n    newHeaders.set(\"x-snippet-type\", \"inline-terraform-string\");\n\n    return new Response(response.body, {\n      status: response.status,\n      statusText: response.statusText,\n      headers: newHeaders,\n    });\n  }\n};\n"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_snippet",
+      "name": "multi_file",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "zone_id": "abc123def456",
+            "name": "cftftest_multi",
+            "main_module": "index.js",
+            "files": [
+              {
+                "name": "index.js",
+                "content": "export default { fetch() { return new Response('Hello'); } }"
+              },
+              {
+                "name": "utils.js",
+                "content": "export function helper() { return 42; }"
+              },
+              {
+                "name": "config.js",
+                "content": "export default {\"key\": \"value\"};"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_snippet",
+      "name": "special_chars",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "zone_id": "abc123def456",
+            "name": "cftftest_special",
+            "main_module": "special.js",
+            "files": [
+              {
+                "name": "special.js",
+                "content": "export default { fetch() { const msg = \"Hello, \\\"World\\\"!\"; return new Response(msg); } }"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_snippet",
+      "name": "with_count",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "index_key": 0,
+          "schema_version": 0,
+          "attributes": {
+            "zone_id": "abc123def456",
+            "name": "cftftest_count_0",
+            "main_module": "main.js",
+            "files": [
+              {
+                "name": "main.js",
+                "content": "export default { fetch(r) { console.log('Index: 0'); return fetch(r); } }"
+              }
+            ]
+          }
+        },
+        {
+          "index_key": 1,
+          "schema_version": 0,
+          "attributes": {
+            "zone_id": "abc123def456",
+            "name": "cftftest_count_1",
+            "main_module": "main.js",
+            "files": [
+              {
+                "name": "main.js",
+                "content": "export default { fetch(r) { console.log('Index: 1'); return fetch(r); } }"
+              }
+            ]
+          }
+        },
+        {
+          "index_key": 2,
+          "schema_version": 0,
+          "attributes": {
+            "zone_id": "abc123def456",
+            "name": "cftftest_count_2",
+            "main_module": "main.js",
+            "files": [
+              {
+                "name": "main.js",
+                "content": "export default { fetch(r) { console.log('Index: 2'); return fetch(r); } }"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_snippet",
+      "name": "with_for_each_set",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "index_key": "api",
+          "schema_version": 0,
+          "attributes": {
+            "zone_id": "abc123def456",
+            "name": "cftftest_api",
+            "main_module": "api.js",
+            "files": [
+              {
+                "name": "api.js",
+                "content": "export default { fetch(r) { return fetch(r); } }; // Snippet for api"
+              }
+            ]
+          }
+        },
+        {
+          "index_key": "web",
+          "schema_version": 0,
+          "attributes": {
+            "zone_id": "abc123def456",
+            "name": "cftftest_web",
+            "main_module": "web.js",
+            "files": [
+              {
+                "name": "web.js",
+                "content": "export default { fetch(r) { return fetch(r); } }; // Snippet for web"
+              }
+            ]
+          }
+        },
+        {
+          "index_key": "worker",
+          "schema_version": 0,
+          "attributes": {
+            "zone_id": "abc123def456",
+            "name": "cftftest_worker",
+            "main_module": "worker.js",
+            "files": [
+              {
+                "name": "worker.js",
+                "content": "export default { fetch(r) { return fetch(r); } }; // Snippet for worker"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_snippet",
+      "name": "with_for_each_map",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "index_key": "dev",
+          "schema_version": 0,
+          "attributes": {
+            "zone_id": "abc123def456",
+            "name": "cftftest_dev",
+            "main_module": "development.js",
+            "files": [
+              {
+                "name": "development.js",
+                "content": "export default { fetch(r) { return fetch(r); } }; // Environment: dev"
+              }
+            ]
+          }
+        },
+        {
+          "index_key": "prod",
+          "schema_version": 0,
+          "attributes": {
+            "zone_id": "abc123def456",
+            "name": "cftftest_prod",
+            "main_module": "production.js",
+            "files": [
+              {
+                "name": "production.js",
+                "content": "export default { fetch(r) { return fetch(r); } }; // Environment: prod"
+              }
+            ]
+          }
+        },
+        {
+          "index_key": "staging",
+          "schema_version": 0,
+          "attributes": {
+            "zone_id": "abc123def456",
+            "name": "cftftest_staging",
+            "main_module": "staging.js",
+            "files": [
+              {
+                "name": "staging.js",
+                "content": "export default { fetch(r) { return fetch(r); } }; // Environment: staging"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_snippet",
+      "name": "conditional",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "zone_id": "abc123def456",
+            "name": "cftftest_conditional",
+            "main_module": "custom.js",
+            "files": [
+              {
+                "name": "custom.js",
+                "content": "export default { fetch(r) { return fetch(r); } }; // Custom"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_snippet",
+      "name": "multiline",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "zone_id": "abc123def456",
+            "name": "cftftest_multiline",
+            "main_module": "app.js",
+            "files": [
+              {
+                "name": "app.js",
+                "content": "export default {\n  async fetch(request) {\n    return new Response('Hello World!');\n  }\n}\n"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_snippet",
+      "name": "with_jsonencode",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "zone_id": "abc123def456",
+            "name": "cftftest_json",
+            "main_module": "index.js",
+            "files": [
+              {
+                "name": "index.js",
+                "content": "const config = {\"debug\":true,\"key\":\"value\"}; export default { fetch(r) { return new Response(JSON.stringify(config)); } }"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_snippet",
+      "name": "interpolated",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "zone_id": "abc123def456",
+            "name": "cftftest_interpolated",
+            "main_module": "index.js",
+            "files": [
+              {
+                "name": "index.js",
+                "content": "export default { fetch(r) { return fetch(r); } }; // test_snippet"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_snippet",
+      "name": "with_lifecycle",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "zone_id": "abc123def456",
+            "name": "cftftest_lifecycle",
+            "main_module": "main.js",
+            "files": [
+              {
+                "name": "main.js",
+                "content": "export default { fetch(r) { return fetch(r); } }; // Lifecycle test"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_snippet",
+      "name": "with_depends_on",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "zone_id": "abc123def456",
+            "name": "cftftest_depends",
+            "main_module": "dependent.js",
+            "files": [
+              {
+                "name": "dependent.js",
+                "content": "export default { fetch(r) { return fetch(r); } }; // Depends on minimal snippet"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_snippet",
+      "name": "long_content",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "zone_id": "abc123def456",
+            "name": "cftftest_long",
+            "main_module": "worker.js",
+            "files": [
+              {
+                "name": "worker.js",
+                "content": "// This is a comprehensive worker script\nexport default {\n  async fetch(request, env, ctx) {\n    const url = new URL(request.url);\n\n    // Handle different routes\n    switch (url.pathname) {\n      case '/api':\n        return handleAPI(request);\n      case '/health':\n        return new Response('OK', { status: 200 });\n      default:\n        return new Response('Not Found', { status: 404 });\n    }\n  }\n}\n\nasync function handleAPI(request) {\n  const data = await request.json();\n  return new Response(JSON.stringify(data), {\n    headers: { 'Content-Type': 'application/json' }\n  });\n}\n"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cloudflare/tf-migrate/internal/resources/pages_project"
 	"github.com/cloudflare/tf-migrate/internal/resources/r2_bucket"
 	"github.com/cloudflare/tf-migrate/internal/resources/regional_hostname"
+	"github.com/cloudflare/tf-migrate/internal/resources/snippet"
 	"github.com/cloudflare/tf-migrate/internal/resources/spectrum_application"
 	"github.com/cloudflare/tf-migrate/internal/resources/tiered_cache"
 	"github.com/cloudflare/tf-migrate/internal/resources/url_normalization_settings"
@@ -69,6 +70,7 @@ func RegisterAllMigrations() {
 	pages_project.NewV4ToV5Migrator()
 	r2_bucket.NewV4ToV5Migrator()
 	regional_hostname.NewV4ToV5Migrator()
+	snippet.NewV4ToV5Migrator()
 	tiered_cache.NewV4ToV5Migrator()
 	spectrum_application.NewV4ToV5Migrator()
 	url_normalization_settings.NewV4ToV5Migrator()

--- a/internal/resources/snippet/v4_to_v5.go
+++ b/internal/resources/snippet/v4_to_v5.go
@@ -1,0 +1,108 @@
+package snippet
+
+import (
+	"github.com/hashicorp/hcl/v2/hclwrite"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+
+	"github.com/cloudflare/tf-migrate/internal"
+	"github.com/cloudflare/tf-migrate/internal/transform"
+	tfhcl "github.com/cloudflare/tf-migrate/internal/transform/hcl"
+	"github.com/cloudflare/tf-migrate/internal/transform/state"
+)
+
+// V4ToV5Migrator handles migration of snippet resources from v4 to v5
+type V4ToV5Migrator struct{}
+
+// NewV4ToV5Migrator creates and registers a new snippet migrator
+func NewV4ToV5Migrator() transform.ResourceTransformer {
+	migrator := &V4ToV5Migrator{}
+	// Register with v4 resource name (both v4 and v5 use the same name)
+	internal.RegisterMigrator("cloudflare_snippet", "v4", "v5", migrator)
+	return migrator
+}
+
+// GetResourceType returns the v5 resource type
+func (m *V4ToV5Migrator) GetResourceType() string {
+	// Resource name unchanged in v5
+	return "cloudflare_snippet"
+}
+
+// CanHandle checks if this migrator can handle the given resource type
+func (m *V4ToV5Migrator) CanHandle(resourceType string) bool {
+	return resourceType == "cloudflare_snippet"
+}
+
+// Preprocess performs string-level transformations before HCL parsing
+// Not needed for snippet migration - ConvertBlocksToArrayAttribute handles files conversion
+func (m *V4ToV5Migrator) Preprocess(content string) string {
+	return content
+}
+
+// Postprocess performs string-level transformations after HCL generation
+func (m *V4ToV5Migrator) Postprocess(content string) string {
+	return content
+}
+
+// GetResourceRename returns the old and new resource names if renamed
+// Snippet resource is NOT renamed (same name in v4 and v5)
+func (m *V4ToV5Migrator) GetResourceRename() (string, string) {
+	return "cloudflare_snippet", "cloudflare_snippet"
+}
+
+// TransformConfig transforms the HCL configuration from v4 to v5
+func (m *V4ToV5Migrator) TransformConfig(ctx *transform.Context, block *hclwrite.Block) (*transform.TransformResult, error) {
+	body := block.Body()
+
+	// Step 1: Rename name → snippet_name
+	tfhcl.RenameAttribute(body, "name", "snippet_name")
+
+	// Step 2: Convert files blocks to array attribute
+	// v4: files { name = "..." content = "..." }
+	// v5: files = [{ name = "..." content = "..." }]
+	tfhcl.ConvertBlocksToArrayAttribute(body, "files", false)
+
+	// Step 3: Create metadata wrapper for main_module
+	// v4: main_module = "main.js"
+	// v5: metadata = { main_module = "main.js" }
+	tfhcl.MoveAttributesToNestedObject(body, "metadata", []string{"main_module"})
+
+	return &transform.TransformResult{
+		Blocks:         []*hclwrite.Block{block},
+		RemoveOriginal: false,
+	}, nil
+}
+
+// TransformState transforms the Terraform state from v4 to v5
+func (m *V4ToV5Migrator) TransformState(ctx *transform.Context, instance gjson.Result, resourcePath string, resourceName string) (string, error) {
+	result := instance.String()
+	attrs := instance.Get("attributes")
+
+	if !attrs.Exists() {
+		return result, nil
+	}
+
+	// Step 1: Rename name → snippet_name
+	result = state.RenameField(result, "attributes", attrs, "name", "snippet_name")
+
+	// Step 2: Move main_module → metadata.main_module
+	if mainModule := attrs.Get("main_module"); mainModule.Exists() {
+		mainModuleVal := mainModule.Value()
+
+		// Create metadata object with main_module inside
+		metadata := map[string]interface{}{
+			"main_module": mainModuleVal,
+		}
+
+		// Set metadata in state
+		result, _ = sjson.Set(result, "attributes.metadata", metadata)
+
+		// Remove main_module from root
+		result, _ = sjson.Delete(result, "attributes.main_module")
+	}
+
+	// Step 3: Set schema_version = 0
+	result, _ = sjson.Set(result, "schema_version", 0)
+
+	return result, nil
+}

--- a/internal/resources/snippet/v4_to_v5_test.go
+++ b/internal/resources/snippet/v4_to_v5_test.go
@@ -1,0 +1,388 @@
+package snippet
+
+import (
+	"testing"
+
+	"github.com/cloudflare/tf-migrate/internal/testhelpers"
+)
+
+func TestV4ToV5Transformation(t *testing.T) {
+	migrator := NewV4ToV5Migrator()
+
+	t.Run("ConfigTransformation", func(t *testing.T) {
+		tests := []testhelpers.ConfigTestCase{
+			{
+				Name: "Minimal resource with single file",
+				Input: `resource "cloudflare_snippet" "example" {
+  zone_id     = "abc123"
+  name        = "my_snippet"
+  main_module = "main.js"
+
+  files {
+    name    = "main.js"
+    content = "console.log('hello');"
+  }
+}`,
+				Expected: `resource "cloudflare_snippet" "example" {
+  zone_id = "abc123"
+
+  snippet_name = "my_snippet"
+  files = [{
+    name    = "main.js"
+    content = "console.log('hello');"
+  }]
+  metadata = {
+    main_module = "main.js"
+  }
+}`,
+			},
+			{
+				Name: "Resource with multiple files",
+				Input: `resource "cloudflare_snippet" "multi" {
+  zone_id     = "zone123"
+  name        = "multi_file_snippet"
+  main_module = "index.js"
+
+  files {
+    name    = "index.js"
+    content = "export default { fetch() {} }"
+  }
+
+  files {
+    name    = "utils.js"
+    content = "export function helper() {}"
+  }
+
+  files {
+    name    = "config.json"
+    content = "{\"key\": \"value\"}"
+  }
+}`,
+				Expected: `resource "cloudflare_snippet" "multi" {
+  zone_id = "zone123"
+
+  snippet_name = "multi_file_snippet"
+  files = [{
+    name    = "index.js"
+    content = "export default { fetch() {} }"
+  }, {
+    name    = "utils.js"
+    content = "export function helper() {}"
+  }, {
+    name    = "config.json"
+    content = "{\"key\": \"value\"}"
+  }]
+  metadata = {
+    main_module = "index.js"
+  }
+}`,
+			},
+			{
+				Name: "Resource with file without content",
+				Input: `resource "cloudflare_snippet" "optional_content" {
+  zone_id     = "zone456"
+  name        = "snippet_no_content"
+  main_module = "empty.js"
+
+  files {
+    name = "empty.js"
+  }
+}`,
+				Expected: `resource "cloudflare_snippet" "optional_content" {
+  zone_id = "zone456"
+
+  snippet_name = "snippet_no_content"
+  files = [{
+    name = "empty.js"
+  }]
+  metadata = {
+    main_module = "empty.js"
+  }
+}`,
+			},
+			{
+				Name: "Resource with variable references",
+				Input: `resource "cloudflare_snippet" "vars" {
+  zone_id     = var.zone_id
+  name        = var.snippet_name
+  main_module = var.main_module
+
+  files {
+    name    = var.file_name
+    content = file("${path.module}/snippet.js")
+  }
+}`,
+				Expected: `resource "cloudflare_snippet" "vars" {
+  zone_id = var.zone_id
+
+  snippet_name = var.snippet_name
+  files = [{
+    name    = var.file_name
+    content = file("${path.module}/snippet.js")
+  }]
+  metadata = {
+    main_module = var.main_module
+  }
+}`,
+			},
+			{
+				Name: "Resource with special characters in content",
+				Input: `resource "cloudflare_snippet" "special_chars" {
+  zone_id     = "zone789"
+  name        = "special"
+  main_module = "app.js"
+
+  files {
+    name    = "app.js"
+    content = "const msg = \"Hello, \\\"World\\\"!\"; console.log(msg);"
+  }
+}`,
+				Expected: `resource "cloudflare_snippet" "special_chars" {
+  zone_id = "zone789"
+
+  snippet_name = "special"
+  files = [{
+    name    = "app.js"
+    content = "const msg = \"Hello, \\\"World\\\"!\"; console.log(msg);"
+  }]
+  metadata = {
+    main_module = "app.js"
+  }
+}`,
+			},
+			{
+				Name: "Multiple resources in one config",
+				Input: `resource "cloudflare_snippet" "first" {
+  zone_id     = "zone1"
+  name        = "first_snippet"
+  main_module = "index.js"
+
+  files {
+    name    = "index.js"
+    content = "// first"
+  }
+}
+
+resource "cloudflare_snippet" "second" {
+  zone_id     = "zone2"
+  name        = "second_snippet"
+  main_module = "app.js"
+
+  files {
+    name    = "app.js"
+    content = "// second"
+  }
+}`,
+				Expected: `resource "cloudflare_snippet" "first" {
+  zone_id = "zone1"
+
+  snippet_name = "first_snippet"
+  files = [{
+    name    = "index.js"
+    content = "// first"
+  }]
+  metadata = {
+    main_module = "index.js"
+  }
+}
+
+resource "cloudflare_snippet" "second" {
+  zone_id = "zone2"
+
+  snippet_name = "second_snippet"
+  files = [{
+    name    = "app.js"
+    content = "// second"
+  }]
+  metadata = {
+    main_module = "app.js"
+  }
+}`,
+			},
+		}
+
+		testhelpers.RunConfigTransformTests(t, tests, migrator)
+	})
+
+	t.Run("StateTransformation", func(t *testing.T) {
+		tests := []testhelpers.StateTestCase{
+			{
+				Name: "Minimal state with single file",
+				Input: `{
+  "type": "cloudflare_snippet",
+  "name": "example",
+  "attributes": {
+    "zone_id": "abc123",
+    "name": "my_snippet",
+    "main_module": "main.js",
+    "files": [
+      {
+        "name": "main.js",
+        "content": "console.log('hello');"
+      }
+    ]
+  }
+}`,
+				Expected: `{
+  "type": "cloudflare_snippet",
+  "name": "example",
+  "attributes": {
+    "zone_id": "abc123",
+    "snippet_name": "my_snippet",
+    "files": [
+      {
+        "name": "main.js",
+        "content": "console.log('hello');"
+      }
+    ],
+    "metadata": {
+      "main_module": "main.js"
+    }
+  },
+  "schema_version": 0
+}`,
+			},
+			{
+				Name: "State with multiple files",
+				Input: `{
+  "type": "cloudflare_snippet",
+  "name": "multi",
+  "attributes": {
+    "zone_id": "zone123",
+    "name": "multi_file_snippet",
+    "main_module": "index.js",
+    "files": [
+      {
+        "name": "index.js",
+        "content": "export default {}"
+      },
+      {
+        "name": "utils.js",
+        "content": "export function helper() {}"
+      }
+    ]
+  }
+}`,
+				Expected: `{
+  "type": "cloudflare_snippet",
+  "name": "multi",
+  "attributes": {
+    "zone_id": "zone123",
+    "snippet_name": "multi_file_snippet",
+    "files": [
+      {
+        "name": "index.js",
+        "content": "export default {}"
+      },
+      {
+        "name": "utils.js",
+        "content": "export function helper() {}"
+      }
+    ],
+    "metadata": {
+      "main_module": "index.js"
+    }
+  },
+  "schema_version": 0
+}`,
+			},
+			{
+				Name: "State with file without content",
+				Input: `{
+  "type": "cloudflare_snippet",
+  "name": "no_content",
+  "attributes": {
+    "zone_id": "zone456",
+    "name": "snippet_no_content",
+    "main_module": "empty.js",
+    "files": [
+      {
+        "name": "empty.js"
+      }
+    ]
+  }
+}`,
+				Expected: `{
+  "type": "cloudflare_snippet",
+  "name": "no_content",
+  "attributes": {
+    "zone_id": "zone456",
+    "snippet_name": "snippet_no_content",
+    "files": [
+      {
+        "name": "empty.js"
+      }
+    ],
+    "metadata": {
+      "main_module": "empty.js"
+    }
+  },
+  "schema_version": 0
+}`,
+			},
+			{
+				Name: "State without attributes (edge case)",
+				Input: `{
+  "type": "cloudflare_snippet",
+  "name": "empty"
+}`,
+				Expected: `{
+  "type": "cloudflare_snippet",
+  "name": "empty"
+}`,
+			},
+			{
+				Name: "State with existing schema_version (should override)",
+				Input: `{
+  "type": "cloudflare_snippet",
+  "name": "versioned",
+  "attributes": {
+    "zone_id": "zone999",
+    "name": "test",
+    "main_module": "index.js",
+    "files": [{"name": "index.js"}]
+  },
+  "schema_version": 1
+}`,
+				Expected: `{
+  "type": "cloudflare_snippet",
+  "name": "versioned",
+  "attributes": {
+    "zone_id": "zone999",
+    "snippet_name": "test",
+    "files": [{"name": "index.js"}],
+    "metadata": {
+      "main_module": "index.js"
+    }
+  },
+  "schema_version": 0
+}`,
+			},
+		}
+
+		testhelpers.RunStateTransformTests(t, tests, migrator)
+	})
+}
+
+func TestMigratorInterface(t *testing.T) {
+	migrator := NewV4ToV5Migrator()
+
+	t.Run("CanHandle accepts cloudflare_snippet", func(t *testing.T) {
+		if !migrator.CanHandle("cloudflare_snippet") {
+			t.Error("CanHandle(cloudflare_snippet) should return true")
+		}
+	})
+
+	t.Run("CanHandle rejects other resources", func(t *testing.T) {
+		if migrator.CanHandle("cloudflare_other_resource") {
+			t.Error("CanHandle(cloudflare_other_resource) should return false")
+		}
+	})
+
+	t.Run("Preprocess returns content unchanged", func(t *testing.T) {
+		input := "test content"
+		if got := migrator.Preprocess(input); got != input {
+			t.Errorf("Preprocess() = %v, want %v", got, input)
+		}
+	})
+}


### PR DESCRIPTION
feat(migration): add v4 to v5 migration for cloudflare_snippet

  Implements automated migration for cloudflare_snippet resource from v4 to v5.

  Changes:
  - Rename: name → snippet_name
  - Convert: files blocks → files array attribute
  - Restructure: main_module → metadata.main_module
  - Update state: rename fields and nest main_module in metadata
 
  Testing:
  - 13 integration test cases covering all scenarios
  - 7 provider acceptance tests using V2 migration tool
  - Tests handle special characters, variables, count, for_each, conditionals