### PR TITLE
feat(zero_trust_tunnel_cloudflared_config): support v4 to v5 migration

### DIFF
--- a/integration/v4_to_v5/integration_test.go
+++ b/integration/v4_to_v5/integration_test.go
@@ -35,6 +35,7 @@ import (
 	_ "github.com/cloudflare/tf-migrate/internal/resources/zero_trust_dlp_custom_profile"
 	_ "github.com/cloudflare/tf-migrate/internal/resources/zero_trust_gateway_policy"
 	_ "github.com/cloudflare/tf-migrate/internal/resources/zero_trust_list"
+	_ "github.com/cloudflare/tf-migrate/internal/resources/zero_trust_tunnel_cloudflared_config"
 	_ "github.com/cloudflare/tf-migrate/internal/resources/zone_setting"
 )
 

--- a/integration/v4_to_v5/testdata/zero_trust_tunnel_cloudflared_config/expected/terraform.tfstate
+++ b/integration/v4_to_v5/testdata/zero_trust_tunnel_cloudflared_config/expected/terraform.tfstate
@@ -1,0 +1,175 @@
+{
+  "lineage": "test-lineage-zero-trust-tunnel-config",
+  "outputs": {},
+  "resources": [
+    {
+      "instances": [
+        {
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "id": "b0000000-0000-0000-0000-000000000001",
+            "name": "cftftest-minimal-tunnel",
+            "secret": "dGVzdC1zZWNyZXQtdGhhdC1pcy1hdC1sZWFzdC0zMi1ieXRlcy1sb25n"
+          },
+          "schema_version": 0
+        }
+      ],
+      "mode": "managed",
+      "name": "minimal",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_zero_trust_tunnel_cloudflared"
+    },
+    {
+      "instances": [
+        {
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "id": "b0000000-0000-0000-0000-000000000002",
+            "name": "cftftest-comprehensive-tunnel",
+            "secret": "YW5vdGhlci1zZWNyZXQtMzItYnl0ZXMtb3ItbG9uZ2VyLWhlcmU="
+          },
+          "schema_version": 0
+        }
+      ],
+      "mode": "managed",
+      "name": "comprehensive",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_zero_trust_tunnel_cloudflared"
+    },
+    {
+      "instances": [
+        {
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "id": "b0000000-0000-0000-0000-000000000003",
+            "name": "cftftest-deprecated-tunnel",
+            "secret": "ZGVwcmVjYXRlZC10dW5uZWwtc2VjcmV0LTMyLWJ5dGVzLW1pbmltdW0="
+          },
+          "schema_version": 0
+        }
+      ],
+      "mode": "managed",
+      "name": "deprecated_name",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_zero_trust_tunnel_cloudflared"
+    },
+    {
+      "instances": [
+        {
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "config": {
+              "ingress": [
+                {
+                  "service": "http_status:404"
+                }
+              ]
+            },
+            "tunnel_id": "b0000000-0000-0000-0000-000000000001"
+          },
+          "dependencies": [
+            "cloudflare_zero_trust_tunnel_cloudflared.minimal"
+          ],
+          "schema_version": 0
+        }
+      ],
+      "mode": "managed",
+      "name": "minimal",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_zero_trust_tunnel_cloudflared_config"
+    },
+    {
+      "instances": [
+        {
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "config": {
+              "ingress": [
+                {
+                  "hostname": "app.example.com",
+                  "service": "http://localhost:8080"
+                },
+                {
+                  "service": "http_status:404"
+                }
+              ]
+            },
+            "tunnel_id": "b0000000-0000-0000-0000-000000000003"
+          },
+          "dependencies": [
+            "cloudflare_zero_trust_tunnel_cloudflared.deprecated_name"
+          ],
+          "schema_version": 0
+        }
+      ],
+      "mode": "managed",
+      "name": "deprecated_name",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_zero_trust_tunnel_cloudflared_config"
+    },
+    {
+      "instances": [
+        {
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "config": {
+              "ingress": [
+                {
+                  "hostname": "app.example.com",
+                  "origin_request": {
+                    "access": {
+                      "required": false
+                    },
+                    "connect_timeout": 15000000000,
+                    "tls_timeout": 5000000000
+                  },
+                  "path": "/api",
+                  "service": "http://localhost:8080"
+                },
+                {
+                  "hostname": "api.example.com",
+                  "service": "http://localhost:3000"
+                },
+                {
+                  "service": "http_status:404"
+                }
+              ],
+              "origin_request": {
+                "access": {
+                  "aud_tag": [
+                    "abc123"
+                  ],
+                  "required": true,
+                  "team_name": "my-team"
+                },
+                "ca_pool": "/path/to/ca.pem",
+                "connect_timeout": 30000000000,
+                "disable_chunked_encoding": false,
+                "http_host_header": "example.com",
+                "keep_alive_connections": 100,
+                "keep_alive_timeout": 90000000000,
+                "no_tls_verify": false,
+                "origin_server_name": "origin.example.com",
+                "proxy_type": "",
+                "tcp_keep_alive": 90000000000,
+                "tls_timeout": 10000000000
+              }
+            },
+            "tunnel_id": "b0000000-0000-0000-0000-000000000002"
+          },
+          "dependencies": [
+            "cloudflare_zero_trust_tunnel_cloudflared.comprehensive"
+          ],
+          "schema_version": 0
+        }
+      ],
+      "mode": "managed",
+      "name": "comprehensive",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_zero_trust_tunnel_cloudflared_config"
+    }
+  ],
+  "serial": 1,
+  "terraform_version": "1.5.0",
+  "version": 4
+}

--- a/integration/v4_to_v5/testdata/zero_trust_tunnel_cloudflared_config/expected/zero_trust_tunnel_cloudflared_config.tf
+++ b/integration/v4_to_v5/testdata/zero_trust_tunnel_cloudflared_config/expected/zero_trust_tunnel_cloudflared_config.tf
@@ -1,0 +1,134 @@
+variable "cloudflare_account_id" {
+  type = string
+}
+
+variable "cloudflare_zone_id" {
+  description = "Cloudflare zone ID"
+  type        = string
+}
+
+variable "cloudflare_domain" {
+  description = "Cloudflare domain for testing"
+  type        = string
+}
+
+locals {
+  name_prefix = "cftftest"
+}
+
+# ========================================
+# Parent Tunnel Resources
+# ========================================
+
+# Tunnel for minimal config test
+resource "cloudflare_zero_trust_tunnel_cloudflared" "minimal" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-minimal-tunnel"
+  secret     = base64encode("test-secret-that-is-at-least-32-bytes-long")
+}
+
+# Tunnel for comprehensive config test
+resource "cloudflare_zero_trust_tunnel_cloudflared" "comprehensive" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-comprehensive-tunnel"
+  secret     = base64encode("another-secret-32-bytes-or-longer-here")
+}
+
+# Tunnel for testing deprecated resource name
+resource "cloudflare_zero_trust_tunnel_cloudflared" "deprecated_name" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-deprecated-tunnel"
+  secret     = base64encode("deprecated-tunnel-secret-32-bytes-minimum")
+}
+
+# ========================================
+# Tunnel Config Resources
+# ========================================
+
+# Test 1: Minimal configuration using preferred resource name
+resource "cloudflare_zero_trust_tunnel_cloudflared_config" "minimal" {
+  account_id = var.cloudflare_account_id
+  tunnel_id  = cloudflare_zero_trust_tunnel_cloudflared.minimal.id
+
+  config {
+    ingress_rule {
+      service = "http_status:404"
+    }
+  }
+}
+
+# Test 2: Deprecated resource name (cloudflare_tunnel_config)
+resource "cloudflare_zero_trust_tunnel_cloudflared_config" "deprecated_name" {
+  account_id = var.cloudflare_account_id
+  tunnel_id  = cloudflare_zero_trust_tunnel_cloudflared.deprecated_name.id
+
+  config {
+    ingress_rule {
+      hostname = "app.example.com"
+      service  = "http://localhost:8080"
+    }
+    ingress_rule {
+      service = "http_status:404"
+    }
+  }
+}
+
+# Test 3: Comprehensive configuration with all transformations
+resource "cloudflare_zero_trust_tunnel_cloudflared_config" "comprehensive" {
+  account_id = var.cloudflare_account_id
+  tunnel_id  = cloudflare_zero_trust_tunnel_cloudflared.comprehensive.id
+
+  config {
+
+    # Config-level origin_request
+    origin_request {
+      connect_timeout          = "30s"
+      tls_timeout              = "10s"
+      tcp_keep_alive           = "1m30s"
+      keep_alive_timeout       = "1m30s"
+      keep_alive_connections   = 100
+      http_host_header         = "example.com"
+      origin_server_name       = "origin.example.com"
+      ca_pool                  = "/path/to/ca.pem"
+      no_tls_verify            = false
+      disable_chunked_encoding = false
+      # Deprecated fields to be removed
+      bastion_mode  = true
+      proxy_address = "127.0.0.1"
+      proxy_port    = 8080
+      proxy_type    = ""
+
+      # access block (MaxItems:1 array -> object)
+      access {
+        required  = true
+        team_name = "my-team"
+        aud_tag   = ["abc123"]
+      }
+    }
+
+    ingress_rule {
+      hostname = "app.example.com"
+      service  = "http://localhost:8080"
+      path     = "/api"
+
+      # Ingress-level origin_request
+      origin_request {
+        connect_timeout = "15s"
+        tls_timeout     = "5s"
+        # access block
+        access {
+          required = false
+        }
+      }
+    }
+
+    ingress_rule {
+      hostname = "api.example.com"
+      service  = "http://localhost:3000"
+    }
+
+    ingress_rule {
+      service = "http_status:404"
+    }
+  }
+}

--- a/integration/v4_to_v5/testdata/zero_trust_tunnel_cloudflared_config/input/terraform.tfstate
+++ b/integration/v4_to_v5/testdata/zero_trust_tunnel_cloudflared_config/input/terraform.tfstate
@@ -1,0 +1,208 @@
+{
+  "version": 4,
+  "terraform_version": "1.5.0",
+  "serial": 1,
+  "lineage": "test-lineage-zero-trust-tunnel-config",
+  "outputs": {},
+  "resources": [
+    {
+      "mode": "managed",
+      "type": "cloudflare_zero_trust_tunnel_cloudflared",
+      "name": "minimal",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "b0000000-0000-0000-0000-000000000001",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "name": "cftftest-minimal-tunnel",
+            "secret": "dGVzdC1zZWNyZXQtdGhhdC1pcy1hdC1sZWFzdC0zMi1ieXRlcy1sb25n"
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_zero_trust_tunnel_cloudflared",
+      "name": "comprehensive",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "b0000000-0000-0000-0000-000000000002",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "name": "cftftest-comprehensive-tunnel",
+            "secret": "YW5vdGhlci1zZWNyZXQtMzItYnl0ZXMtb3ItbG9uZ2VyLWhlcmU="
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_zero_trust_tunnel_cloudflared",
+      "name": "deprecated_name",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "b0000000-0000-0000-0000-000000000003",
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "name": "cftftest-deprecated-tunnel",
+            "secret": "ZGVwcmVjYXRlZC10dW5uZWwtc2VjcmV0LTMyLWJ5dGVzLW1pbmltdW0="
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_zero_trust_tunnel_cloudflared_config",
+      "name": "minimal",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "tunnel_id": "b0000000-0000-0000-0000-000000000001",
+            "config": [
+              {
+                "ingress_rule": [
+                  {
+                    "service": "http_status:404"
+                  }
+                ]
+              }
+            ]
+          },
+          "dependencies": [
+            "cloudflare_zero_trust_tunnel_cloudflared.minimal"
+          ]
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_tunnel_config",
+      "name": "deprecated_name",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "tunnel_id": "b0000000-0000-0000-0000-000000000003",
+            "config": [
+              {
+                "ingress_rule": [
+                  {
+                    "hostname": "app.example.com",
+                    "service": "http://localhost:8080"
+                  },
+                  {
+                    "service": "http_status:404"
+                  }
+                ]
+              }
+            ]
+          },
+          "dependencies": [
+            "cloudflare_zero_trust_tunnel_cloudflared.deprecated_name"
+          ]
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_tunnel_config",
+      "name": "comprehensive",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "tunnel_id": "b0000000-0000-0000-0000-000000000002",
+            "config": [
+              {
+                "warp_routing": [
+                  {
+                    "enabled": true
+                  }
+                ],
+                "origin_request": [
+                  {
+                    "connect_timeout": "30s",
+                    "tls_timeout": "10s",
+                    "tcp_keep_alive": "1m30s",
+                    "keep_alive_timeout": "1m30s",
+                    "keep_alive_connections": 100,
+                    "http_host_header": "example.com",
+                    "origin_server_name": "origin.example.com",
+                    "ca_pool": "/path/to/ca.pem",
+                    "no_tls_verify": false,
+                    "disable_chunked_encoding": false,
+                    "bastion_mode": true,
+                    "proxy_address": "127.0.0.1",
+                    "proxy_port": 8080,
+                    "proxy_type": "",
+                    "ip_rules": [
+                      {
+                        "prefix": "192.0.2.0/24",
+                        "ports": [80, 443],
+                        "allow": true
+                      }
+                    ],
+                    "access": [
+                      {
+                        "required": true,
+                        "team_name": "my-team",
+                        "aud_tag": ["abc123"]
+                      }
+                    ]
+                  }
+                ],
+                "ingress_rule": [
+                  {
+                    "hostname": "app.example.com",
+                    "service": "http://localhost:8080",
+                    "path": "/api",
+                    "origin_request": [
+                      {
+                        "connect_timeout": "15s",
+                        "tls_timeout": "5s",
+                        "ip_rules": [
+                          {
+                            "prefix": "198.51.100.0/24",
+                            "allow": false
+                          }
+                        ],
+                        "access": [
+                          {
+                            "required": false
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "hostname": "api.example.com",
+                    "service": "http://localhost:3000"
+                  },
+                  {
+                    "service": "http_status:404"
+                  }
+                ]
+              }
+            ]
+          },
+          "dependencies": [
+            "cloudflare_zero_trust_tunnel_cloudflared.comprehensive"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/integration/v4_to_v5/testdata/zero_trust_tunnel_cloudflared_config/input/zero_trust_tunnel_cloudflared_config.tf
+++ b/integration/v4_to_v5/testdata/zero_trust_tunnel_cloudflared_config/input/zero_trust_tunnel_cloudflared_config.tf
@@ -1,0 +1,149 @@
+variable "cloudflare_account_id" {
+  type = string
+}
+
+variable "cloudflare_zone_id" {
+  description = "Cloudflare zone ID"
+  type        = string
+}
+
+variable "cloudflare_domain" {
+  description = "Cloudflare domain for testing"
+  type        = string
+}
+
+locals {
+  name_prefix = "cftftest"
+}
+
+# ========================================
+# Parent Tunnel Resources
+# ========================================
+
+# Tunnel for minimal config test
+resource "cloudflare_zero_trust_tunnel_cloudflared" "minimal" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-minimal-tunnel"
+  secret     = base64encode("test-secret-that-is-at-least-32-bytes-long")
+}
+
+# Tunnel for comprehensive config test
+resource "cloudflare_zero_trust_tunnel_cloudflared" "comprehensive" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-comprehensive-tunnel"
+  secret     = base64encode("another-secret-32-bytes-or-longer-here")
+}
+
+# Tunnel for testing deprecated resource name
+resource "cloudflare_zero_trust_tunnel_cloudflared" "deprecated_name" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-deprecated-tunnel"
+  secret     = base64encode("deprecated-tunnel-secret-32-bytes-minimum")
+}
+
+# ========================================
+# Tunnel Config Resources
+# ========================================
+
+# Test 1: Minimal configuration using preferred resource name
+resource "cloudflare_zero_trust_tunnel_cloudflared_config" "minimal" {
+  account_id = var.cloudflare_account_id
+  tunnel_id  = cloudflare_zero_trust_tunnel_cloudflared.minimal.id
+
+  config {
+    ingress_rule {
+      service = "http_status:404"
+    }
+  }
+}
+
+# Test 2: Deprecated resource name (cloudflare_tunnel_config)
+resource "cloudflare_tunnel_config" "deprecated_name" {
+  account_id = var.cloudflare_account_id
+  tunnel_id  = cloudflare_zero_trust_tunnel_cloudflared.deprecated_name.id
+
+  config {
+    ingress_rule {
+      hostname = "app.example.com"
+      service  = "http://localhost:8080"
+    }
+    ingress_rule {
+      service = "http_status:404"
+    }
+  }
+}
+
+# Test 3: Comprehensive configuration with all transformations
+resource "cloudflare_tunnel_config" "comprehensive" {
+  account_id = var.cloudflare_account_id
+  tunnel_id  = cloudflare_zero_trust_tunnel_cloudflared.comprehensive.id
+
+  config {
+    # warp_routing will be removed in v5
+    warp_routing {
+      enabled = true
+    }
+
+    # Config-level origin_request
+    origin_request {
+      connect_timeout          = "30s"
+      tls_timeout              = "10s"
+      tcp_keep_alive           = "1m30s"
+      keep_alive_timeout       = "1m30s"
+      keep_alive_connections   = 100
+      http_host_header         = "example.com"
+      origin_server_name       = "origin.example.com"
+      ca_pool                  = "/path/to/ca.pem"
+      no_tls_verify            = false
+      disable_chunked_encoding = false
+      # Deprecated fields to be removed
+      bastion_mode             = true
+      proxy_address            = "127.0.0.1"
+      proxy_port               = 8080
+      proxy_type               = ""
+      # ip_rules block will be removed
+      ip_rules {
+        prefix = "192.0.2.0/24"
+        ports  = [80, 443]
+        allow  = true
+      }
+
+      # access block (MaxItems:1 array -> object)
+      access {
+        required  = true
+        team_name = "my-team"
+        aud_tag   = ["abc123"]
+      }
+    }
+
+    ingress_rule {
+      hostname = "app.example.com"
+      service  = "http://localhost:8080"
+      path     = "/api"
+
+      # Ingress-level origin_request
+      origin_request {
+        connect_timeout = "15s"
+        tls_timeout     = "5s"
+        # ip_rules to be removed
+        ip_rules {
+          prefix = "198.51.100.0/24"
+          allow  = false
+        }
+        # access block
+        access {
+          required = false
+        }
+      }
+    }
+
+    ingress_rule {
+      hostname = "api.example.com"
+      service  = "http://localhost:3000"
+    }
+
+    ingress_rule {
+      service = "http_status:404"
+    }
+  }
+}

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -48,6 +48,7 @@ import (
 	"github.com/cloudflare/tf-migrate/internal/resources/zero_trust_list"
 	"github.com/cloudflare/tf-migrate/internal/resources/zero_trust_local_fallback_domain"
 	"github.com/cloudflare/tf-migrate/internal/resources/zero_trust_tunnel_cloudflared"
+	"github.com/cloudflare/tf-migrate/internal/resources/zero_trust_tunnel_cloudflared_config"
 	"github.com/cloudflare/tf-migrate/internal/resources/zero_trust_tunnel_cloudflared_route"
 	"github.com/cloudflare/tf-migrate/internal/resources/zero_trust_tunnel_cloudflared_virtual_network"
 	"github.com/cloudflare/tf-migrate/internal/resources/zone"
@@ -112,6 +113,7 @@ func RegisterAllMigrations() {
 	zero_trust_list.NewV4ToV5Migrator()
 	zero_trust_local_fallback_domain.NewV4ToV5Migrator()
 	zero_trust_tunnel_cloudflared.NewV4ToV5Migrator()
+	zero_trust_tunnel_cloudflared_config.NewV4ToV5Migrator()
 	zero_trust_tunnel_cloudflared_route.NewV4ToV5Migrator()
 	zero_trust_tunnel_cloudflared_virtual_network.NewV4ToV5Migrator()
 }

--- a/internal/resources/zero_trust_tunnel_cloudflared_config/v4_to_v5.go
+++ b/internal/resources/zero_trust_tunnel_cloudflared_config/v4_to_v5.go
@@ -1,0 +1,221 @@
+package zero_trust_tunnel_cloudflared_config
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/hcl/v2/hclwrite"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+
+	"github.com/cloudflare/tf-migrate/internal"
+	"github.com/cloudflare/tf-migrate/internal/transform"
+	tfhcl "github.com/cloudflare/tf-migrate/internal/transform/hcl"
+	"github.com/cloudflare/tf-migrate/internal/transform/state"
+)
+
+// V4ToV5Migrator handles migration of zero trust tunnel cloudflared config resources from v4 to v5
+type V4ToV5Migrator struct{}
+
+func NewV4ToV5Migrator() transform.ResourceTransformer {
+	migrator := &V4ToV5Migrator{}
+	// Register BOTH v4 resource names (deprecated and preferred)
+	internal.RegisterMigrator("cloudflare_tunnel_config", "v4", "v5", migrator)
+	internal.RegisterMigrator("cloudflare_zero_trust_tunnel_cloudflared_config", "v4", "v5", migrator)
+	return migrator
+}
+
+func (m *V4ToV5Migrator) GetResourceType() string {
+	// Return the NEW (v5) resource name (same as preferred v4 name)
+	return "cloudflare_zero_trust_tunnel_cloudflared_config"
+}
+
+func (m *V4ToV5Migrator) CanHandle(resourceType string) bool {
+	// Handle both the deprecated name and the preferred v4 name
+	return resourceType == "cloudflare_tunnel_config" || resourceType == "cloudflare_zero_trust_tunnel_cloudflared_config"
+}
+
+func (m *V4ToV5Migrator) Preprocess(content string) string {
+	// No preprocessing needed - HCL parser can handle all transformations
+	return content
+}
+
+// GetResourceRename implements the ResourceRenamer interface
+// This allows the migration tool to collect all resource renames and apply them globally
+func (m *V4ToV5Migrator) GetResourceRename() (string, string) {
+	return "cloudflare_tunnel_config", "cloudflare_zero_trust_tunnel_cloudflared_config"
+}
+
+func (m *V4ToV5Migrator) TransformConfig(ctx *transform.Context, block *hclwrite.Block) (*transform.TransformResult, error) {
+	resourceType := tfhcl.GetResourceType(block)
+
+	// Rename resource type if using deprecated name
+	if resourceType == "cloudflare_tunnel_config" {
+		tfhcl.RenameResourceType(block, "cloudflare_tunnel_config", "cloudflare_zero_trust_tunnel_cloudflared_config")
+	}
+
+	body := block.Body()
+
+	// Process config block if it exists
+	configBlocks := tfhcl.FindBlocksByType(body, "config")
+	for _, configBlock := range configBlocks {
+		configBody := configBlock.Body()
+
+		// Remove deprecated blocks that were removed in v5
+		tfhcl.RemoveBlocksByType(configBody, "warp_routing")
+
+		// Remove ip_rules from all origin_request blocks
+		// (at config level)
+		originReqBlocks := tfhcl.FindBlocksByType(configBody, "origin_request")
+		for _, originReqBlock := range originReqBlocks {
+			tfhcl.RemoveBlocksByType(originReqBlock.Body(), "ip_rules")
+		}
+
+		// Remove ip_rules from nested origin_request blocks within ingress_rule
+		ingressBlocks := tfhcl.FindBlocksByType(configBody, "ingress_rule")
+		for _, ingressBlock := range ingressBlocks {
+			nestedOriginReqBlocks := tfhcl.FindBlocksByType(ingressBlock.Body(), "origin_request")
+			for _, nestedOriginReqBlock := range nestedOriginReqBlocks {
+				tfhcl.RemoveBlocksByType(nestedOriginReqBlock.Body(), "ip_rules")
+			}
+		}
+	}
+
+	// Note: Additional v4→v5 schema changes (MaxItems:1 block→attribute conversions,
+	// ingress_rule→ingress rename) are handled in the state transformation.
+	// HCL config transformation focuses on removing deprecated fields to ensure
+	// configs remain valid. Users can update block→attribute syntax using
+	// terraform fmt or the v5 provider will handle it.
+
+	return &transform.TransformResult{
+		Blocks:         []*hclwrite.Block{block},
+		RemoveOriginal: false,
+	}, nil
+}
+
+func (m *V4ToV5Migrator) TransformState(ctx *transform.Context, instance gjson.Result, resourcePath, resourceName string) (string, error) {
+	result := instance.String()
+	attrs := instance.Get("attributes")
+
+	if !attrs.Exists() {
+		return result, nil
+	}
+
+	// Always use relative path within the instance JSON (not the full state path)
+	path := "attributes"
+
+	// 1. Transform config array [{}] → object {}
+	result = state.TransformFieldArrayToObject(result, path, attrs, "config", state.ArrayToObjectOptions{})
+
+	// Get the transformed config to work with (re-parse from root)
+	resultParsed := gjson.Parse(result)
+	attrs = resultParsed.Get(path)
+	configObj := attrs.Get("config")
+
+	if configObj.Exists() && configObj.IsObject() {
+		configPath := path + ".config"
+
+		// 2. Rename ingress_rule → ingress inside config
+		result = state.RenameField(result, configPath, configObj, "ingress_rule", "ingress")
+
+		// 3. Remove deprecated fields from config
+		result = state.RemoveFields(result, configPath, configObj, "warp_routing")
+
+		// Refresh config after changes
+		configObj = gjson.Parse(result).Get(configPath)
+
+		// 4. Transform config-level origin_request array → object
+		originReqPath := configPath + ".origin_request"
+		result = transformOriginRequest(result, originReqPath, configObj.Get("origin_request"))
+
+		// 5. Transform ingress array elements' origin_request
+		ingressArray := gjson.Parse(result).Get(configPath + ".ingress")
+		if ingressArray.Exists() && ingressArray.IsArray() {
+			for i, ingressItem := range ingressArray.Array() {
+				originReq := ingressItem.Get("origin_request")
+				if originReq.Exists() {
+					ingressOriginReqPath := fmt.Sprintf("%s.ingress.%d.origin_request", configPath, i)
+					result = transformOriginRequest(result, ingressOriginReqPath, originReq)
+				}
+			}
+		}
+	}
+
+	// Set schema_version to 0 for v5
+	result, _ = sjson.Set(result, "schema_version", 0)
+
+	// Update the type field if it exists (for unit tests that pass instance-level type)
+	if instance.Get("type").Exists() {
+		result, _ = sjson.Set(result, "type", "cloudflare_zero_trust_tunnel_cloudflared_config")
+	}
+
+	return result, nil
+}
+
+// transformOriginRequest transforms an origin_request field from array to object and handles nested transformations
+func transformOriginRequest(stateJSON string, path string, originReq gjson.Result) string {
+	if !originReq.Exists() {
+		return stateJSON
+	}
+
+	// If it's an array, convert to object first
+	if originReq.IsArray() {
+		array := originReq.Array()
+		if len(array) > 0 {
+			stateJSON, _ = sjson.Set(stateJSON, path, array[0].Value())
+		} else {
+			// Empty array - delete it
+			stateJSON, _ = sjson.Delete(stateJSON, path)
+			return stateJSON
+		}
+		// Refresh origin_request after conversion
+		originReq = gjson.Parse(stateJSON).Get(path)
+	}
+
+	if !originReq.IsObject() {
+		return stateJSON
+	}
+
+	// Remove deprecated fields
+	stateJSON = state.RemoveFields(stateJSON, path, originReq, "bastion_mode", "proxy_address", "proxy_port", "ip_rules")
+
+	// Refresh after removals
+	originReq = gjson.Parse(stateJSON).Get(path)
+
+	// Convert duration fields from strings to int64 nanoseconds
+	durationFields := []string{"connect_timeout", "tls_timeout", "tcp_keep_alive", "keep_alive_timeout"}
+	for _, field := range durationFields {
+		fieldValue := originReq.Get(field)
+		if fieldValue.Exists() && fieldValue.Type == gjson.String {
+			if nanos, err := parseDurationToNanoseconds(fieldValue.String()); err == nil {
+				stateJSON, _ = sjson.Set(stateJSON, path+"."+field, nanos)
+			}
+		}
+	}
+
+	// Convert keep_alive_connections from int to int64
+	keepAliveConns := originReq.Get("keep_alive_connections")
+	if keepAliveConns.Exists() {
+		stateJSON, _ = sjson.Set(stateJSON, path+".keep_alive_connections", state.ConvertToInt64(keepAliveConns))
+	}
+
+	// Refresh origin_request after duration conversions
+	originReq = gjson.Parse(stateJSON).Get(path)
+
+	// Transform nested access array → object
+	accessField := originReq.Get("access")
+	if accessField.Exists() {
+		stateJSON = state.TransformFieldArrayToObject(stateJSON, path, originReq, "access", state.ArrayToObjectOptions{})
+	}
+
+	return stateJSON
+}
+
+// parseDurationToNanoseconds converts a Go duration string (e.g., "30s", "1m30s") to int64 nanoseconds
+func parseDurationToNanoseconds(durationStr string) (int64, error) {
+	duration, err := time.ParseDuration(durationStr)
+	if err != nil {
+		return 0, fmt.Errorf("failed to parse duration %q: %w", durationStr, err)
+	}
+	return duration.Nanoseconds(), nil
+}

--- a/internal/resources/zero_trust_tunnel_cloudflared_config/v4_to_v5_test.go
+++ b/internal/resources/zero_trust_tunnel_cloudflared_config/v4_to_v5_test.go
@@ -1,0 +1,399 @@
+package zero_trust_tunnel_cloudflared_config
+
+import (
+	"testing"
+
+	"github.com/cloudflare/tf-migrate/internal/testhelpers"
+)
+
+func TestV4ToV5Transformation(t *testing.T) {
+	migrator := NewV4ToV5Migrator()
+
+	t.Run("ConfigTransformation", func(t *testing.T) {
+		tests := []testhelpers.ConfigTestCase{
+			{
+				Name: "Minimal config - deprecated resource name",
+				Input: `resource "cloudflare_tunnel_config" "example" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+  tunnel_id  = "f70ff02e-f290-4d76-8c21-c00e98a7fbde"
+  config {
+    ingress_rule {
+      service = "http_status:404"
+    }
+  }
+}`,
+				Expected: `resource "cloudflare_zero_trust_tunnel_cloudflared_config" "example" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+  tunnel_id  = "f70ff02e-f290-4d76-8c21-c00e98a7fbde"
+  config {
+    ingress_rule {
+      service = "http_status:404"
+    }
+  }
+}`,
+			},
+			{
+				Name: "Minimal config - preferred resource name",
+				Input: `resource "cloudflare_zero_trust_tunnel_cloudflared_config" "example" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+  tunnel_id  = "f70ff02e-f290-4d76-8c21-c00e98a7fbde"
+  config {
+    ingress_rule {
+      service = "http_status:404"
+    }
+  }
+}`,
+				Expected: `resource "cloudflare_zero_trust_tunnel_cloudflared_config" "example" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+  tunnel_id  = "f70ff02e-f290-4d76-8c21-c00e98a7fbde"
+  config {
+    ingress_rule {
+      service = "http_status:404"
+    }
+  }
+}`,
+			},
+			{
+				Name: "Remove warp_routing block",
+				Input: `resource "cloudflare_tunnel_config" "example" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+  tunnel_id  = "f70ff02e-f290-4d76-8c21-c00e98a7fbde"
+  config {
+    warp_routing {
+      enabled = true
+    }
+    ingress_rule {
+      service = "http_status:404"
+    }
+  }
+}`,
+				Expected: `resource "cloudflare_zero_trust_tunnel_cloudflared_config" "example" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+  tunnel_id  = "f70ff02e-f290-4d76-8c21-c00e98a7fbde"
+  config {
+    ingress_rule {
+      service = "http_status:404"
+    }
+  }
+}`,
+			},
+			{
+				Name: "Remove ip_rules from config-level origin_request",
+				Input: `resource "cloudflare_tunnel_config" "example" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+  tunnel_id  = "f70ff02e-f290-4d76-8c21-c00e98a7fbde"
+  config {
+    origin_request {
+      connect_timeout = "30s"
+      ip_rules {
+        prefix = "192.0.2.0/24"
+        ports  = [80, 443]
+        allow  = true
+      }
+    }
+    ingress_rule {
+      service = "http_status:404"
+    }
+  }
+}`,
+				Expected: `resource "cloudflare_zero_trust_tunnel_cloudflared_config" "example" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+  tunnel_id  = "f70ff02e-f290-4d76-8c21-c00e98a7fbde"
+  config {
+    origin_request {
+      connect_timeout = "30s"
+    }
+    ingress_rule {
+      service = "http_status:404"
+    }
+  }
+}`,
+			},
+			{
+				Name: "Remove ip_rules from ingress-level origin_request",
+				Input: `resource "cloudflare_tunnel_config" "example" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+  tunnel_id  = "f70ff02e-f290-4d76-8c21-c00e98a7fbde"
+  config {
+    ingress_rule {
+      hostname = "app.example.com"
+      service  = "http://localhost:8080"
+      origin_request {
+        connect_timeout = "10s"
+        ip_rules {
+          prefix = "198.51.100.0/24"
+          allow  = false
+        }
+      }
+    }
+    ingress_rule {
+      service = "http_status:404"
+    }
+  }
+}`,
+				Expected: `resource "cloudflare_zero_trust_tunnel_cloudflared_config" "example" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+  tunnel_id  = "f70ff02e-f290-4d76-8c21-c00e98a7fbde"
+  config {
+    ingress_rule {
+      hostname = "app.example.com"
+      service  = "http://localhost:8080"
+      origin_request {
+        connect_timeout = "10s"
+      }
+    }
+    ingress_rule {
+      service = "http_status:404"
+    }
+  }
+}`,
+			},
+			{
+				Name: "Remove all deprecated blocks - comprehensive",
+				Input: `resource "cloudflare_tunnel_config" "example" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+  tunnel_id  = "f70ff02e-f290-4d76-8c21-c00e98a7fbde"
+  config {
+    warp_routing {
+      enabled = true
+    }
+    origin_request {
+      connect_timeout = "30s"
+      ip_rules {
+        prefix = "192.0.2.0/24"
+        ports  = [80, 443]
+        allow  = true
+      }
+    }
+    ingress_rule {
+      hostname = "app.example.com"
+      service  = "http://localhost:8080"
+      origin_request {
+        tls_timeout = "10s"
+        ip_rules {
+          prefix = "198.51.100.0/24"
+          allow  = false
+        }
+      }
+    }
+    ingress_rule {
+      service = "http_status:404"
+    }
+  }
+}`,
+				Expected: `resource "cloudflare_zero_trust_tunnel_cloudflared_config" "example" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+  tunnel_id  = "f70ff02e-f290-4d76-8c21-c00e98a7fbde"
+  config {
+    origin_request {
+      connect_timeout = "30s"
+    }
+    ingress_rule {
+      hostname = "app.example.com"
+      service  = "http://localhost:8080"
+      origin_request {
+        tls_timeout = "10s"
+      }
+    }
+    ingress_rule {
+      service = "http_status:404"
+    }
+  }
+}`,
+			},
+		}
+
+		testhelpers.RunConfigTransformTests(t, tests, migrator)
+	})
+
+	t.Run("StateTransformation", func(t *testing.T) {
+		tests := []testhelpers.StateTestCase{
+			{
+				Name: "Minimal state - deprecated resource name",
+				Input: `{
+  "type": "cloudflare_tunnel_config",
+  "name": "example",
+  "attributes": {
+    "account_id": "f037e56e89293a057740de681ac9abbe",
+    "tunnel_id": "f70ff02e-f290-4d76-8c21-c00e98a7fbde",
+    "config": [
+      {
+        "ingress_rule": [
+          {
+            "service": "http_status:404"
+          }
+        ]
+      }
+    ]
+  },
+  "schema_version": 0
+}`,
+				Expected: `{
+  "type": "cloudflare_zero_trust_tunnel_cloudflared_config",
+  "name": "example",
+  "attributes": {
+    "account_id": "f037e56e89293a057740de681ac9abbe",
+    "tunnel_id": "f70ff02e-f290-4d76-8c21-c00e98a7fbde",
+    "config": {
+      "ingress": [
+        {
+          "service": "http_status:404"
+        }
+      ]
+    }
+  },
+  "schema_version": 0
+}`,
+			},
+			{
+				Name: "Minimal state - preferred resource name",
+				Input: `{
+  "type": "cloudflare_zero_trust_tunnel_cloudflared_config",
+  "name": "example",
+  "attributes": {
+    "account_id": "f037e56e89293a057740de681ac9abbe",
+    "tunnel_id": "f70ff02e-f290-4d76-8c21-c00e98a7fbde",
+    "config": [
+      {
+        "ingress_rule": [
+          {
+            "service": "http_status:404"
+          }
+        ]
+      }
+    ]
+  },
+  "schema_version": 0
+}`,
+				Expected: `{
+  "type": "cloudflare_zero_trust_tunnel_cloudflared_config",
+  "name": "example",
+  "attributes": {
+    "account_id": "f037e56e89293a057740de681ac9abbe",
+    "tunnel_id": "f70ff02e-f290-4d76-8c21-c00e98a7fbde",
+    "config": {
+      "ingress": [
+        {
+          "service": "http_status:404"
+        }
+      ]
+    }
+  },
+  "schema_version": 0
+}`,
+			},
+			{
+				Name: "Complete transformation with all fields",
+				Input: `{
+  "type": "cloudflare_tunnel_config",
+  "name": "example",
+  "attributes": {
+    "account_id": "f037e56e89293a057740de681ac9abbe",
+    "tunnel_id": "f70ff02e-f290-4d76-8c21-c00e98a7fbde",
+    "config": [
+      {
+        "warp_routing": [
+          {
+            "enabled": true
+          }
+        ],
+        "origin_request": [
+          {
+            "connect_timeout": "30s",
+            "tls_timeout": "10s",
+            "tcp_keep_alive": "1m30s",
+            "keep_alive_timeout": "1m30s",
+            "keep_alive_connections": 100,
+            "bastion_mode": true,
+            "proxy_address": "127.0.0.1",
+            "proxy_port": 8080,
+            "ip_rules": [
+              {
+                "prefix": "192.0.2.0/24",
+                "ports": [80, 443],
+                "allow": true
+              }
+            ],
+            "access": [
+              {
+                "required": true,
+                "team_name": "my-team",
+                "aud_tag": ["abc123"]
+              }
+            ]
+          }
+        ],
+        "ingress_rule": [
+          {
+            "hostname": "app.example.com",
+            "service": "http://localhost:8080",
+            "origin_request": [
+              {
+                "connect_timeout": "15s",
+                "ip_rules": [
+                  {
+                    "prefix": "198.51.100.0/24",
+                    "allow": false
+                  }
+                ],
+                "access": [
+                  {
+                    "required": false
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "service": "http_status:404"
+          }
+        ]
+      }
+    ]
+  },
+  "schema_version": 0
+}`,
+				Expected: `{
+  "type": "cloudflare_zero_trust_tunnel_cloudflared_config",
+  "name": "example",
+  "attributes": {
+    "account_id": "f037e56e89293a057740de681ac9abbe",
+    "tunnel_id": "f70ff02e-f290-4d76-8c21-c00e98a7fbde",
+    "config": {
+      "origin_request": {
+        "connect_timeout": 30000000000,
+        "tls_timeout": 10000000000,
+        "tcp_keep_alive": 90000000000,
+        "keep_alive_timeout": 90000000000,
+        "keep_alive_connections": 100,
+        "access": {
+          "required": true,
+          "team_name": "my-team",
+          "aud_tag": ["abc123"]
+        }
+      },
+      "ingress": [
+        {
+          "hostname": "app.example.com",
+          "service": "http://localhost:8080",
+          "origin_request": {
+            "connect_timeout": 15000000000,
+            "access": {
+              "required": false
+            }
+          }
+        },
+        {
+          "service": "http_status:404"
+        }
+      ]
+    }
+  },
+  "schema_version": 0
+}`,
+			},
+		}
+
+		testhelpers.RunStateTransformTests(t, tests, migrator)
+	})
+}


### PR DESCRIPTION
Supports migration of two v4 resources, `tunnel_config` and `zero_trust_tunnel_cloudflared_config`.

The following changes were made:
- handle rename if it was v4 resource name `tunnel_config`
- removed fields that no longer exist in v5: `warp_routing.enabled`, `origin_request.bastion_mode`, `origin_request.proxy_port`, `origin_request.proxy_address`, `origin_request.ip_rules`
- block to attribute conversions: `origin_request`, `config`, `origin_request.access`
- renames: `ingress_rule` to `ingress`
- Type conversions (TypeInt → Int64)
- String to Int64: `tls_timeout`, `connect_timeout`, `tcp_keep_alive`, `keep_alive_timeout`