### PR TITLE
zero_trust_local_fallback_domain v4->v5 migration

### DIFF
--- a/integration/v4_to_v5/testdata/zero_trust_local_fallback_domain/expected/terraform.tfstate
+++ b/integration/v4_to_v5/testdata/zero_trust_local_fallback_domain/expected/terraform.tfstate
@@ -1,0 +1,142 @@
+{
+  "version": 4,
+  "terraform_version": "1.5.0",
+  "serial": 1,
+  "lineage": "test-lineage",
+  "outputs": {},
+  "resources": [
+    {
+      "mode": "managed",
+      "type": "cloudflare_zero_trust_device_default_profile_local_domain_fallback",
+      "name": "default_single",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "account_id": "test-account-id",
+            "domains": [
+              {
+                "suffix": "example.com"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_zero_trust_device_default_profile_local_domain_fallback",
+      "name": "default_multi",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "account_id": "test-account-id",
+            "domains": [
+              {
+                "suffix": "corp.example.com",
+                "description": "Corporate network",
+                "dns_server": ["10.0.0.1", "10.0.0.2"]
+              },
+              {
+                "suffix": "internal.example.com",
+                "description": "Internal services",
+                "dns_server": ["10.1.0.1"]
+              },
+              {
+                "suffix": "local.example.com"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_zero_trust_device_custom_profile_local_domain_fallback",
+      "name": "custom_single",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "account_id": "test-account-id",
+            "policy_id": "test-policy-id",
+            "domains": [
+              {
+                "suffix": "custom.example.com"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_zero_trust_device_custom_profile_local_domain_fallback",
+      "name": "custom_multi",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "account_id": "test-account-id",
+            "policy_id": "another-policy-id",
+            "domains": [
+              {
+                "suffix": "dev.example.com",
+                "description": "Development environment",
+                "dns_server": ["192.168.1.1"]
+              },
+              {
+                "suffix": "staging.example.com"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_zero_trust_device_default_profile_local_domain_fallback",
+      "name": "deprecated_default",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "account_id": "test-account-id",
+            "domains": [
+              {
+                "suffix": "deprecated.example.com",
+                "description": "Using deprecated resource name"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_zero_trust_device_custom_profile_local_domain_fallback",
+      "name": "deprecated_custom",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "account_id": "test-account-id",
+            "policy_id": "deprecated-policy",
+            "domains": [
+              {
+                "suffix": "old.example.com"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/integration/v4_to_v5/testdata/zero_trust_local_fallback_domain/expected/zero_trust_local_fallback_domain.tf
+++ b/integration/v4_to_v5/testdata/zero_trust_local_fallback_domain/expected/zero_trust_local_fallback_domain.tf
@@ -1,0 +1,102 @@
+# Test comprehensive migration of zero_trust_local_fallback_domain resources
+# This includes both default profile (no policy_id) and custom profile (with policy_id) variants
+
+variable "cloudflare_account_id" {
+  description = "Cloudflare account ID"
+  type        = string
+}
+
+variable "cloudflare_zone_id" {
+  description = "Cloudflare zone ID"
+  type        = string
+}
+
+variable "cloudflare_domain" {
+  description = "Cloudflare domain for testing"
+  type        = string
+}
+
+# Default profile - no policy_id
+resource "cloudflare_zero_trust_device_default_profile_local_domain_fallback" "default_single" {
+  account_id = var.cloudflare_account_id
+
+  domains = [
+    {
+      suffix = var.cloudflare_domain
+    }
+  ]
+}
+
+# Default profile - multiple domains with all fields
+resource "cloudflare_zero_trust_device_default_profile_local_domain_fallback" "default_multi" {
+  account_id = var.cloudflare_account_id
+
+  domains = [
+    {
+      suffix      = "corp.${var.cloudflare_domain}"
+      description = "Corporate network"
+      dns_server  = ["10.0.0.1", "10.0.0.2"]
+    },
+    {
+      suffix      = "internal.${var.cloudflare_domain}"
+      description = "Internal services"
+      dns_server  = ["10.1.0.1"]
+    },
+    {
+      suffix = "local.${var.cloudflare_domain}"
+    }
+  ]
+}
+
+# Custom profile - with policy_id
+resource "cloudflare_zero_trust_device_custom_profile_local_domain_fallback" "custom_single" {
+  account_id = var.cloudflare_account_id
+  policy_id  = "test-policy-id"
+
+  domains = [
+    {
+      suffix = "custom.${var.cloudflare_domain}"
+    }
+  ]
+}
+
+# Custom profile - multiple domains
+resource "cloudflare_zero_trust_device_custom_profile_local_domain_fallback" "custom_multi" {
+  account_id = var.cloudflare_account_id
+  policy_id  = "another-policy-id"
+
+  domains = [
+    {
+      suffix      = "dev.${var.cloudflare_domain}"
+      description = "Development environment"
+      dns_server  = ["192.168.1.1"]
+    },
+    {
+      suffix = "staging.${var.cloudflare_domain}"
+    }
+  ]
+}
+
+# Deprecated resource name - default profile
+resource "cloudflare_zero_trust_device_default_profile_local_domain_fallback" "deprecated_default" {
+  account_id = var.cloudflare_account_id
+
+  domains = [
+    {
+      suffix      = "deprecated.${var.cloudflare_domain}"
+      description = "Using deprecated resource name"
+    }
+  ]
+}
+
+# Deprecated resource name - custom profile
+resource "cloudflare_zero_trust_device_custom_profile_local_domain_fallback" "deprecated_custom" {
+  account_id = var.cloudflare_account_id
+  policy_id  = "deprecated-policy-id"
+
+  domains = [
+    {
+      suffix = "old.${var.cloudflare_domain}"
+    }
+  ]
+}

--- a/integration/v4_to_v5/testdata/zero_trust_local_fallback_domain/input/terraform.tfstate
+++ b/integration/v4_to_v5/testdata/zero_trust_local_fallback_domain/input/terraform.tfstate
@@ -1,0 +1,142 @@
+{
+  "version": 4,
+  "terraform_version": "1.5.0",
+  "serial": 1,
+  "lineage": "test-lineage",
+  "outputs": {},
+  "resources": [
+    {
+      "mode": "managed",
+      "type": "cloudflare_zero_trust_local_fallback_domain",
+      "name": "default_single",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "account_id": "test-account-id",
+            "domains": [
+              {
+                "suffix": "example.com"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_zero_trust_local_fallback_domain",
+      "name": "default_multi",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "account_id": "test-account-id",
+            "domains": [
+              {
+                "suffix": "corp.example.com",
+                "description": "Corporate network",
+                "dns_server": ["10.0.0.1", "10.0.0.2"]
+              },
+              {
+                "suffix": "internal.example.com",
+                "description": "Internal services",
+                "dns_server": ["10.1.0.1"]
+              },
+              {
+                "suffix": "local.example.com"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_zero_trust_local_fallback_domain",
+      "name": "custom_single",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "account_id": "test-account-id",
+            "policy_id": "test-policy-id",
+            "domains": [
+              {
+                "suffix": "custom.example.com"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_zero_trust_local_fallback_domain",
+      "name": "custom_multi",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "account_id": "test-account-id",
+            "policy_id": "another-policy-id",
+            "domains": [
+              {
+                "suffix": "dev.example.com",
+                "description": "Development environment",
+                "dns_server": ["192.168.1.1"]
+              },
+              {
+                "suffix": "staging.example.com"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_fallback_domain",
+      "name": "deprecated_default",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "account_id": "test-account-id",
+            "domains": [
+              {
+                "suffix": "deprecated.example.com",
+                "description": "Using deprecated resource name"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_fallback_domain",
+      "name": "deprecated_custom",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "account_id": "test-account-id",
+            "policy_id": "deprecated-policy",
+            "domains": [
+              {
+                "suffix": "old.example.com"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/integration/v4_to_v5/testdata/zero_trust_local_fallback_domain/input/zero_trust_local_fallback_domain.tf
+++ b/integration/v4_to_v5/testdata/zero_trust_local_fallback_domain/input/zero_trust_local_fallback_domain.tf
@@ -1,0 +1,90 @@
+# Test comprehensive migration of zero_trust_local_fallback_domain resources
+# This includes both default profile (no policy_id) and custom profile (with policy_id) variants
+
+variable "cloudflare_account_id" {
+  description = "Cloudflare account ID"
+  type        = string
+}
+
+variable "cloudflare_zone_id" {
+  description = "Cloudflare zone ID"
+  type        = string
+}
+
+variable "cloudflare_domain" {
+  description = "Cloudflare domain for testing"
+  type        = string
+}
+
+# Default profile - no policy_id
+resource "cloudflare_zero_trust_local_fallback_domain" "default_single" {
+  account_id = var.cloudflare_account_id
+
+  domains {
+    suffix = var.cloudflare_domain
+  }
+}
+
+# Default profile - multiple domains with all fields
+resource "cloudflare_zero_trust_local_fallback_domain" "default_multi" {
+  account_id = var.cloudflare_account_id
+
+  domains {
+    suffix      = "corp.${var.cloudflare_domain}"
+    description = "Corporate network"
+    dns_server  = ["10.0.0.1", "10.0.0.2"]
+  }
+  domains {
+    suffix      = "internal.${var.cloudflare_domain}"
+    description = "Internal services"
+    dns_server  = ["10.1.0.1"]
+  }
+  domains {
+    suffix = "local.${var.cloudflare_domain}"
+  }
+}
+
+# Custom profile - with policy_id
+resource "cloudflare_zero_trust_local_fallback_domain" "custom_single" {
+  account_id = var.cloudflare_account_id
+  policy_id  = "test-policy-id"
+
+  domains {
+    suffix = "custom.${var.cloudflare_domain}"
+  }
+}
+
+# Custom profile - multiple domains
+resource "cloudflare_zero_trust_local_fallback_domain" "custom_multi" {
+  account_id = var.cloudflare_account_id
+  policy_id  = "another-policy-id"
+
+  domains {
+    suffix      = "dev.${var.cloudflare_domain}"
+    description = "Development environment"
+    dns_server  = ["192.168.1.1"]
+  }
+  domains {
+    suffix = "staging.${var.cloudflare_domain}"
+  }
+}
+
+# Deprecated resource name - default profile
+resource "cloudflare_fallback_domain" "deprecated_default" {
+  account_id = var.cloudflare_account_id
+
+  domains {
+    suffix      = "deprecated.${var.cloudflare_domain}"
+    description = "Using deprecated resource name"
+  }
+}
+
+# Deprecated resource name - custom profile
+resource "cloudflare_fallback_domain" "deprecated_custom" {
+  account_id = var.cloudflare_account_id
+  policy_id  = "deprecated-policy-id"
+
+  domains {
+    suffix = "old.${var.cloudflare_domain}"
+  }
+}

--- a/integration/v4_to_v5/testdata/zero_trust_local_fallback_domain/input/zero_trust_local_fallback_domain_e2e.tf
+++ b/integration/v4_to_v5/testdata/zero_trust_local_fallback_domain/input/zero_trust_local_fallback_domain_e2e.tf
@@ -1,0 +1,37 @@
+# Test comprehensive migration of zero_trust_local_fallback_domain resources
+# This includes default profile (no policy_id) but not custom profile (with policy_id) variants
+# TODO Add custom_profile e2e tests once zero_trust_device_profiles is migrated and we can use those policy_ids
+
+variable "cloudflare_account_id" {
+  description = "Cloudflare account ID"
+  type        = string
+}
+
+variable "cloudflare_zone_id" {
+  description = "Cloudflare zone ID"
+  type        = string
+}
+
+variable "cloudflare_domain" {
+  description = "Cloudflare domain for testing"
+  type        = string
+}
+
+# Default profile - multiple domains with all fields
+resource "cloudflare_zero_trust_local_fallback_domain" "default_multi" {
+  account_id = var.cloudflare_account_id
+
+  domains {
+    suffix      = "corp.${var.cloudflare_domain}"
+    description = "Corporate network"
+    dns_server  = ["10.0.0.1", "10.0.0.2"]
+  }
+  domains {
+    suffix      = "internal.${var.cloudflare_domain}"
+    description = "Internal services"
+    dns_server  = ["10.1.0.1"]
+  }
+  domains {
+    suffix = "local.${var.cloudflare_domain}"
+  }
+}

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -46,6 +46,7 @@ import (
 	"github.com/cloudflare/tf-migrate/internal/resources/zero_trust_dlp_custom_profile"
 	"github.com/cloudflare/tf-migrate/internal/resources/zero_trust_gateway_policy"
 	"github.com/cloudflare/tf-migrate/internal/resources/zero_trust_list"
+	"github.com/cloudflare/tf-migrate/internal/resources/zero_trust_local_fallback_domain"
 	"github.com/cloudflare/tf-migrate/internal/resources/zero_trust_tunnel_cloudflared"
 	"github.com/cloudflare/tf-migrate/internal/resources/zero_trust_tunnel_cloudflared_route"
 	"github.com/cloudflare/tf-migrate/internal/resources/zone"
@@ -108,6 +109,7 @@ func RegisterAllMigrations() {
 	zero_trust_gateway_policy.NewV4ToV5Migrator()
 	zero_trust_device_posture_rule.NewV4ToV5Migrator()
 	zero_trust_list.NewV4ToV5Migrator()
+	zero_trust_local_fallback_domain.NewV4ToV5Migrator()
 	zero_trust_tunnel_cloudflared.NewV4ToV5Migrator()
 	zero_trust_tunnel_cloudflared_route.NewV4ToV5Migrator()
 }

--- a/internal/resources/zero_trust_local_fallback_domain/v4_to_v5.go
+++ b/internal/resources/zero_trust_local_fallback_domain/v4_to_v5.go
@@ -1,0 +1,155 @@
+package zero_trust_local_fallback_domain
+
+import (
+	"github.com/hashicorp/hcl/v2/hclwrite"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+
+	"github.com/cloudflare/tf-migrate/internal"
+	"github.com/cloudflare/tf-migrate/internal/transform"
+	tfhcl "github.com/cloudflare/tf-migrate/internal/transform/hcl"
+)
+
+type V4ToV5Migrator struct {
+	oldType             string
+	oldTypeDeprecated   string
+	newTypeDefault      string
+	newTypeCustom       string
+	lastTransformedType string
+}
+
+func NewV4ToV5Migrator() transform.ResourceTransformer {
+	migrator := &V4ToV5Migrator{
+		oldType:             "cloudflare_zero_trust_local_fallback_domain",
+		oldTypeDeprecated:   "cloudflare_fallback_domain",
+		newTypeDefault:      "cloudflare_zero_trust_device_default_profile_local_domain_fallback",
+		newTypeCustom:       "cloudflare_zero_trust_device_custom_profile_local_domain_fallback",
+		lastTransformedType: "",
+	}
+
+	internal.RegisterMigrator("cloudflare_zero_trust_local_fallback_domain", "v4", "v5", migrator)
+	internal.RegisterMigrator("cloudflare_fallback_domain", "v4", "v5", migrator)
+
+	return migrator
+}
+
+func (m *V4ToV5Migrator) GetResourceType() string {
+	// Return the type used in the last transformation
+	// If not set, default to default profile
+	if m.lastTransformedType != "" {
+		return m.lastTransformedType
+	}
+	return m.newTypeDefault
+}
+
+func (m *V4ToV5Migrator) CanHandle(resourceType string) bool {
+	return resourceType == m.oldType || resourceType == m.oldTypeDeprecated
+}
+
+func (m *V4ToV5Migrator) Preprocess(content string) string {
+	return content
+}
+
+// GetResourceRename implements the ResourceRenamer interface
+// Note: This is complex because we have conditional renaming
+// We'll return the default profile name here, but actual renaming happens in TransformConfig
+func (m *V4ToV5Migrator) GetResourceRename() (string, string) {
+	// Return one of the mappings - the actual logic is in TransformConfig
+	return "cloudflare_zero_trust_local_fallback_domain", m.newTypeDefault
+}
+
+func (m *V4ToV5Migrator) TransformConfig(ctx *transform.Context, block *hclwrite.Block) (*transform.TransformResult, error) {
+	body := block.Body()
+
+	// Check if policy_id exists and is not null
+	policyIDAttr := body.GetAttribute("policy_id")
+	hasPolicyID := false
+	if policyIDAttr != nil {
+		// Check if the value is not null
+		exprTokens := policyIDAttr.Expr().BuildTokens(nil)
+		// If the expression is just "null", treat it as not having policy_id
+		if len(exprTokens) != 1 || string(exprTokens[0].Bytes) != "null" {
+			hasPolicyID = true
+		}
+	}
+
+	var newResourceType string
+	if hasPolicyID {
+		newResourceType = m.newTypeCustom
+	} else {
+		newResourceType = m.newTypeDefault
+	}
+	m.lastTransformedType = newResourceType
+
+	// Rename resource type to appropriate v5 resource
+	currentType := tfhcl.GetResourceType(block)
+	tfhcl.RenameResourceType(block, currentType, newResourceType)
+
+	// Remove policy_id attribute if it's null (default profile doesn't accept policy_id)
+	if !hasPolicyID && policyIDAttr != nil {
+		body.RemoveAttribute("policy_id")
+	}
+
+	// Convert domains blocks to attribute array
+	tfhcl.ConvertBlocksToAttributeList(body, "domains", nil)
+
+	return &transform.TransformResult{
+		Blocks:         []*hclwrite.Block{block},
+		RemoveOriginal: false,
+	}, nil
+}
+
+func (m *V4ToV5Migrator) TransformState(ctx *transform.Context, stateJSON gjson.Result, resourcePath, resourceName string) (string, error) {
+	result := stateJSON.String()
+
+	attrs := stateJSON.Get("attributes")
+	if !attrs.Exists() {
+		result, _ = sjson.Set(result, "schema_version", 0)
+		m.lastTransformedType = m.newTypeDefault
+		return result, nil
+	}
+
+	// Check if policy_id exists and is not null
+	policyID := attrs.Get("policy_id")
+	hasPolicyID := policyID.Exists() && policyID.Type != gjson.Null
+	if hasPolicyID {
+		m.lastTransformedType = m.newTypeCustom
+	} else {
+		m.lastTransformedType = m.newTypeDefault
+	}
+
+	transform.SetStateTypeRename(ctx, resourceName, m.oldType, m.lastTransformedType)
+	transform.SetStateTypeRename(ctx, resourceName, m.oldTypeDeprecated, m.lastTransformedType)
+
+	// Remove policy_id from state if it's null (default profile doesn't have policy_id)
+	if !hasPolicyID && policyID.Exists() {
+		result, _ = sjson.Delete(result, "attributes.policy_id")
+	}
+
+	// Transform domains (TypeSet → ListNestedAttribute/SetNestedAttribute)
+	// The state structure is the same for both v5 variants, just different collection semantics
+	// v4: domains is a set of objects
+	// v5: domains is either a list (default profile) or set (custom profile) of objects
+	// The JSON structure is identical, so no transformation needed
+	domains := attrs.Get("domains")
+	if domains.Exists() && domains.IsArray() {
+		if len(domains.Array()) == 0 {
+			result, _ = sjson.Delete(result, "attributes.domains")
+		}
+	}
+
+	// Handle dns_server empty arrays within each domain
+	if domains.Exists() && domains.IsArray() {
+		domains.ForEach(func(key, value gjson.Result) bool {
+			dnsServer := value.Get("dns_server")
+			if dnsServer.Exists() && dnsServer.IsArray() && len(dnsServer.Array()) == 0 {
+				result, _ = sjson.Delete(result, "attributes.domains."+key.String()+".dns_server")
+			}
+			return true
+		})
+	}
+
+	result, _ = sjson.Set(result, "schema_version", 0)
+
+	return result, nil
+}

--- a/internal/resources/zero_trust_local_fallback_domain/v4_to_v5_test.go
+++ b/internal/resources/zero_trust_local_fallback_domain/v4_to_v5_test.go
@@ -1,0 +1,628 @@
+package zero_trust_local_fallback_domain
+
+import (
+	"testing"
+
+	"github.com/cloudflare/tf-migrate/internal/testhelpers"
+)
+
+func TestConfigTransformation(t *testing.T) {
+	migrator := NewV4ToV5Migrator()
+
+	tests := []testhelpers.ConfigTestCase{
+		{
+			Name: "basic default profile - no policy_id",
+			Input: `
+resource "cloudflare_zero_trust_local_fallback_domain" "example" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+
+  domains {
+    suffix = "example.com"
+  }
+}`,
+			Expected: `
+resource "cloudflare_zero_trust_device_default_profile_local_domain_fallback" "example" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+
+  domains = [
+    {
+      suffix = "example.com"
+    }
+  ]
+}`,
+		},
+		{
+			Name: "default profile with all domain fields",
+			Input: `
+resource "cloudflare_zero_trust_local_fallback_domain" "example" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+
+  domains {
+    suffix      = "example.com"
+    description = "Example domain"
+    dns_server  = ["1.1.1.1", "8.8.8.8"]
+  }
+}`,
+			Expected: `
+resource "cloudflare_zero_trust_device_default_profile_local_domain_fallback" "example" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+
+  domains = [
+    {
+      suffix      = "example.com"
+      description = "Example domain"
+      dns_server  = ["1.1.1.1", "8.8.8.8"]
+    }
+  ]
+}`,
+		},
+		{
+			Name: "default profile with multiple domains",
+			Input: `
+resource "cloudflare_zero_trust_local_fallback_domain" "example" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+
+  domains {
+    suffix      = "example.com"
+    description = "Example domain"
+  }
+
+  domains {
+    suffix     = "another.com"
+    dns_server = ["1.1.1.1"]
+  }
+
+  domains {
+    suffix = "third.com"
+  }
+}`,
+			Expected: `
+resource "cloudflare_zero_trust_device_default_profile_local_domain_fallback" "example" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+
+  domains = [
+    {
+      suffix      = "example.com"
+      description = "Example domain"
+    },
+    {
+      suffix     = "another.com"
+      dns_server = ["1.1.1.1"]
+    },
+    {
+      suffix = "third.com"
+    }
+  ]
+}`,
+		},
+		{
+			Name: "deprecated resource name - default profile",
+			Input: `
+resource "cloudflare_fallback_domain" "example" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+
+  domains {
+    suffix = "example.com"
+  }
+}`,
+			Expected: `
+resource "cloudflare_zero_trust_device_default_profile_local_domain_fallback" "example" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+
+  domains = [
+    {
+      suffix = "example.com"
+    }
+  ]
+}`,
+		},
+		{
+			Name: "default profile with policy_id = null",
+			Input: `
+resource "cloudflare_zero_trust_local_fallback_domain" "example" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+  policy_id  = null
+
+  domains {
+    suffix = "example.com"
+  }
+}`,
+			Expected: `
+resource "cloudflare_zero_trust_device_default_profile_local_domain_fallback" "example" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+
+  domains = [
+    {
+      suffix = "example.com"
+    }
+  ]
+}`,
+		},
+		{
+			Name: "basic custom profile - with policy_id",
+			Input: `
+resource "cloudflare_zero_trust_local_fallback_domain" "example" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+  policy_id  = "policy123"
+
+  domains {
+    suffix = "example.com"
+  }
+}`,
+			Expected: `
+resource "cloudflare_zero_trust_device_custom_profile_local_domain_fallback" "example" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+  policy_id  = "policy123"
+
+  domains = [
+    {
+      suffix = "example.com"
+    }
+  ]
+}`,
+		},
+		{
+			Name: "custom profile with all domain fields",
+			Input: `
+resource "cloudflare_zero_trust_local_fallback_domain" "example" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+  policy_id  = "policy123"
+
+  domains {
+    suffix      = "corp.example.com"
+    description = "Corporate domain"
+    dns_server  = ["10.0.0.1"]
+  }
+}`,
+			Expected: `
+resource "cloudflare_zero_trust_device_custom_profile_local_domain_fallback" "example" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+  policy_id  = "policy123"
+
+  domains = [
+    {
+      suffix      = "corp.example.com"
+      description = "Corporate domain"
+      dns_server  = ["10.0.0.1"]
+    }
+  ]
+}`,
+		},
+		{
+			Name: "custom profile with multiple domains",
+			Input: `
+resource "cloudflare_zero_trust_local_fallback_domain" "example" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+  policy_id  = "policy123"
+
+  domains {
+    suffix = "corp1.example.com"
+  }
+
+  domains {
+    suffix      = "corp2.example.com"
+    description = "Secondary corporate domain"
+    dns_server  = ["10.0.0.2", "10.0.0.3"]
+  }
+}`,
+			Expected: `
+resource "cloudflare_zero_trust_device_custom_profile_local_domain_fallback" "example" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+  policy_id  = "policy123"
+
+  domains = [
+    {
+      suffix = "corp1.example.com"
+    },
+    {
+      suffix      = "corp2.example.com"
+      description = "Secondary corporate domain"
+      dns_server  = ["10.0.0.2", "10.0.0.3"]
+    }
+  ]
+}`,
+		},
+		{
+			Name: "deprecated resource name - custom profile",
+			Input: `
+resource "cloudflare_fallback_domain" "example" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+  policy_id  = "policy123"
+
+  domains {
+    suffix = "example.com"
+  }
+}`,
+			Expected: `
+resource "cloudflare_zero_trust_device_custom_profile_local_domain_fallback" "example" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+  policy_id  = "policy123"
+
+  domains = [
+    {
+      suffix = "example.com"
+    }
+  ]
+}`,
+		},
+		{
+			Name: "multiple resources - mixed default and custom",
+			Input: `
+resource "cloudflare_zero_trust_local_fallback_domain" "default" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+
+  domains {
+    suffix = "default.example.com"
+  }
+}
+
+resource "cloudflare_zero_trust_local_fallback_domain" "custom" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+  policy_id  = "policy123"
+
+  domains {
+    suffix = "custom.example.com"
+  }
+}`,
+			Expected: `
+resource "cloudflare_zero_trust_device_default_profile_local_domain_fallback" "default" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+
+  domains = [
+    {
+      suffix = "default.example.com"
+    }
+  ]
+}
+
+resource "cloudflare_zero_trust_device_custom_profile_local_domain_fallback" "custom" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+  policy_id  = "policy123"
+
+  domains = [
+    {
+      suffix = "custom.example.com"
+    }
+  ]
+}`,
+		},
+	}
+
+	testhelpers.RunConfigTransformTests(t, tests, migrator)
+}
+
+func TestStateTransformation(t *testing.T) {
+	migrator := NewV4ToV5Migrator()
+
+	tests := []testhelpers.StateTestCase{
+		{
+			Name: "basic default profile state",
+			Input: `{
+  "schema_version": 0,
+  "attributes": {
+    "account_id": "f037e56e89293a057740de681ac9abbe",
+    "domains": [
+      {
+        "suffix": "example.com"
+      }
+    ]
+  }
+}`,
+			Expected: `{
+  "schema_version": 0,
+  "attributes": {
+    "account_id": "f037e56e89293a057740de681ac9abbe",
+    "domains": [
+      {
+        "suffix": "example.com"
+      }
+    ]
+  }
+}`,
+		},
+		{
+			Name: "default profile with all fields",
+			Input: `{
+  "schema_version": 0,
+  "attributes": {
+    "account_id": "f037e56e89293a057740de681ac9abbe",
+    "domains": [
+      {
+        "suffix": "example.com",
+        "description": "Example domain",
+        "dns_server": ["1.1.1.1", "8.8.8.8"]
+      }
+    ]
+  }
+}`,
+			Expected: `{
+  "schema_version": 0,
+  "attributes": {
+    "account_id": "f037e56e89293a057740de681ac9abbe",
+    "domains": [
+      {
+        "suffix": "example.com",
+        "description": "Example domain",
+        "dns_server": ["1.1.1.1", "8.8.8.8"]
+      }
+    ]
+  }
+}`,
+		},
+		{
+			Name: "default profile with multiple domains",
+			Input: `{
+  "schema_version": 0,
+  "attributes": {
+    "account_id": "f037e56e89293a057740de681ac9abbe",
+    "domains": [
+      {
+        "suffix": "example.com",
+        "description": "Example"
+      },
+      {
+        "suffix": "another.com",
+        "dns_server": ["1.1.1.1"]
+      },
+      {
+        "suffix": "third.com"
+      }
+    ]
+  }
+}`,
+			Expected: `{
+  "schema_version": 0,
+  "attributes": {
+    "account_id": "f037e56e89293a057740de681ac9abbe",
+    "domains": [
+      {
+        "suffix": "example.com",
+        "description": "Example"
+      },
+      {
+        "suffix": "another.com",
+        "dns_server": ["1.1.1.1"]
+      },
+      {
+        "suffix": "third.com"
+      }
+    ]
+  }
+}`,
+		},
+		{
+			Name: "default profile with null policy_id",
+			Input: `{
+  "schema_version": 0,
+  "attributes": {
+    "account_id": "f037e56e89293a057740de681ac9abbe",
+    "policy_id": null,
+    "domains": [
+      {
+        "suffix": "example.com"
+      }
+    ]
+  }
+}`,
+			Expected: `{
+  "schema_version": 0,
+  "attributes": {
+    "account_id": "f037e56e89293a057740de681ac9abbe",
+    "domains": [
+      {
+        "suffix": "example.com"
+      }
+    ]
+  }
+}`,
+		},
+		{
+			Name: "basic custom profile state",
+			Input: `{
+  "schema_version": 0,
+  "attributes": {
+    "account_id": "f037e56e89293a057740de681ac9abbe",
+    "policy_id": "policy123",
+    "domains": [
+      {
+        "suffix": "corp.example.com"
+      }
+    ]
+  }
+}`,
+			Expected: `{
+  "schema_version": 0,
+  "attributes": {
+    "account_id": "f037e56e89293a057740de681ac9abbe",
+    "policy_id": "policy123",
+    "domains": [
+      {
+        "suffix": "corp.example.com"
+      }
+    ]
+  }
+}`,
+		},
+		{
+			Name: "custom profile with all fields",
+			Input: `{
+  "schema_version": 0,
+  "attributes": {
+    "account_id": "f037e56e89293a057740de681ac9abbe",
+    "policy_id": "policy123",
+    "domains": [
+      {
+        "suffix": "corp.example.com",
+        "description": "Corporate domain",
+        "dns_server": ["10.0.0.1"]
+      }
+    ]
+  }
+}`,
+			Expected: `{
+  "schema_version": 0,
+  "attributes": {
+    "account_id": "f037e56e89293a057740de681ac9abbe",
+    "policy_id": "policy123",
+    "domains": [
+      {
+        "suffix": "corp.example.com",
+        "description": "Corporate domain",
+        "dns_server": ["10.0.0.1"]
+      }
+    ]
+  }
+}`,
+		},
+		{
+			Name: "empty domains array",
+			Input: `{
+  "schema_version": 0,
+  "attributes": {
+    "account_id": "f037e56e89293a057740de681ac9abbe",
+    "domains": []
+  }
+}`,
+			Expected: `{
+  "schema_version": 0,
+  "attributes": {
+    "account_id": "f037e56e89293a057740de681ac9abbe"
+  }
+}`,
+		},
+		{
+			Name: "empty dns_server in domain",
+			Input: `{
+  "schema_version": 0,
+  "attributes": {
+    "account_id": "f037e56e89293a057740de681ac9abbe",
+    "domains": [
+      {
+        "suffix": "example.com",
+        "dns_server": []
+      }
+    ]
+  }
+}`,
+			Expected: `{
+  "schema_version": 0,
+  "attributes": {
+    "account_id": "f037e56e89293a057740de681ac9abbe",
+    "domains": [
+      {
+        "suffix": "example.com"
+      }
+    ]
+  }
+}`,
+		},
+		{
+			Name: "missing optional fields",
+			Input: `{
+  "schema_version": 0,
+  "attributes": {
+    "account_id": "f037e56e89293a057740de681ac9abbe",
+    "domains": [
+      {
+        "suffix": "example.com"
+      }
+    ]
+  }
+}`,
+			Expected: `{
+  "schema_version": 0,
+  "attributes": {
+    "account_id": "f037e56e89293a057740de681ac9abbe",
+    "domains": [
+      {
+        "suffix": "example.com"
+      }
+    ]
+  }
+}`,
+		},
+		{
+			Name: "invalid instance - missing attributes",
+			Input: `{
+  "schema_version": 0
+}`,
+			Expected: `{
+  "schema_version": 0
+}`,
+		},
+		{
+			Name: "null description field",
+			Input: `{
+  "schema_version": 0,
+  "attributes": {
+    "account_id": "f037e56e89293a057740de681ac9abbe",
+    "domains": [
+      {
+        "suffix": "example.com",
+        "description": null
+      }
+    ]
+  }
+}`,
+			Expected: `{
+  "schema_version": 0,
+  "attributes": {
+    "account_id": "f037e56e89293a057740de681ac9abbe",
+    "domains": [
+      {
+        "suffix": "example.com",
+        "description": null
+      }
+    ]
+  }
+}`,
+		},
+	}
+
+	testhelpers.RunStateTransformTests(t, tests, migrator)
+}
+
+func TestCanHandle(t *testing.T) {
+	migrator := NewV4ToV5Migrator()
+
+	tests := []struct {
+		name         string
+		resourceType string
+		expected     bool
+	}{
+		{
+			name:         "handles current v4 name",
+			resourceType: "cloudflare_zero_trust_local_fallback_domain",
+			expected:     true,
+		},
+		{
+			name:         "handles deprecated v4 name",
+			resourceType: "cloudflare_fallback_domain",
+			expected:     true,
+		},
+		{
+			name:         "does not handle unrelated resource",
+			resourceType: "cloudflare_other_resource",
+			expected:     false,
+		},
+		{
+			name:         "does not handle v5 default profile name",
+			resourceType: "cloudflare_zero_trust_device_default_profile_local_domain_fallback",
+			expected:     false,
+		},
+		{
+			name:         "does not handle v5 custom profile name",
+			resourceType: "cloudflare_zero_trust_device_custom_profile_local_domain_fallback",
+			expected:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := migrator.CanHandle(tt.resourceType)
+			if result != tt.expected {
+				t.Errorf("CanHandle(%q) = %v, expected %v", tt.resourceType, result, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Transforms the `cloudflare_zero_trust_local_fallback_domain` into either `cloudflare_zero_trust_device_default_profile_local_domain_fallback` or `cloudflare_zero_trust_device_custom_profile_local_domain_fallback` depending on whether a `policy_id` is present. 

E2E test currently only tests the `cloudflare_zero_trust_device_default_profile_local_domain_fallback` case, becuase for the other case we rely on a real policy id, which needs the migration for `zero_trust_device_profiles` to be done. Integration tests account for both cases. 

```
========================================
✓ E2E Test Complete!
========================================

Summary:

  Step 1: v4 terraform apply
    Status: ✓ SUCCESS

  Step 2: Migration (v4 → v5)
    Status: ✓ SUCCESS

  Step 3: v5 plan (before apply)
    Status: ✓ No changes needed

  Step 4: v5 terraform apply
    Status: ✓ SUCCESS

  Step 5: v5 plan (after apply)
    Status: ✓ SUCCESS - Stable state achieved
    Result: No changes detected
```