### PR TITLE
fix(zero_trust_*): ensure all resources use cftftest prefix

### DIFF
--- a/integration/v4_to_v5/testdata/zero_trust_list/expected/terraform.tfstate
+++ b/integration/v4_to_v5/testdata/zero_trust_list/expected/terraform.tfstate
@@ -375,7 +375,7 @@
                 "value": "www.malware.cf-tf-test.com"
               }
             ],
-            "name": "test-list-malware",
+            "name": "cftftest-list-malware",
             "type": "DOMAIN"
           },
           "index_key": "malware",
@@ -403,7 +403,7 @@
                 "value": "www.phishing.cf-tf-test.com"
               }
             ],
-            "name": "test-list-phishing",
+            "name": "cftftest-list-phishing",
             "type": "DOMAIN"
           },
           "index_key": "phishing",
@@ -431,7 +431,7 @@
                 "value": "www.spam.cf-tf-test.com"
               }
             ],
-            "name": "test-list-spam",
+            "name": "cftftest-list-spam",
             "type": "DOMAIN"
           },
           "index_key": "spam",
@@ -456,7 +456,7 @@
                 "value": "staging.cf-tf-test.com"
               }
             ],
-            "name": "test-list-staging",
+            "name": "cftftest-list-staging",
             "type": "DOMAIN"
           },
           "index_key": "staging",
@@ -481,7 +481,7 @@
                 "value": "production.cf-tf-test.com"
               }
             ],
-            "name": "test-list-production",
+            "name": "cftftest-list-production",
             "type": "DOMAIN"
           },
           "index_key": "production",
@@ -506,7 +506,7 @@
                 "value": "development.cf-tf-test.com"
               }
             ],
-            "name": "test-list-development",
+            "name": "cftftest-list-development",
             "type": "DOMAIN"
           },
           "index_key": "development",
@@ -531,7 +531,7 @@
                 "value": "testing.cf-tf-test.com"
               }
             ],
-            "name": "test-list-testing",
+            "name": "cftftest-list-testing",
             "type": "DOMAIN"
           },
           "index_key": "testing",
@@ -556,7 +556,7 @@
                 "value": "192.168.0.0/24"
               }
             ],
-            "name": "test-list-range-0",
+            "name": "cftftest-list-range-0",
             "type": "IP"
           },
           "index_key": 0,
@@ -581,7 +581,7 @@
                 "value": "192.168.1.0/24"
               }
             ],
-            "name": "test-list-range-1",
+            "name": "cftftest-list-range-1",
             "type": "IP"
           },
           "index_key": 1,
@@ -606,7 +606,7 @@
                 "value": "192.168.2.0/24"
               }
             ],
-            "name": "test-list-range-2",
+            "name": "cftftest-list-range-2",
             "type": "IP"
           },
           "index_key": 2,

--- a/integration/v4_to_v5/testdata/zero_trust_list/expected/zero_trust_list.tf
+++ b/integration/v4_to_v5/testdata/zero_trust_list/expected/zero_trust_list.tf
@@ -16,7 +16,7 @@ variable "cloudflare_domain" {
 # Resource-specific variables with defaults
 variable "list_prefix" {
   type    = string
-  default = "test"
+  default = "cftftest"
 }
 
 variable "enable_security_lists" {

--- a/integration/v4_to_v5/testdata/zero_trust_list/input/terraform.tfstate
+++ b/integration/v4_to_v5/testdata/zero_trust_list/input/terraform.tfstate
@@ -375,7 +375,7 @@
                 "value": "www.malware.cf-tf-test.com"
               }
             ],
-            "name": "test-list-malware",
+            "name": "cftftest-list-malware",
             "type": "DOMAIN"
           },
           "index_key": "malware",
@@ -403,7 +403,7 @@
                 "value": "www.phishing.cf-tf-test.com"
               }
             ],
-            "name": "test-list-phishing",
+            "name": "cftftest-list-phishing",
             "type": "DOMAIN"
           },
           "index_key": "phishing",
@@ -431,7 +431,7 @@
                 "value": "www.spam.cf-tf-test.com"
               }
             ],
-            "name": "test-list-spam",
+            "name": "cftftest-list-spam",
             "type": "DOMAIN"
           },
           "index_key": "spam",
@@ -456,7 +456,7 @@
                 "value": "staging.cf-tf-test.com"
               }
             ],
-            "name": "test-list-staging",
+            "name": "cftftest-list-staging",
             "type": "DOMAIN"
           },
           "index_key": "staging",
@@ -481,7 +481,7 @@
                 "value": "production.cf-tf-test.com"
               }
             ],
-            "name": "test-list-production",
+            "name": "cftftest-list-production",
             "type": "DOMAIN"
           },
           "index_key": "production",
@@ -506,7 +506,7 @@
                 "value": "development.cf-tf-test.com"
               }
             ],
-            "name": "test-list-development",
+            "name": "cftftest-list-development",
             "type": "DOMAIN"
           },
           "index_key": "development",
@@ -531,7 +531,7 @@
                 "value": "testing.cf-tf-test.com"
               }
             ],
-            "name": "test-list-testing",
+            "name": "cftftest-list-testing",
             "type": "DOMAIN"
           },
           "index_key": "testing",
@@ -556,7 +556,7 @@
                 "value": "192.168.0.0/24"
               }
             ],
-            "name": "test-list-range-0",
+            "name": "cftftest-list-range-0",
             "type": "IP"
           },
           "index_key": 0,
@@ -581,7 +581,7 @@
                 "value": "192.168.1.0/24"
               }
             ],
-            "name": "test-list-range-1",
+            "name": "cftftest-list-range-1",
             "type": "IP"
           },
           "index_key": 1,
@@ -606,7 +606,7 @@
                 "value": "192.168.2.0/24"
               }
             ],
-            "name": "test-list-range-2",
+            "name": "cftftest-list-range-2",
             "type": "IP"
           },
           "index_key": 2,

--- a/integration/v4_to_v5/testdata/zero_trust_list/input/zero_trust_list.tf
+++ b/integration/v4_to_v5/testdata/zero_trust_list/input/zero_trust_list.tf
@@ -16,7 +16,7 @@ variable "cloudflare_domain" {
 # Resource-specific variables with defaults
 variable "list_prefix" {
   type    = string
-  default = "test"
+  default = "cftftest"
 }
 
 variable "enable_security_lists" {

--- a/integration/v4_to_v5/testdata/zero_trust_tunnel_cloudflared/expected/zero_trust_tunnel_cloudflared.tf
+++ b/integration/v4_to_v5/testdata/zero_trust_tunnel_cloudflared/expected/zero_trust_tunnel_cloudflared.tf
@@ -62,7 +62,7 @@ locals {
   tunnel_secret_base = "generated-secret-that-is-32-bytes-long"
   common_account_id  = var.cloudflare_account_id
   tunnel_suffix      = "prod"
-  full_tunnel_name   = "${var.tunnel_prefix}-${local.tunnel_suffix}"
+  full_tunnel_name   = "${local.name_prefix}-${var.tunnel_prefix}-${local.tunnel_suffix}"
 }
 
 # Tunnel using variables and locals
@@ -99,7 +99,7 @@ resource "cloudflare_zero_trust_tunnel_cloudflared" "applications" {
   for_each = var.application_tunnels
 
   account_id    = var.cloudflare_account_id
-  name          = "${each.key}-tunnel"
+  name          = "${local.name_prefix}-${each.key}-tunnel"
   config_src    = each.value.config_src
   tunnel_secret = base64encode(each.value.secret)
 }
@@ -134,7 +134,7 @@ resource "cloudflare_zero_trust_tunnel_cloudflared" "environments" {
   for_each = { for idx, tunnel in var.environment_tunnels : tunnel.name => tunnel }
 
   account_id    = var.cloudflare_account_id
-  name          = "${each.value.name}-env-tunnel"
+  name          = "${local.name_prefix}-${each.value.name}-env-tunnel"
   config_src    = each.value.config_src
   tunnel_secret = base64encode(each.value.secret)
 }
@@ -149,7 +149,7 @@ resource "cloudflare_zero_trust_tunnel_cloudflared" "replicas" {
   count = var.replica_count
 
   account_id    = var.cloudflare_account_id
-  name          = "replica-tunnel-${count.index + 1}"
+  name          = "${local.name_prefix}-replica-tunnel-${count.index + 1}"
   config_src    = "local"
   tunnel_secret = base64encode("replica-${count.index}-secret-32-bytes-long")
 }
@@ -222,7 +222,7 @@ resource "cloudflare_zero_trust_tunnel_cloudflared" "encoded" {
 # Pattern 11: Tunnel using string interpolation
 resource "cloudflare_zero_trust_tunnel_cloudflared" "interpolated" {
   account_id    = var.cloudflare_account_id
-  name          = "${var.tunnel_prefix}-interpolated-${local.tunnel_suffix}"
+  name          = "${local.name_prefix}-${var.tunnel_prefix}-interpolated-${local.tunnel_suffix}"
   config_src    = "local"
   tunnel_secret = base64encode("interpolated-secret-32-bytes-or-more")
 }
@@ -235,7 +235,7 @@ variable "is_production" {
 
 resource "cloudflare_zero_trust_tunnel_cloudflared" "complex_config" {
   account_id    = var.cloudflare_account_id
-  name          = "${var.is_production ? "prod" : "dev"}-complex-tunnel"
+  name          = "${local.name_prefix}-${var.is_production ? "prod" : "dev"}-complex-tunnel"
   config_src    = var.is_production ? "cloudflare" : "local"
   tunnel_secret = base64encode("complex-tunnel-secret-32-bytes-long")
 }

--- a/integration/v4_to_v5/testdata/zero_trust_tunnel_cloudflared/input/zero_trust_tunnel_cloudflared.tf
+++ b/integration/v4_to_v5/testdata/zero_trust_tunnel_cloudflared/input/zero_trust_tunnel_cloudflared.tf
@@ -62,7 +62,7 @@ locals {
   tunnel_secret_base = "generated-secret-that-is-32-bytes-long"
   common_account_id  = var.cloudflare_account_id
   tunnel_suffix      = "prod"
-  full_tunnel_name   = "${var.tunnel_prefix}-${local.tunnel_suffix}"
+  full_tunnel_name   = "${local.name_prefix}-${var.tunnel_prefix}-${local.tunnel_suffix}"
 }
 
 # Tunnel using variables and locals
@@ -99,7 +99,7 @@ resource "cloudflare_tunnel" "applications" {
   for_each = var.application_tunnels
 
   account_id = var.cloudflare_account_id
-  name       = "${each.key}-tunnel"
+  name       = "${local.name_prefix}-${each.key}-tunnel"
   secret     = base64encode(each.value.secret)
   config_src = each.value.config_src
 }
@@ -134,7 +134,7 @@ resource "cloudflare_tunnel" "environments" {
   for_each = { for idx, tunnel in var.environment_tunnels : tunnel.name => tunnel }
 
   account_id = var.cloudflare_account_id
-  name       = "${each.value.name}-env-tunnel"
+  name       = "${local.name_prefix}-${each.value.name}-env-tunnel"
   secret     = base64encode(each.value.secret)
   config_src = each.value.config_src
 }
@@ -149,7 +149,7 @@ resource "cloudflare_tunnel" "replicas" {
   count = var.replica_count
 
   account_id = var.cloudflare_account_id
-  name       = "replica-tunnel-${count.index + 1}"
+  name       = "${local.name_prefix}-replica-tunnel-${count.index + 1}"
   secret     = base64encode("replica-${count.index}-secret-32-bytes-long")
   config_src = "local"
 }
@@ -222,7 +222,7 @@ resource "cloudflare_tunnel" "encoded" {
 # Pattern 11: Tunnel using string interpolation
 resource "cloudflare_tunnel" "interpolated" {
   account_id = var.cloudflare_account_id
-  name       = "${var.tunnel_prefix}-interpolated-${local.tunnel_suffix}"
+  name       = "${local.name_prefix}-${var.tunnel_prefix}-interpolated-${local.tunnel_suffix}"
   secret     = base64encode("interpolated-secret-32-bytes-or-more")
   config_src = "local"
 }
@@ -235,7 +235,7 @@ variable "is_production" {
 
 resource "cloudflare_tunnel" "complex_config" {
   account_id = var.cloudflare_account_id
-  name       = "${var.is_production ? "prod" : "dev"}-complex-tunnel"
+  name       = "${local.name_prefix}-${var.is_production ? "prod" : "dev"}-complex-tunnel"
   secret     = base64encode("complex-tunnel-secret-32-bytes-long")
   config_src = var.is_production ? "cloudflare" : "local"
 }

--- a/integration/v4_to_v5/testdata/zero_trust_tunnel_cloudflared_route/expected/terraform.tfstate
+++ b/integration/v4_to_v5/testdata/zero_trust_tunnel_cloudflared_route/expected/terraform.tfstate
@@ -62,7 +62,7 @@
             "account_id": "f037e56e89293a057740de681ac9abbe",
             "config_src": "local",
             "id": "a0000000-0000-0000-0000-000000000004",
-            "name": "var-test-prod",
+            "name": "cftftest-route-cftftest-var-test-prod",
             "tunnel_secret": "Z2VuZXJhdGVkLXNlY3JldC10aGF0LWlzLTMyLWJ5dGVzLWxvbmc="
           },
           "schema_version": 0

--- a/integration/v4_to_v5/testdata/zero_trust_tunnel_cloudflared_route/expected/zero_trust_tunnel_cloudflared_route.tf
+++ b/integration/v4_to_v5/testdata/zero_trust_tunnel_cloudflared_route/expected/zero_trust_tunnel_cloudflared_route.tf
@@ -70,7 +70,7 @@ locals {
 # Tunnel using variables and locals
 resource "cloudflare_zero_trust_tunnel_cloudflared" "with_vars" {
   account_id    = local.common_account_id
-  name          = "route-${local.full_tunnel_name}"
+  name          = "${local.name_prefix}-route-${local.full_tunnel_name}"
   config_src    = var.config_source
   tunnel_secret = base64encode(local.tunnel_secret_base)
 }
@@ -101,7 +101,7 @@ resource "cloudflare_zero_trust_tunnel_cloudflared" "applications" {
   for_each = var.application_tunnels
 
   account_id    = var.cloudflare_account_id
-  name          = "route-${each.key}-tunnel"
+  name          = "${local.name_prefix}-route-${each.key}-tunnel"
   config_src    = each.value.config_src
   tunnel_secret = base64encode(each.value.secret)
 }
@@ -136,7 +136,7 @@ resource "cloudflare_zero_trust_tunnel_cloudflared" "environments" {
   for_each = { for idx, tunnel in var.environment_tunnels : tunnel.name => tunnel }
 
   account_id    = var.cloudflare_account_id
-  name          = "route-${each.value.name}-env-tunnel"
+  name          = "${local.name_prefix}-route-${each.value.name}-env-tunnel"
   config_src    = each.value.config_src
   tunnel_secret = base64encode(each.value.secret)
 }
@@ -151,7 +151,7 @@ resource "cloudflare_zero_trust_tunnel_cloudflared" "replicas" {
   count = var.replica_count
 
   account_id    = var.cloudflare_account_id
-  name          = "route-replica-tunnel-${count.index + 1}"
+  name          = "${local.name_prefix}-route-replica-tunnel-${count.index + 1}"
   config_src    = "local"
   tunnel_secret = base64encode("replica-${count.index}-secret-32-bytes-long")
 }
@@ -181,7 +181,7 @@ resource "cloudflare_zero_trust_tunnel_cloudflared" "primary" {
 
 resource "cloudflare_zero_trust_tunnel_cloudflared" "secondary" {
   account_id    = var.cloudflare_account_id
-  name          = "${cloudflare_zero_trust_tunnel_cloudflared.primary.name}-secondary"
+  name          = "${local.name_prefix}-${cloudflare_zero_trust_tunnel_cloudflared.primary.name}-secondary"
   config_src    = "cloudflare"
   tunnel_secret = base64encode("secondary-tunnel-secret-32-bytes-ok")
 }
@@ -223,7 +223,7 @@ resource "cloudflare_zero_trust_tunnel_cloudflared" "encoded" {
 # Tunnel using string interpolation
 resource "cloudflare_zero_trust_tunnel_cloudflared" "interpolated" {
   account_id    = var.cloudflare_account_id
-  name          = "route-${var.tunnel_prefix}-interpolated-${local.tunnel_suffix}"
+  name          = "${local.name_prefix}-route-${var.tunnel_prefix}-interpolated-${local.tunnel_suffix}"
   config_src    = "local"
   tunnel_secret = base64encode("interpolated-secret-32-bytes-or-more")
 }
@@ -236,7 +236,7 @@ variable "is_production" {
 
 resource "cloudflare_zero_trust_tunnel_cloudflared" "complex_config" {
   account_id    = var.cloudflare_account_id
-  name          = "route-${var.is_production ? "prod" : "dev"}-complex-tunnel"
+  name          = "${local.name_prefix}-route-${var.is_production ? "prod" : "dev"}-complex-tunnel"
   config_src    = var.is_production ? "cloudflare" : "local"
   tunnel_secret = base64encode("complex-tunnel-secret-32-bytes-long")
 }

--- a/integration/v4_to_v5/testdata/zero_trust_tunnel_cloudflared_route/input/terraform.tfstate
+++ b/integration/v4_to_v5/testdata/zero_trust_tunnel_cloudflared_route/input/terraform.tfstate
@@ -75,7 +75,7 @@
           "attributes": {
             "id": "a0000000-0000-0000-0000-000000000004",
             "account_id": "f037e56e89293a057740de681ac9abbe",
-            "name": "var-test-prod",
+            "name": "cftftest-route-cftftest-var-test-prod",
             "secret": "Z2VuZXJhdGVkLXNlY3JldC10aGF0LWlzLTMyLWJ5dGVzLWxvbmc=",
             "config_src": "local",
             "cname": "a0000000-0000-0000-0000-000000000004.cfargotunnel.com",

--- a/integration/v4_to_v5/testdata/zero_trust_tunnel_cloudflared_route/input/zero_trust_tunnel_cloudflared_route.tf
+++ b/integration/v4_to_v5/testdata/zero_trust_tunnel_cloudflared_route/input/zero_trust_tunnel_cloudflared_route.tf
@@ -70,7 +70,7 @@ locals {
 # Tunnel using variables and locals
 resource "cloudflare_tunnel" "with_vars" {
   account_id = local.common_account_id
-  name       = "route-${local.full_tunnel_name}"
+  name       = "${local.name_prefix}-route-${local.full_tunnel_name}"
   secret     = base64encode(local.tunnel_secret_base)
   config_src = var.config_source
 }
@@ -101,7 +101,7 @@ resource "cloudflare_tunnel" "applications" {
   for_each = var.application_tunnels
 
   account_id = var.cloudflare_account_id
-  name       = "route-${each.key}-tunnel"
+  name       = "${local.name_prefix}-route-${each.key}-tunnel"
   secret     = base64encode(each.value.secret)
   config_src = each.value.config_src
 }
@@ -136,7 +136,7 @@ resource "cloudflare_tunnel" "environments" {
   for_each = { for idx, tunnel in var.environment_tunnels : tunnel.name => tunnel }
 
   account_id = var.cloudflare_account_id
-  name       = "route-${each.value.name}-env-tunnel"
+  name       = "${local.name_prefix}-route-${each.value.name}-env-tunnel"
   secret     = base64encode(each.value.secret)
   config_src = each.value.config_src
 }
@@ -151,7 +151,7 @@ resource "cloudflare_tunnel" "replicas" {
   count = var.replica_count
 
   account_id = var.cloudflare_account_id
-  name       = "route-replica-tunnel-${count.index + 1}"
+  name       = "${local.name_prefix}-route-replica-tunnel-${count.index + 1}"
   secret     = base64encode("replica-${count.index}-secret-32-bytes-long")
   config_src = "local"
 }
@@ -181,7 +181,7 @@ resource "cloudflare_tunnel" "primary" {
 
 resource "cloudflare_tunnel" "secondary" {
   account_id = var.cloudflare_account_id
-  name       = "${cloudflare_tunnel.primary.name}-secondary"
+  name       = "${local.name_prefix}-${cloudflare_tunnel.primary.name}-secondary"
   secret     = base64encode("secondary-tunnel-secret-32-bytes-ok")
   config_src = "cloudflare"
 }
@@ -223,7 +223,7 @@ resource "cloudflare_tunnel" "encoded" {
 # Tunnel using string interpolation
 resource "cloudflare_tunnel" "interpolated" {
   account_id = var.cloudflare_account_id
-  name       = "route-${var.tunnel_prefix}-interpolated-${local.tunnel_suffix}"
+  name       = "${local.name_prefix}-route-${var.tunnel_prefix}-interpolated-${local.tunnel_suffix}"
   secret     = base64encode("interpolated-secret-32-bytes-or-more")
   config_src = "local"
 }
@@ -236,7 +236,7 @@ variable "is_production" {
 
 resource "cloudflare_tunnel" "complex_config" {
   account_id = var.cloudflare_account_id
-  name       = "route-${var.is_production ? "prod" : "dev"}-complex-tunnel"
+  name       = "${local.name_prefix}-route-${var.is_production ? "prod" : "dev"}-complex-tunnel"
   secret     = base64encode("complex-tunnel-secret-32-bytes-long")
   config_src = var.is_production ? "cloudflare" : "local"
 }

--- a/integration/v4_to_v5/testdata/zero_trust_tunnel_cloudflared_virtual_network/expected/zero_trust_tunnel_cloudflared_virtual_network.tf
+++ b/integration/v4_to_v5/testdata/zero_trust_tunnel_cloudflared_virtual_network/expected/zero_trust_tunnel_cloudflared_virtual_network.tf
@@ -33,13 +33,6 @@ resource "cloudflare_zero_trust_tunnel_cloudflared_virtual_network" "complete" {
   comment            = "Integration test"
 }
 
-# Pattern 3: Default network
-resource "cloudflare_zero_trust_tunnel_cloudflared_virtual_network" "default_net" {
-  account_id         = local.account_id
-  name               = "${local.prefix}-default"
-  is_default_network = true
-}
-
 # Pattern 4: Empty optionals (tests default handling)
 resource "cloudflare_zero_trust_tunnel_cloudflared_virtual_network" "empty_opts" {
   account_id = local.account_id

--- a/integration/v4_to_v5/testdata/zero_trust_tunnel_cloudflared_virtual_network/input/zero_trust_tunnel_cloudflared_virtual_network.tf
+++ b/integration/v4_to_v5/testdata/zero_trust_tunnel_cloudflared_virtual_network/input/zero_trust_tunnel_cloudflared_virtual_network.tf
@@ -33,13 +33,6 @@ resource "cloudflare_zero_trust_tunnel_virtual_network" "complete" {
   comment            = "Integration test"
 }
 
-# Pattern 3: Default network
-resource "cloudflare_tunnel_virtual_network" "default_net" {
-  account_id         = local.account_id
-  name               = "${local.prefix}-default"
-  is_default_network = true
-}
-
 # Pattern 4: Empty optionals (tests default handling)
 resource "cloudflare_zero_trust_tunnel_virtual_network" "empty_opts" {
   account_id = local.account_id


### PR DESCRIPTION
The `cftftest` prefix is necessary for sweepers to properly clean up resources. 
Removes default virtual network e2e test, as it didnt play well when sweeping resources.