### PR TITLE
fix(pages_project): v4 to v5 migration logic adjustment for pages_project

### DIFF
--- a/integration/v4_to_v5/testdata/pages_project/expected/terraform.tfstate
+++ b/integration/v4_to_v5/testdata/pages_project/expected/terraform.tfstate
@@ -7,14 +7,7 @@
         {
           "attributes": {
             "account_id": "f037e56e89293a057740de681ac9abbe",
-            "build_config": {
-              "build_caching": null,
-              "build_command": null,
-              "destination_dir": null,
-              "root_dir": null,
-              "web_analytics_tag": null,
-              "web_analytics_token": null
-            },
+            "build_config": {},
             "canonical_deployment": null,
             "created_on": "2024-01-01T00:00:00Z",
             "framework": "",
@@ -41,7 +34,6 @@
           "attributes": {
             "account_id": "f037e56e89293a057740de681ac9abbe",
             "build_config": {
-              "build_caching": null,
               "build_command": "npm run build",
               "destination_dir": "public",
               "root_dir": "/",
@@ -73,14 +65,7 @@
         {
           "attributes": {
             "account_id": "f037e56e89293a057740de681ac9abbe",
-            "build_config": {
-              "build_caching": null,
-              "build_command": null,
-              "destination_dir": null,
-              "root_dir": null,
-              "web_analytics_tag": null,
-              "web_analytics_token": null
-            },
+            "build_config": {},
             "canonical_deployment": null,
             "created_on": "2024-01-01T00:00:00Z",
             "framework": "",
@@ -124,14 +109,7 @@
         {
           "attributes": {
             "account_id": "f037e56e89293a057740de681ac9abbe",
-            "build_config": {
-              "build_caching": null,
-              "build_command": null,
-              "destination_dir": null,
-              "root_dir": null,
-              "web_analytics_tag": null,
-              "web_analytics_token": null
-            },
+            "build_config": {},
             "canonical_deployment": null,
             "created_on": "2024-01-01T00:00:00Z",
             "deployment_configs": {
@@ -268,12 +246,9 @@
           "attributes": {
             "account_id": "f037e56e89293a057740de681ac9abbe",
             "build_config": {
-              "build_caching": null,
               "build_command": "npm run build",
               "destination_dir": "dist",
-              "root_dir": "/app",
-              "web_analytics_tag": null,
-              "web_analytics_token": null
+              "root_dir": "/app"
             },
             "canonical_deployment": null,
             "created_on": "2024-01-01T00:00:00Z",
@@ -363,14 +338,7 @@
         {
           "attributes": {
             "account_id": "f037e56e89293a057740de681ac9abbe",
-            "build_config": {
-              "build_caching": null,
-              "build_command": null,
-              "destination_dir": null,
-              "root_dir": null,
-              "web_analytics_tag": null,
-              "web_analytics_token": null
-            },
+            "build_config": {},
             "canonical_deployment": null,
             "created_on": "2024-01-01T00:00:00Z",
             "deployment_configs": {

--- a/internal/resources/pages_project/v4_to_v5_test.go
+++ b/internal/resources/pages_project/v4_to_v5_test.go
@@ -277,14 +277,7 @@ func TestV4ToV5Transformation(t *testing.T) {
     "account_id": "test123",
     "name": "test-project",
     "production_branch": "main",
-    "build_config": {
-      "build_caching": null,
-      "build_command": null,
-      "destination_dir": null,
-      "root_dir": null,
-      "web_analytics_tag": null,
-      "web_analytics_token": null
-    },
+    "build_config": {},
     "canonical_deployment": null,
     "framework": "",
     "framework_version": "",
@@ -319,11 +312,7 @@ func TestV4ToV5Transformation(t *testing.T) {
     "production_branch": "main",
     "build_config": {
       "build_command": "npm run build",
-      "destination_dir": "public",
-      "build_caching": null,
-      "root_dir": null,
-      "web_analytics_tag": null,
-      "web_analytics_token": null
+      "destination_dir": "public"
     },
     "canonical_deployment": null,
     "framework": "",
@@ -369,14 +358,7 @@ func TestV4ToV5Transformation(t *testing.T) {
         "production_deployments_enabled": true
       }
     },
-    "build_config": {
-      "build_caching": null,
-      "build_command": null,
-      "destination_dir": null,
-      "root_dir": null,
-      "web_analytics_tag": null,
-      "web_analytics_token": null
-    },
+    "build_config": {},
     "canonical_deployment": null,
     "framework": "",
     "framework_version": "",
@@ -459,14 +441,7 @@ func TestV4ToV5Transformation(t *testing.T) {
         "wrangler_config_hash": null
       }
     },
-    "build_config": {
-      "build_caching": null,
-      "build_command": null,
-      "destination_dir": null,
-      "root_dir": null,
-      "web_analytics_tag": null,
-      "web_analytics_token": null
-    },
+    "build_config": {},
     "canonical_deployment": null,
     "framework": "",
     "framework_version": "",
@@ -539,14 +514,7 @@ func TestV4ToV5Transformation(t *testing.T) {
         "wrangler_config_hash": null
       }
     },
-    "build_config": {
-      "build_caching": null,
-      "build_command": null,
-      "destination_dir": null,
-      "root_dir": null,
-      "web_analytics_tag": null,
-      "web_analytics_token": null
-    },
+    "build_config": {},
     "canonical_deployment": null,
     "framework": "",
     "framework_version": "",
@@ -626,14 +594,7 @@ func TestV4ToV5Transformation(t *testing.T) {
         "wrangler_config_hash": null
       }
     },
-    "build_config": {
-      "build_caching": null,
-      "build_command": null,
-      "destination_dir": null,
-      "root_dir": null,
-      "web_analytics_tag": null,
-      "web_analytics_token": null
-    },
+    "build_config": {},
     "canonical_deployment": null,
     "framework": "",
     "framework_version": "",
@@ -700,11 +661,7 @@ func TestV4ToV5Transformation(t *testing.T) {
     "production_branch": "main",
     "build_config": {
       "build_command": "npm run build",
-      "destination_dir": "public",
-      "build_caching": null,
-      "root_dir": null,
-      "web_analytics_tag": null,
-      "web_analytics_token": null
+      "destination_dir": "public"
     },
     "source": {
       "type": "github",
@@ -853,14 +810,7 @@ func TestV4ToV5Transformation(t *testing.T) {
         "wrangler_config_hash": null
       }
     },
-    "build_config": {
-      "build_caching": null,
-      "build_command": null,
-      "destination_dir": null,
-      "root_dir": null,
-      "web_analytics_tag": null,
-      "web_analytics_token": null
-    },
+    "build_config": {},
     "canonical_deployment": null,
     "framework": "",
     "framework_version": "",
@@ -921,14 +871,7 @@ func TestV4ToV5Transformation(t *testing.T) {
         "wrangler_config_hash": null
       }
     },
-    "build_config": {
-      "build_caching": null,
-      "build_command": null,
-      "destination_dir": null,
-      "root_dir": null,
-      "web_analytics_tag": null,
-      "web_analytics_token": null
-    },
+    "build_config": {},
     "canonical_deployment": null,
     "framework": "",
     "framework_version": "",
@@ -989,14 +932,7 @@ func TestV4ToV5Transformation(t *testing.T) {
         "wrangler_config_hash": null
       }
     },
-    "build_config": {
-      "build_caching": null,
-      "build_command": null,
-      "destination_dir": null,
-      "root_dir": null,
-      "web_analytics_tag": null,
-      "web_analytics_token": null
-    },
+    "build_config": {},
     "canonical_deployment": null,
     "framework": "",
     "framework_version": "",
@@ -1057,14 +993,7 @@ func TestV4ToV5Transformation(t *testing.T) {
         "wrangler_config_hash": null
       }
     },
-    "build_config": {
-      "build_caching": null,
-      "build_command": null,
-      "destination_dir": null,
-      "root_dir": null,
-      "web_analytics_tag": null,
-      "web_analytics_token": null
-    },
+    "build_config": {},
     "canonical_deployment": null,
     "framework": "",
     "framework_version": "",
@@ -1151,14 +1080,7 @@ func TestV4ToV5Transformation(t *testing.T) {
         "wrangler_config_hash": null
       }
     },
-    "build_config": {
-      "build_caching": null,
-      "build_command": null,
-      "destination_dir": null,
-      "root_dir": null,
-      "web_analytics_tag": null,
-      "web_analytics_token": null
-    },
+    "build_config": {},
     "canonical_deployment": null,
     "framework": "",
     "framework_version": "",
@@ -1251,14 +1173,7 @@ func TestV4ToV5Transformation(t *testing.T) {
         "wrangler_config_hash": null
       }
     },
-    "build_config": {
-      "build_caching": null,
-      "build_command": null,
-      "destination_dir": null,
-      "root_dir": null,
-      "web_analytics_tag": null,
-      "web_analytics_token": null
-    },
+    "build_config": {},
     "canonical_deployment": null,
     "framework": "",
     "framework_version": "",


### PR DESCRIPTION
fix(pages_project): handle v4/v5 provider behavioral differences in migration

  Fixes 5 issues where v4 API responses differ from v5 provider expectations:

  1. **Config-aware build_config filtering** (lines 219-258, 571-603)
     - Parse HCL config to identify user-specified fields
     - Preserve fields in config OR with truthy values
     - Remove API-added defaults that v5 provider omits

  2. **Compatibility flags conversion** (lines 450-459)
     - Convert empty arrays [] to null

  3. **Placement mode handling** (lines 561-587)
     - Convert empty strings to null
     - Remove empty placement objects

  4. **Empty build_config handling** (lines 247-275)
     - Use empty object {} when all fields are falsy
     - Not object with null fields

  5. **Remove placement balancing** (removed lines 171-189)
     - Don't add empty placement={} to balance preview/production
     - Each environment independently has or omits placement

  **Result:** 4/4 runnable provider tests passing (100%), runtime 33.763s