### PR TITLE
feat(zero_trust_tunnel_cloudflared): support zero_trust_tunnel for v4 to v5 migration

### DIFF
--- a/integration/v4_to_v5/testdata/zero_trust_tunnel_cloudflared/expected/zero_trust_tunnel_cloudflared.tf
+++ b/integration/v4_to_v5/testdata/zero_trust_tunnel_cloudflared/expected/zero_trust_tunnel_cloudflared.tf
@@ -17,8 +17,29 @@ variable "cloudflare_domain" {
 # Basic Tunnel Resources
 # ========================================
 
+# Basic tunnel with minimal configuration
+resource "cloudflare_zero_trust_tunnel_cloudflared" "minimal" {
+  account_id    = var.cloudflare_account_id
+  name          = "${local.name_prefix}-minimal-tunnel"
+  config_src    = "local"
+  tunnel_secret = base64encode("test-secret-that-is-at-least-32-bytes-long")
+}
 
+# Tunnel with local config source
+resource "cloudflare_zero_trust_tunnel_cloudflared" "local_config" {
+  account_id    = var.cloudflare_account_id
+  name          = "${local.name_prefix}-local-config-tunnel"
+  config_src    = "local"
+  tunnel_secret = base64encode("another-secret-32-bytes-or-longer-here")
+}
 
+# Tunnel with cloudflare config source
+resource "cloudflare_zero_trust_tunnel_cloudflared" "cloudflare_config" {
+  account_id    = var.cloudflare_account_id
+  name          = "${local.name_prefix}-cloudflare-config-tunnel"
+  config_src    = "cloudflare"
+  tunnel_secret = base64encode("remote-tunnel-secret-32-bytes-minimum")
+}
 
 # ========================================
 # Advanced Terraform Patterns for Testing
@@ -44,6 +65,13 @@ locals {
   full_tunnel_name   = "${var.tunnel_prefix}-${local.tunnel_suffix}"
 }
 
+# Tunnel using variables and locals
+resource "cloudflare_zero_trust_tunnel_cloudflared" "with_vars" {
+  account_id    = local.common_account_id
+  name          = local.full_tunnel_name
+  config_src    = var.config_source
+  tunnel_secret = base64encode(local.tunnel_secret_base)
+}
 
 # Pattern 3: for_each with map
 variable "application_tunnels" {
@@ -67,6 +95,14 @@ variable "application_tunnels" {
   }
 }
 
+resource "cloudflare_zero_trust_tunnel_cloudflared" "applications" {
+  for_each = var.application_tunnels
+
+  account_id    = var.cloudflare_account_id
+  name          = "${each.key}-tunnel"
+  config_src    = each.value.config_src
+  tunnel_secret = base64encode(each.value.secret)
+}
 
 # Pattern 4: for_each with list converted to set
 variable "environment_tunnels" {
@@ -94,75 +130,6 @@ variable "environment_tunnels" {
   ]
 }
 
-
-# Pattern 5: Count-based resources
-variable "replica_count" {
-  type    = number
-  default = 3
-}
-
-
-# Pattern 6: Conditional resource creation
-variable "enable_backup_tunnel" {
-  type    = bool
-  default = true
-}
-
-
-
-
-
-# Pattern 9: Using terraform expressions
-variable "use_cloudflare_config" {
-  type    = bool
-  default = false
-}
-
-
-
-
-# Pattern 12: Complex expression for config_src
-variable "is_production" {
-  type    = bool
-  default = true
-}
-
-# Basic tunnel with minimal configuration
-resource "cloudflare_zero_trust_tunnel_cloudflared" "minimal" {
-  account_id    = var.cloudflare_account_id
-  name          = "${local.name_prefix}-minimal-tunnel"
-  config_src    = "local"
-  tunnel_secret = base64encode("test-secret-that-is-at-least-32-bytes-long")
-}
-# Tunnel with local config source
-resource "cloudflare_zero_trust_tunnel_cloudflared" "local_config" {
-  account_id    = var.cloudflare_account_id
-  name          = "${local.name_prefix}-local-config-tunnel"
-  config_src    = "local"
-  tunnel_secret = base64encode("another-secret-32-bytes-or-longer-here")
-}
-# Tunnel with cloudflare config source
-resource "cloudflare_zero_trust_tunnel_cloudflared" "cloudflare_config" {
-  account_id    = var.cloudflare_account_id
-  name          = "${local.name_prefix}-cloudflare-config-tunnel"
-  config_src    = "cloudflare"
-  tunnel_secret = base64encode("remote-tunnel-secret-32-bytes-minimum")
-}
-# Tunnel using variables and locals
-resource "cloudflare_zero_trust_tunnel_cloudflared" "with_vars" {
-  account_id    = local.common_account_id
-  name          = local.full_tunnel_name
-  config_src    = var.config_source
-  tunnel_secret = base64encode(local.tunnel_secret_base)
-}
-resource "cloudflare_zero_trust_tunnel_cloudflared" "applications" {
-  for_each = var.application_tunnels
-
-  account_id    = var.cloudflare_account_id
-  name          = "${each.key}-tunnel"
-  config_src    = each.value.config_src
-  tunnel_secret = base64encode(each.value.secret)
-}
 resource "cloudflare_zero_trust_tunnel_cloudflared" "environments" {
   for_each = { for idx, tunnel in var.environment_tunnels : tunnel.name => tunnel }
 
@@ -171,6 +138,13 @@ resource "cloudflare_zero_trust_tunnel_cloudflared" "environments" {
   config_src    = each.value.config_src
   tunnel_secret = base64encode(each.value.secret)
 }
+
+# Pattern 5: Count-based resources
+variable "replica_count" {
+  type    = number
+  default = 3
+}
+
 resource "cloudflare_zero_trust_tunnel_cloudflared" "replicas" {
   count = var.replica_count
 
@@ -179,6 +153,13 @@ resource "cloudflare_zero_trust_tunnel_cloudflared" "replicas" {
   config_src    = "local"
   tunnel_secret = base64encode("replica-${count.index}-secret-32-bytes-long")
 }
+
+# Pattern 6: Conditional resource creation
+variable "enable_backup_tunnel" {
+  type    = bool
+  default = true
+}
+
 resource "cloudflare_zero_trust_tunnel_cloudflared" "backup" {
   count = var.enable_backup_tunnel ? 1 : 0
 
@@ -187,6 +168,7 @@ resource "cloudflare_zero_trust_tunnel_cloudflared" "backup" {
   config_src    = "cloudflare"
   tunnel_secret = base64encode("backup-tunnel-secret-32-bytes-long")
 }
+
 # Pattern 7: Cross-resource references
 resource "cloudflare_zero_trust_tunnel_cloudflared" "primary" {
   account_id    = var.cloudflare_account_id
@@ -194,6 +176,7 @@ resource "cloudflare_zero_trust_tunnel_cloudflared" "primary" {
   config_src    = "local"
   tunnel_secret = base64encode("primary-tunnel-secret-32-bytes-long")
 }
+
 # Tunnel that references another tunnel in its name
 resource "cloudflare_zero_trust_tunnel_cloudflared" "secondary" {
   account_id    = var.cloudflare_account_id
@@ -201,6 +184,7 @@ resource "cloudflare_zero_trust_tunnel_cloudflared" "secondary" {
   config_src    = "cloudflare"
   tunnel_secret = base64encode("secondary-tunnel-secret-32-bytes-ok")
 }
+
 # Pattern 8: Resource with lifecycle meta-arguments
 resource "cloudflare_zero_trust_tunnel_cloudflared" "protected" {
   account_id = var.cloudflare_account_id
@@ -213,12 +197,20 @@ resource "cloudflare_zero_trust_tunnel_cloudflared" "protected" {
   }
   tunnel_secret = base64encode("protected-tunnel-secret-32-bytes-ok")
 }
+
+# Pattern 9: Using terraform expressions
+variable "use_cloudflare_config" {
+  type    = bool
+  default = false
+}
+
 resource "cloudflare_zero_trust_tunnel_cloudflared" "conditional_config" {
   account_id    = var.cloudflare_account_id
   name          = "${local.name_prefix}-conditional-config-tunnel"
   config_src    = var.use_cloudflare_config ? "cloudflare" : "local"
   tunnel_secret = base64encode("conditional-secret-32-bytes-or-more")
 }
+
 # Pattern 10: Tunnel with base64encode function
 resource "cloudflare_zero_trust_tunnel_cloudflared" "encoded" {
   account_id    = var.cloudflare_account_id
@@ -226,6 +218,7 @@ resource "cloudflare_zero_trust_tunnel_cloudflared" "encoded" {
   config_src    = "local"
   tunnel_secret = base64encode("this-secret-is-base64-encoded-32b")
 }
+
 # Pattern 11: Tunnel using string interpolation
 resource "cloudflare_zero_trust_tunnel_cloudflared" "interpolated" {
   account_id    = var.cloudflare_account_id
@@ -233,6 +226,13 @@ resource "cloudflare_zero_trust_tunnel_cloudflared" "interpolated" {
   config_src    = "local"
   tunnel_secret = base64encode("interpolated-secret-32-bytes-or-more")
 }
+
+# Pattern 12: Complex expression for config_src
+variable "is_production" {
+  type    = bool
+  default = true
+}
+
 resource "cloudflare_zero_trust_tunnel_cloudflared" "complex_config" {
   account_id    = var.cloudflare_account_id
   name          = "${var.is_production ? "prod" : "dev"}-complex-tunnel"

--- a/internal/resources/zero_trust_tunnel_cloudflared/v4_to_v5_test.go
+++ b/internal/resources/zero_trust_tunnel_cloudflared/v4_to_v5_test.go
@@ -77,11 +77,42 @@ resource "cloudflare_tunnel" "tunnel2" {
   name          = "tunnel-one"
   tunnel_secret = base64encode("first-tunnel-secret-32-bytes-long")
 }
+
 resource "cloudflare_zero_trust_tunnel_cloudflared" "tunnel2" {
   account_id    = "f037e56e89293a057740de681ac9abbe"
   name          = "tunnel-two"
   config_src    = "cloudflare"
   tunnel_secret = base64encode("second-tunnel-secret-32-bytes-long")
+}`,
+			},
+			{
+				Name: "alternative_v4_name_minimal",
+				Input: `
+resource "cloudflare_zero_trust_tunnel" "alt_minimal" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+  name       = "alt-minimal-tunnel"
+  secret     = base64encode("alternative-name-secret-32-bytes-long")
+}`,
+				Expected: `resource "cloudflare_zero_trust_tunnel_cloudflared" "alt_minimal" {
+  account_id    = "f037e56e89293a057740de681ac9abbe"
+  name          = "alt-minimal-tunnel"
+  tunnel_secret = base64encode("alternative-name-secret-32-bytes-long")
+}`,
+			},
+			{
+				Name: "alternative_v4_name_with_config",
+				Input: `
+resource "cloudflare_zero_trust_tunnel" "alt_config" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+  name       = "alt-config-tunnel"
+  secret     = base64encode("alternative-config-secret-32-bytes-ok")
+  config_src = "cloudflare"
+}`,
+				Expected: `resource "cloudflare_zero_trust_tunnel_cloudflared" "alt_config" {
+  account_id    = "f037e56e89293a057740de681ac9abbe"
+  name          = "alt-config-tunnel"
+  config_src    = "cloudflare"
+  tunnel_secret = base64encode("alternative-config-secret-32-bytes-ok")
 }`,
 			},
 		}
@@ -166,6 +197,60 @@ resource "cloudflare_zero_trust_tunnel_cloudflared" "tunnel2" {
     "account_id": "f037e56e89293a057740de681ac9abbe",
     "name": "no-computed-tunnel",
     "tunnel_secret": "dGVzdC1zZWNyZXQtd2l0aG91dC1jb21wdXRlZC1maWVsZHMtMzItYnl0ZXM="
+  }
+}`,
+			},
+			{
+				Name: "alternative_v4_name_minimal_state",
+				Input: `{
+  "type": "cloudflare_zero_trust_tunnel",
+  "name": "alt_minimal",
+  "attributes": {
+    "id": "c3d4e5f6-a7b8-9012-cdef-123456789012",
+    "account_id": "f037e56e89293a057740de681ac9abbe",
+    "name": "alt-minimal-tunnel",
+    "secret": "YWx0ZXJuYXRpdmUtbmFtZS1zZWNyZXQtMzItYnl0ZXMtbG9uZw==",
+    "cname": "c3d4e5f6-a7b8-9012-cdef-123456789012.cfargotunnel.com",
+    "tunnel_token": "eyJhIjoiZjAzN2U1NmU4OTI5M2EwNTc3NDBkZTY4MWFjOWFiYmUiLCJ0IjoiYzNkNGU1ZjYtYTdiOC05MDEyLWNkZWYtMTIzNDU2Nzg5MDEyIiwicyI6IllXNW4ifQ=="
+  }
+}`,
+				Expected: `{
+  "type": "cloudflare_zero_trust_tunnel_cloudflared",
+  "name": "alt_minimal",
+  "schema_version": 0,
+  "attributes": {
+    "id": "c3d4e5f6-a7b8-9012-cdef-123456789012",
+    "account_id": "f037e56e89293a057740de681ac9abbe",
+    "name": "alt-minimal-tunnel",
+    "tunnel_secret": "YWx0ZXJuYXRpdmUtbmFtZS1zZWNyZXQtMzItYnl0ZXMtbG9uZw=="
+  }
+}`,
+			},
+			{
+				Name: "alternative_v4_name_with_config_state",
+				Input: `{
+  "type": "cloudflare_zero_trust_tunnel",
+  "name": "alt_config",
+  "attributes": {
+    "id": "d4e5f6a7-b8c9-0123-def0-234567890123",
+    "account_id": "f037e56e89293a057740de681ac9abbe",
+    "name": "alt-config-tunnel",
+    "secret": "YWx0ZXJuYXRpdmUtY29uZmlnLXNlY3JldC0zMi1ieXRlcy1vaw==",
+    "config_src": "cloudflare",
+    "cname": "d4e5f6a7-b8c9-0123-def0-234567890123.cfargotunnel.com",
+    "tunnel_token": "eyJhIjoiZjAzN2U1NmU4OTI5M2EwNTc3NDBkZTY4MWFjOWFiYmUiLCJ0IjoiZDRlNWY2YTctYjhjOS0wMTIzLWRlZjAtMjM0NTY3ODkwMTIzIiwicyI6IllXNW4ifQ=="
+  }
+}`,
+				Expected: `{
+  "type": "cloudflare_zero_trust_tunnel_cloudflared",
+  "name": "alt_config",
+  "schema_version": 0,
+  "attributes": {
+    "id": "d4e5f6a7-b8c9-0123-def0-234567890123",
+    "account_id": "f037e56e89293a057740de681ac9abbe",
+    "name": "alt-config-tunnel",
+    "tunnel_secret": "YWx0ZXJuYXRpdmUtY29uZmlnLXNlY3JldC0zMi1ieXRlcy1vaw==",
+    "config_src": "cloudflare"
   }
 }`,
 			},


### PR DESCRIPTION
Adds support for `cloudflare_zero_trust_tunnel` for v4 to v5 migration. `cloudflare_tunnel` is already supported, this ensures both resources map to the same resource in v5.