### PR TITLE
Free up disk space before integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,14 +21,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Free up disk space
-        run: |
-          sudo rm -rf /usr/share/dotnet
-          sudo rm -rf /opt/ghc
-          sudo rm -rf /usr/local/share/boost
-          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
-          df -h
-
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
@@ -38,6 +30,14 @@ jobs:
         run: |
           go mod download
           go mod tidy
+
+      - name: Free up disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /usr/local/share/boost
+          docker system prune -af
+          df -h
 
       - name: Run unit tests
         run: make test-unit
@@ -82,6 +82,17 @@ jobs:
         run: |
           go mod download
           go mod tidy
+
+      - name: Free up disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /usr/local/share/boost
+          docker system prune -af
+          df -h
+
+      - name: Build tf-migrate binary
+        run: make build
 
       - name: Run integration tests
         run: make test-integration


### PR DESCRIPTION
Running out of disk space during integration tests on recent PRs. This frees up disk space before running the tests and builds the binary once for use in all tests.