### PR TITLE
feat(access_rule): support v4 to v5 migration

### DIFF
--- a/integration/v4_to_v5/testdata/access_rule/expected/access_rule.tf
+++ b/integration/v4_to_v5/testdata/access_rule/expected/access_rule.tf
@@ -1,0 +1,331 @@
+# Comprehensive Integration Test for access_rule v4 → v5 Migration
+# Target: 20-25 resource instances covering all patterns
+
+# Pattern 1: Variables (no defaults - must be provided)
+variable "cloudflare_account_id" {
+  description = "Cloudflare account ID for testing"
+  type        = string
+}
+
+variable "cloudflare_zone_id" {
+  description = "Cloudflare zone ID for testing"
+  type        = string
+}
+
+variable "cloudflare_domain" {
+  description = "Cloudflare domain for testing"
+  type        = string
+}
+
+# Pattern 2: Locals with resource-specific configuration
+locals {
+  blocked_countries = ["CN", "RU"]
+  blocked_ips = [
+    "198.51.100.1",
+    "198.51.100.2",
+    "198.51.100.3",
+  ]
+  ip_ranges = {
+    suspicious_range_1 = "192.0.2.0/24"
+    suspicious_range_2 = "198.51.100.0/24"
+  }
+  enable_ipv6_blocking = true
+  enable_asn_blocking  = true
+}
+
+# Basic Examples - All Mode Types
+resource "cloudflare_access_rule" "example_block" {
+  account_id = var.cloudflare_account_id
+  mode       = "block"
+  notes      = "Block malicious IP"
+  configuration = {
+    target = "ip"
+    value  = "198.51.100.10"
+  }
+}
+
+resource "cloudflare_access_rule" "example_challenge" {
+  account_id = var.cloudflare_account_id
+  mode       = "challenge"
+  notes      = "Challenge unknown country"
+  configuration = {
+    target = "country"
+    value  = "XX"
+  }
+}
+
+resource "cloudflare_access_rule" "example_whitelist" {
+  zone_id = var.cloudflare_zone_id
+  mode    = "whitelist"
+  notes   = "Allow trusted IP"
+  configuration = {
+    target = "ip"
+    value  = "203.0.113.100"
+  }
+}
+
+resource "cloudflare_access_rule" "example_js_challenge" {
+  account_id = var.cloudflare_account_id
+  mode       = "js_challenge"
+  notes      = "JS challenge for specific ASN"
+  configuration = {
+    target = "asn"
+    value  = "AS13335"
+  }
+}
+
+resource "cloudflare_access_rule" "example_managed_challenge" {
+  zone_id = var.cloudflare_zone_id
+  mode    = "managed_challenge"
+  configuration = {
+    target = "ip_range"
+    value  = "198.51.100.0/24"
+  }
+}
+
+# All Target Types Examples
+resource "cloudflare_access_rule" "target_ip" {
+  account_id = var.cloudflare_account_id
+  mode       = "block"
+  notes      = "Block specific IPv4"
+  configuration = {
+    target = "ip"
+    value  = "192.0.2.1"
+  }
+}
+
+resource "cloudflare_access_rule" "target_ip6" {
+  account_id = var.cloudflare_account_id
+  mode       = "block"
+  notes      = "Block specific IPv6"
+  configuration = {
+    target = "ip6"
+    value  = "2001:0db8:0000:0000:0000:0000:0000:0001"
+  }
+}
+
+resource "cloudflare_access_rule" "target_ip_range" {
+  account_id = var.cloudflare_account_id
+  mode       = "block"
+  notes      = "Block IP range"
+  configuration = {
+    target = "ip_range"
+    value  = "203.0.113.0/24"
+  }
+}
+
+resource "cloudflare_access_rule" "target_asn" {
+  zone_id = var.cloudflare_zone_id
+  mode    = "challenge"
+  notes   = "Challenge Google ASN"
+  configuration = {
+    target = "asn"
+    value  = "AS15169"
+  }
+}
+
+resource "cloudflare_access_rule" "target_country" {
+  zone_id = var.cloudflare_zone_id
+  mode    = "block"
+  notes   = "Block unknown country code"
+  configuration = {
+    target = "country"
+    value  = "XX"
+  }
+}
+
+# Pattern 3: for_each with map
+resource "cloudflare_access_rule" "block_countries" {
+  for_each = toset(local.blocked_countries)
+
+  account_id = var.cloudflare_account_id
+  mode       = "block"
+  notes      = "Block country: ${each.value}"
+  configuration = {
+    target = "country"
+    value  = each.value
+  }
+}
+
+# Pattern 4: for_each with set (converted from list)
+resource "cloudflare_access_rule" "block_ips" {
+  for_each = toset(local.blocked_ips)
+
+  zone_id = var.cloudflare_zone_id
+  mode    = "block"
+  notes   = "Block IP from list: ${each.value}"
+  configuration = {
+    target = "ip"
+    value  = each.value
+  }
+}
+
+# Pattern 5: for_each with map (complex)
+resource "cloudflare_access_rule" "block_ranges" {
+  for_each = local.ip_ranges
+
+  account_id = var.cloudflare_account_id
+  mode       = "block"
+  notes      = "Block range: ${each.key} (${each.value})"
+  configuration = {
+    target = "ip_range"
+    value  = each.value
+  }
+}
+
+# Pattern 6: count-based resources
+resource "cloudflare_access_rule" "backup_blocks" {
+  count = 3
+
+  account_id = var.cloudflare_account_id
+  mode       = "block"
+  notes      = "Backup block rule ${count.index + 1}"
+  configuration = {
+    target = "ip"
+    value  = "198.51.100.${count.index + 20}"
+  }
+}
+
+# Pattern 7: Conditional resource creation
+resource "cloudflare_access_rule" "ipv6_conditional" {
+  count = local.enable_ipv6_blocking ? 1 : 0
+
+  account_id = var.cloudflare_account_id
+  mode       = "block"
+  notes      = "Conditional IPv6 block"
+  configuration = {
+    target = "ip6"
+    value  = "2001:0db8:0000:0000:0000:0000:0000:0bad"
+  }
+}
+
+resource "cloudflare_access_rule" "asn_conditional" {
+  count = local.enable_asn_blocking ? 1 : 0
+
+  zone_id = var.cloudflare_zone_id
+  mode    = "challenge"
+  notes   = "Conditional ASN challenge"
+  configuration = {
+    target = "asn"
+    value  = "AS12345"
+  }
+}
+
+# Pattern 8: Lifecycle meta-arguments
+resource "cloudflare_access_rule" "with_lifecycle" {
+  account_id = var.cloudflare_account_id
+  mode       = "block"
+  notes      = "Rule with lifecycle settings"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+  configuration = {
+    target = "ip"
+    value  = "198.51.100.99"
+  }
+}
+
+# Pattern 9: Terraform functions and string interpolation
+resource "cloudflare_access_rule" "with_functions" {
+  account_id = var.cloudflare_account_id
+  mode       = "block"
+  notes      = "Created at: ${formatdate("YYYY-MM-DD", timestamp())}"
+  configuration = {
+    target = "ip"
+    value  = "198.51.100.100"
+  }
+}
+
+# Cross-reference pattern (referencing other resources)
+resource "cloudflare_access_rule" "referenced" {
+  account_id = var.cloudflare_account_id
+  mode       = "block"
+  notes      = "Primary block rule"
+  configuration = {
+    target = "ip"
+    value  = "198.51.100.200"
+  }
+}
+
+resource "cloudflare_access_rule" "referencing" {
+  zone_id = var.cloudflare_zone_id
+  mode    = "challenge"
+  notes   = "Related to ${cloudflare_access_rule.referenced.notes}"
+  configuration = {
+    target = "country"
+    value  = "US"
+  }
+}
+
+# Without notes field (optional field test)
+resource "cloudflare_access_rule" "no_notes_1" {
+  account_id = var.cloudflare_account_id
+  mode       = "whitelist"
+  configuration = {
+    target = "ip"
+    value  = "203.0.113.50"
+  }
+}
+
+resource "cloudflare_access_rule" "no_notes_2" {
+  zone_id = var.cloudflare_zone_id
+  mode    = "challenge"
+  configuration = {
+    target = "ip"
+    value  = "198.51.100.240"
+  }
+}
+
+# Special characters in notes
+resource "cloudflare_access_rule" "special_chars" {
+  account_id = var.cloudflare_account_id
+  mode       = "block"
+  notes      = "Block: \"suspicious\" IP with 'quotes' & special chars! #security"
+  configuration = {
+    target = "ip"
+    value  = "198.51.100.250"
+  }
+}
+
+# Multiple modes on similar configs (testing mode variations)
+resource "cloudflare_access_rule" "mode_block" {
+  account_id = var.cloudflare_account_id
+  mode       = "block"
+  notes      = "Mode: block"
+  configuration = {
+    target = "country"
+    value  = "KP"
+  }
+}
+
+resource "cloudflare_access_rule" "mode_challenge" {
+  account_id = var.cloudflare_account_id
+  mode       = "challenge"
+  notes      = "Mode: challenge"
+  configuration = {
+    target = "country"
+    value  = "IR"
+  }
+}
+
+resource "cloudflare_access_rule" "mode_whitelist" {
+  account_id = var.cloudflare_account_id
+  mode       = "whitelist"
+  notes      = "Mode: whitelist"
+  configuration = {
+    target = "country"
+    value  = "US"
+  }
+}
+
+# Edge case: Very long notes
+resource "cloudflare_access_rule" "long_notes" {
+  zone_id = var.cloudflare_zone_id
+  mode    = "block"
+  notes   = "This is a very long note field that tests the handling of extended text content. It includes multiple sentences and various punctuation marks! Does the migration handle this correctly? We'll find out."
+  configuration = {
+    target = "ip"
+    value  = "198.51.100.254"
+  }
+}

--- a/integration/v4_to_v5/testdata/access_rule/expected/terraform.tfstate
+++ b/integration/v4_to_v5/testdata/access_rule/expected/terraform.tfstate
@@ -1,0 +1,48 @@
+{
+  "version": 4,
+  "terraform_version": "1.0.0",
+  "serial": 1,
+  "lineage": "test-lineage",
+  "outputs": {},
+  "resources": [
+    {
+      "mode": "managed",
+      "type": "cloudflare_access_rule",
+      "name": "block_ip",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "mode": "block",
+            "configuration": {
+              "target": "ip",
+              "value": "192.168.1.1"
+            },
+            "notes": "Block malicious IP"
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_access_rule",
+      "name": "zone_challenge",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "zone_id": "0da42c8d2132a9ddaf714f9e7c920711",
+            "mode": "challenge",
+            "configuration": {
+              "target": "country",
+              "value": "CN"
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/integration/v4_to_v5/testdata/access_rule/input/access_rule.tf
+++ b/integration/v4_to_v5/testdata/access_rule/input/access_rule.tf
@@ -1,0 +1,331 @@
+# Comprehensive Integration Test for access_rule v4 → v5 Migration
+# Target: 20-25 resource instances covering all patterns
+
+# Pattern 1: Variables (no defaults - must be provided)
+variable "cloudflare_account_id" {
+  description = "Cloudflare account ID for testing"
+  type        = string
+}
+
+variable "cloudflare_zone_id" {
+  description = "Cloudflare zone ID for testing"
+  type        = string
+}
+
+variable "cloudflare_domain" {
+  description = "Cloudflare domain for testing"
+  type        = string
+}
+
+# Pattern 2: Locals with resource-specific configuration
+locals {
+  blocked_countries = ["CN", "RU"]
+  blocked_ips = [
+    "198.51.100.1",
+    "198.51.100.2",
+    "198.51.100.3",
+  ]
+  ip_ranges = {
+    suspicious_range_1 = "192.0.2.0/24"
+    suspicious_range_2 = "198.51.100.0/24"
+  }
+  enable_ipv6_blocking = true
+  enable_asn_blocking  = true
+}
+
+# Basic Examples - All Mode Types
+resource "cloudflare_access_rule" "example_block" {
+  account_id = var.cloudflare_account_id
+  mode       = "block"
+  configuration {
+    target = "ip"
+    value  = "198.51.100.10"
+  }
+  notes = "Block malicious IP"
+}
+
+resource "cloudflare_access_rule" "example_challenge" {
+  account_id = var.cloudflare_account_id
+  mode       = "challenge"
+  configuration {
+    target = "country"
+    value  = "XX"
+  }
+  notes = "Challenge unknown country"
+}
+
+resource "cloudflare_access_rule" "example_whitelist" {
+  zone_id = var.cloudflare_zone_id
+  mode    = "whitelist"
+  configuration {
+    target = "ip"
+    value  = "203.0.113.100"
+  }
+  notes = "Allow trusted IP"
+}
+
+resource "cloudflare_access_rule" "example_js_challenge" {
+  account_id = var.cloudflare_account_id
+  mode       = "js_challenge"
+  configuration {
+    target = "asn"
+    value  = "AS13335"
+  }
+  notes = "JS challenge for specific ASN"
+}
+
+resource "cloudflare_access_rule" "example_managed_challenge" {
+  zone_id = var.cloudflare_zone_id
+  mode    = "managed_challenge"
+  configuration {
+    target = "ip_range"
+    value  = "198.51.100.0/24"
+  }
+}
+
+# All Target Types Examples
+resource "cloudflare_access_rule" "target_ip" {
+  account_id = var.cloudflare_account_id
+  mode       = "block"
+  configuration {
+    target = "ip"
+    value  = "192.0.2.1"
+  }
+  notes = "Block specific IPv4"
+}
+
+resource "cloudflare_access_rule" "target_ip6" {
+  account_id = var.cloudflare_account_id
+  mode       = "block"
+  configuration {
+    target = "ip6"
+    value  = "2001:0db8:0000:0000:0000:0000:0000:0001"
+  }
+  notes = "Block specific IPv6"
+}
+
+resource "cloudflare_access_rule" "target_ip_range" {
+  account_id = var.cloudflare_account_id
+  mode       = "block"
+  configuration {
+    target = "ip_range"
+    value  = "203.0.113.0/24"
+  }
+  notes = "Block IP range"
+}
+
+resource "cloudflare_access_rule" "target_asn" {
+  zone_id = var.cloudflare_zone_id
+  mode    = "challenge"
+  configuration {
+    target = "asn"
+    value  = "AS15169"
+  }
+  notes = "Challenge Google ASN"
+}
+
+resource "cloudflare_access_rule" "target_country" {
+  zone_id = var.cloudflare_zone_id
+  mode    = "block"
+  configuration {
+    target = "country"
+    value  = "XX"
+  }
+  notes = "Block unknown country code"
+}
+
+# Pattern 3: for_each with map
+resource "cloudflare_access_rule" "block_countries" {
+  for_each = toset(local.blocked_countries)
+
+  account_id = var.cloudflare_account_id
+  mode       = "block"
+  configuration {
+    target = "country"
+    value  = each.value
+  }
+  notes = "Block country: ${each.value}"
+}
+
+# Pattern 4: for_each with set (converted from list)
+resource "cloudflare_access_rule" "block_ips" {
+  for_each = toset(local.blocked_ips)
+
+  zone_id = var.cloudflare_zone_id
+  mode    = "block"
+  configuration {
+    target = "ip"
+    value  = each.value
+  }
+  notes = "Block IP from list: ${each.value}"
+}
+
+# Pattern 5: for_each with map (complex)
+resource "cloudflare_access_rule" "block_ranges" {
+  for_each = local.ip_ranges
+
+  account_id = var.cloudflare_account_id
+  mode       = "block"
+  configuration {
+    target = "ip_range"
+    value  = each.value
+  }
+  notes = "Block range: ${each.key} (${each.value})"
+}
+
+# Pattern 6: count-based resources
+resource "cloudflare_access_rule" "backup_blocks" {
+  count = 3
+
+  account_id = var.cloudflare_account_id
+  mode       = "block"
+  configuration {
+    target = "ip"
+    value  = "198.51.100.${count.index + 20}"
+  }
+  notes = "Backup block rule ${count.index + 1}"
+}
+
+# Pattern 7: Conditional resource creation
+resource "cloudflare_access_rule" "ipv6_conditional" {
+  count = local.enable_ipv6_blocking ? 1 : 0
+
+  account_id = var.cloudflare_account_id
+  mode       = "block"
+  configuration {
+    target = "ip6"
+    value  = "2001:0db8:0000:0000:0000:0000:0000:0bad"
+  }
+  notes = "Conditional IPv6 block"
+}
+
+resource "cloudflare_access_rule" "asn_conditional" {
+  count = local.enable_asn_blocking ? 1 : 0
+
+  zone_id = var.cloudflare_zone_id
+  mode    = "challenge"
+  configuration {
+    target = "asn"
+    value  = "AS12345"
+  }
+  notes = "Conditional ASN challenge"
+}
+
+# Pattern 8: Lifecycle meta-arguments
+resource "cloudflare_access_rule" "with_lifecycle" {
+  account_id = var.cloudflare_account_id
+  mode       = "block"
+  configuration {
+    target = "ip"
+    value  = "198.51.100.99"
+  }
+  notes = "Rule with lifecycle settings"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+# Pattern 9: Terraform functions and string interpolation
+resource "cloudflare_access_rule" "with_functions" {
+  account_id = var.cloudflare_account_id
+  mode       = "block"
+  configuration {
+    target = "ip"
+    value  = "198.51.100.100"
+  }
+  notes = "Created at: ${formatdate("YYYY-MM-DD", timestamp())}"
+}
+
+# Cross-reference pattern (referencing other resources)
+resource "cloudflare_access_rule" "referenced" {
+  account_id = var.cloudflare_account_id
+  mode       = "block"
+  configuration {
+    target = "ip"
+    value  = "198.51.100.200"
+  }
+  notes = "Primary block rule"
+}
+
+resource "cloudflare_access_rule" "referencing" {
+  zone_id = var.cloudflare_zone_id
+  mode    = "challenge"
+  configuration {
+    target = "country"
+    value  = "US"
+  }
+  notes = "Related to ${cloudflare_access_rule.referenced.notes}"
+}
+
+# Without notes field (optional field test)
+resource "cloudflare_access_rule" "no_notes_1" {
+  account_id = var.cloudflare_account_id
+  mode       = "whitelist"
+  configuration {
+    target = "ip"
+    value  = "203.0.113.50"
+  }
+}
+
+resource "cloudflare_access_rule" "no_notes_2" {
+  zone_id = var.cloudflare_zone_id
+  mode    = "challenge"
+  configuration {
+    target = "ip"
+    value  = "198.51.100.240"
+  }
+}
+
+# Special characters in notes
+resource "cloudflare_access_rule" "special_chars" {
+  account_id = var.cloudflare_account_id
+  mode       = "block"
+  configuration {
+    target = "ip"
+    value  = "198.51.100.250"
+  }
+  notes = "Block: \"suspicious\" IP with 'quotes' & special chars! #security"
+}
+
+# Multiple modes on similar configs (testing mode variations)
+resource "cloudflare_access_rule" "mode_block" {
+  account_id = var.cloudflare_account_id
+  mode       = "block"
+  configuration {
+    target = "country"
+    value  = "KP"
+  }
+  notes = "Mode: block"
+}
+
+resource "cloudflare_access_rule" "mode_challenge" {
+  account_id = var.cloudflare_account_id
+  mode       = "challenge"
+  configuration {
+    target = "country"
+    value  = "IR"
+  }
+  notes = "Mode: challenge"
+}
+
+resource "cloudflare_access_rule" "mode_whitelist" {
+  account_id = var.cloudflare_account_id
+  mode       = "whitelist"
+  configuration {
+    target = "country"
+    value  = "US"
+  }
+  notes = "Mode: whitelist"
+}
+
+# Edge case: Very long notes
+resource "cloudflare_access_rule" "long_notes" {
+  zone_id = var.cloudflare_zone_id
+  mode    = "block"
+  configuration {
+    target = "ip"
+    value  = "198.51.100.254"
+  }
+  notes = "This is a very long note field that tests the handling of extended text content. It includes multiple sentences and various punctuation marks! Does the migration handle this correctly? We'll find out."
+}

--- a/integration/v4_to_v5/testdata/access_rule/input/terraform.tfstate
+++ b/integration/v4_to_v5/testdata/access_rule/input/terraform.tfstate
@@ -1,0 +1,52 @@
+{
+  "version": 4,
+  "terraform_version": "1.0.0",
+  "serial": 1,
+  "lineage": "test-lineage",
+  "outputs": {},
+  "resources": [
+    {
+      "mode": "managed",
+      "type": "cloudflare_access_rule",
+      "name": "block_ip",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "mode": "block",
+            "configuration": [
+              {
+                "target": "ip",
+                "value": "192.168.1.1"
+              }
+            ],
+            "notes": "Block malicious IP"
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_access_rule",
+      "name": "zone_challenge",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "zone_id": "0da42c8d2132a9ddaf714f9e7c920711",
+            "mode": "challenge",
+            "configuration": [
+              {
+                "target": "country",
+                "value": "CN"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -3,6 +3,7 @@ package registry
 import (
 	zonedata "github.com/cloudflare/tf-migrate/internal/datasources/zone"
 	zonesdata "github.com/cloudflare/tf-migrate/internal/datasources/zones"
+	"github.com/cloudflare/tf-migrate/internal/resources/access_rule"
 	"github.com/cloudflare/tf-migrate/internal/resources/account_member"
 	"github.com/cloudflare/tf-migrate/internal/resources/api_shield"
 	"github.com/cloudflare/tf-migrate/internal/resources/api_token"
@@ -69,6 +70,7 @@ func RegisterAllMigrations() {
 	zonesdata.NewV4ToV5Migrator()
 
 	// Resources
+	access_rule.NewV4ToV5Migrator()
 	account_member.NewV4ToV5Migrator()
 	api_shield.NewV4ToV5Migrator()
 	api_token.NewV4ToV5Migrator()

--- a/internal/resources/access_rule/v4_to_v5.go
+++ b/internal/resources/access_rule/v4_to_v5.go
@@ -1,0 +1,81 @@
+package access_rule
+
+import (
+	"github.com/hashicorp/hcl/v2/hclwrite"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+
+	"github.com/cloudflare/tf-migrate/internal"
+	"github.com/cloudflare/tf-migrate/internal/transform"
+	tfhcl "github.com/cloudflare/tf-migrate/internal/transform/hcl"
+	"github.com/cloudflare/tf-migrate/internal/transform/state"
+)
+
+type V4ToV5Migrator struct {
+}
+
+func NewV4ToV5Migrator() transform.ResourceTransformer {
+	migrator := &V4ToV5Migrator{}
+	// Register with the v4 resource name
+	internal.RegisterMigrator("cloudflare_access_rule", "v4", "v5", migrator)
+	return migrator
+}
+
+func (m *V4ToV5Migrator) GetResourceType() string {
+	// Resource name doesn't change
+	return "cloudflare_access_rule"
+}
+
+func (m *V4ToV5Migrator) CanHandle(resourceType string) bool {
+	return resourceType == "cloudflare_access_rule"
+}
+
+// GetResourceRename implements the ResourceRenamer interface
+// This resource does not rename, so we return the same name for both old and new
+func (m *V4ToV5Migrator) GetResourceRename() (string, string) {
+	return "cloudflare_access_rule", "cloudflare_access_rule"
+}
+
+// Preprocess performs any string-level transformations before HCL parsing.
+// For access_rule, no preprocessing is needed.
+func (m *V4ToV5Migrator) Preprocess(content string) string {
+	return content
+}
+
+// TransformConfig transforms the HCL configuration from v4 to v5.
+func (m *V4ToV5Migrator) TransformConfig(ctx *transform.Context, block *hclwrite.Block) (*transform.TransformResult, error) {
+	body := block.Body()
+
+	// Convert configuration block to attribute (MaxItems:1 → SingleNestedAttribute)
+	// v4: configuration { target = "ip" value = "1.2.3.4" }
+	// v5: configuration = { target = "ip" value = "1.2.3.4" }
+	tfhcl.ConvertBlocksToAttribute(body, "configuration", "configuration", func(block *hclwrite.Block) {})
+
+	return &transform.TransformResult{
+		Blocks:         []*hclwrite.Block{block},
+		RemoveOriginal: false,
+	}, nil
+}
+
+// TransformState transforms the JSON state from v4 to v5.
+func (m *V4ToV5Migrator) TransformState(ctx *transform.Context, stateJSON gjson.Result, resourcePath, resourceName string) (string, error) {
+	result := stateJSON.String()
+
+	// Get attributes
+	attrs := stateJSON.Get("attributes")
+	if !attrs.Exists() {
+		// Even for invalid instances, set schema_version
+		result, _ = sjson.Set(result, "schema_version", 0)
+		return result, nil
+	}
+
+	// Convert configuration array to object (MaxItems:1 → SingleNestedAttribute)
+	// v4 state: "configuration": [{"target": "ip", "value": "1.2.3.4"}]
+	// v5 state: "configuration": {"target": "ip", "value": "1.2.3.4"}
+	result = state.ConvertMaxItemsOneArrayToObject(result, "attributes", attrs, "configuration")
+
+	// Set schema_version to 0 for v5 (ALWAYS required!)
+	result, _ = sjson.Set(result, "schema_version", 0)
+
+	return result, nil
+}

--- a/internal/resources/access_rule/v4_to_v5_test.go
+++ b/internal/resources/access_rule/v4_to_v5_test.go
@@ -1,0 +1,463 @@
+package access_rule
+
+import (
+	"testing"
+
+	"github.com/cloudflare/tf-migrate/internal/testhelpers"
+	"github.com/cloudflare/tf-migrate/internal/transform"
+)
+
+func TestV4ToV5Transformation(t *testing.T) {
+	migrator := NewV4ToV5Migrator()
+
+	t.Run("InterfaceMethods", func(t *testing.T) {
+		// Cast to concrete type to test all methods
+		m := migrator.(*V4ToV5Migrator)
+
+		// Test GetResourceType
+		if got := m.GetResourceType(); got != "cloudflare_access_rule" {
+			t.Errorf("GetResourceType() = %v, want %v", got, "cloudflare_access_rule")
+		}
+
+		// Test GetResourceRename
+		oldName, newName := m.GetResourceRename()
+		if oldName != "cloudflare_access_rule" || newName != "cloudflare_access_rule" {
+			t.Errorf("GetResourceRename() = (%v, %v), want (%v, %v)",
+				oldName, newName, "cloudflare_access_rule", "cloudflare_access_rule")
+		}
+
+		// Test CanHandle
+		if !m.CanHandle("cloudflare_access_rule") {
+			t.Error("CanHandle('cloudflare_access_rule') should return true")
+		}
+		if m.CanHandle("cloudflare_other_resource") {
+			t.Error("CanHandle('cloudflare_other_resource') should return false")
+		}
+
+		// Test Preprocess (no-op)
+		input := "test content"
+		if got := m.Preprocess(input); got != input {
+			t.Errorf("Preprocess() should return input unchanged, got %v", got)
+		}
+	})
+
+	t.Run("ConfigTransformation", func(t *testing.T) {
+		testConfigTransformations(t, migrator)
+	})
+
+	t.Run("StateTransformation", func(t *testing.T) {
+		testStateTransformations(t, migrator)
+	})
+}
+
+func testConfigTransformations(t *testing.T, migrator transform.ResourceTransformer) {
+	tests := []testhelpers.ConfigTestCase{
+		{
+			Name: "Basic access rule with configuration block",
+			Input: `resource "cloudflare_access_rule" "example" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+  mode       = "block"
+  configuration {
+    target = "ip"
+    value  = "1.2.3.4"
+  }
+  notes = "Block suspicious IP"
+}`,
+			Expected: `resource "cloudflare_access_rule" "example" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+  mode       = "block"
+  notes      = "Block suspicious IP"
+  configuration = {
+    target = "ip"
+    value  = "1.2.3.4"
+  }
+}`,
+		},
+		{
+			Name: "Zone-level access rule",
+			Input: `resource "cloudflare_access_rule" "zone_rule" {
+  zone_id = "0da42c8d2132a9ddaf714f9e7c920711"
+  mode    = "challenge"
+  configuration {
+    target = "country"
+    value  = "CN"
+  }
+}`,
+			Expected: `resource "cloudflare_access_rule" "zone_rule" {
+  zone_id = "0da42c8d2132a9ddaf714f9e7c920711"
+  mode    = "challenge"
+  configuration = {
+    target = "country"
+    value  = "CN"
+  }
+}`,
+		},
+		{
+			Name: "Access rule without notes",
+			Input: `resource "cloudflare_access_rule" "no_notes" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+  mode       = "whitelist"
+  configuration {
+    target = "ip_range"
+    value  = "10.0.0.0/8"
+  }
+}`,
+			Expected: `resource "cloudflare_access_rule" "no_notes" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+  mode       = "whitelist"
+  configuration = {
+    target = "ip_range"
+    value  = "10.0.0.0/8"
+  }
+}`,
+		},
+		{
+			Name: "Multiple access rules",
+			Input: `resource "cloudflare_access_rule" "block_ip" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+  mode       = "block"
+  configuration {
+    target = "ip"
+    value  = "192.168.1.1"
+  }
+  notes = "Block malicious IP"
+}
+
+resource "cloudflare_access_rule" "allow_country" {
+  zone_id = "0da42c8d2132a9ddaf714f9e7c920711"
+  mode    = "whitelist"
+  configuration {
+    target = "country"
+    value  = "US"
+  }
+  notes = "Allow US traffic"
+}`,
+			Expected: `resource "cloudflare_access_rule" "block_ip" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+  mode       = "block"
+  notes      = "Block malicious IP"
+  configuration = {
+    target = "ip"
+    value  = "192.168.1.1"
+  }
+}
+
+resource "cloudflare_access_rule" "allow_country" {
+  zone_id = "0da42c8d2132a9ddaf714f9e7c920711"
+  mode    = "whitelist"
+  notes   = "Allow US traffic"
+  configuration = {
+    target = "country"
+    value  = "US"
+  }
+}`,
+		},
+		{
+			Name: "All mode types - js_challenge and managed_challenge",
+			Input: `resource "cloudflare_access_rule" "js_challenge" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+  mode       = "js_challenge"
+  configuration {
+    target = "ip"
+    value  = "203.0.113.0"
+  }
+}
+
+resource "cloudflare_access_rule" "managed_challenge" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+  mode       = "managed_challenge"
+  configuration {
+    target = "asn"
+    value  = "AS13335"
+  }
+}`,
+			Expected: `resource "cloudflare_access_rule" "js_challenge" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+  mode       = "js_challenge"
+  configuration = {
+    target = "ip"
+    value  = "203.0.113.0"
+  }
+}
+
+resource "cloudflare_access_rule" "managed_challenge" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+  mode       = "managed_challenge"
+  configuration = {
+    target = "asn"
+    value  = "AS13335"
+  }
+}`,
+		},
+		{
+			Name: "IPv6 address and ASN target",
+			Input: `resource "cloudflare_access_rule" "ipv6" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+  mode       = "block"
+  configuration {
+    target = "ip6"
+    value  = "2001:0db8:85a3:0000:0000:8a2e:0370:7334"
+  }
+  notes = "Block IPv6"
+}`,
+			Expected: `resource "cloudflare_access_rule" "ipv6" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+  mode       = "block"
+  notes      = "Block IPv6"
+  configuration = {
+    target = "ip6"
+    value  = "2001:0db8:85a3:0000:0000:8a2e:0370:7334"
+  }
+}`,
+		},
+		{
+			Name: "Special characters in notes",
+			Input: `resource "cloudflare_access_rule" "special_chars" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+  mode       = "block"
+  configuration {
+    target = "ip"
+    value  = "1.2.3.4"
+  }
+  notes = "Block: \"suspicious\" IP with 'quotes' & special chars!"
+}`,
+			Expected: `resource "cloudflare_access_rule" "special_chars" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+  mode       = "block"
+  notes      = "Block: \"suspicious\" IP with 'quotes' & special chars!"
+  configuration = {
+    target = "ip"
+    value  = "1.2.3.4"
+  }
+}`,
+		},
+		{
+			Name: "Variable references preserved",
+			Input: `resource "cloudflare_access_rule" "with_vars" {
+  account_id = var.cloudflare_account_id
+  mode       = var.access_mode
+  configuration {
+    target = "ip"
+    value  = var.blocked_ip
+  }
+  notes = "Block ${var.description}"
+}`,
+			Expected: `resource "cloudflare_access_rule" "with_vars" {
+  account_id = var.cloudflare_account_id
+  mode       = var.access_mode
+  notes      = "Block ${var.description}"
+  configuration = {
+    target = "ip"
+    value  = var.blocked_ip
+  }
+}`,
+		},
+	}
+
+	testhelpers.RunConfigTransformTests(t, tests, migrator)
+}
+
+func testStateTransformations(t *testing.T, migrator transform.ResourceTransformer) {
+	tests := []testhelpers.StateTestCase{
+		{
+			Name: "Convert configuration array to object",
+			Input: `{
+  "type": "cloudflare_access_rule",
+  "name": "example",
+  "attributes": {
+    "account_id": "f037e56e89293a057740de681ac9abbe",
+    "mode": "block",
+    "configuration": [
+      {
+        "target": "ip",
+        "value": "1.2.3.4"
+      }
+    ],
+    "notes": "Block suspicious IP"
+  }
+}`,
+			Expected: `{
+  "type": "cloudflare_access_rule",
+  "name": "example",
+  "attributes": {
+    "account_id": "f037e56e89293a057740de681ac9abbe",
+    "mode": "block",
+    "configuration": {
+      "target": "ip",
+      "value": "1.2.3.4"
+    },
+    "notes": "Block suspicious IP"
+  },
+  "schema_version": 0
+}`,
+		},
+		{
+			Name: "Zone-level rule state transformation",
+			Input: `{
+  "type": "cloudflare_access_rule",
+  "name": "zone_rule",
+  "attributes": {
+    "zone_id": "0da42c8d2132a9ddaf714f9e7c920711",
+    "mode": "challenge",
+    "configuration": [
+      {
+        "target": "country",
+        "value": "CN"
+      }
+    ]
+  }
+}`,
+			Expected: `{
+  "type": "cloudflare_access_rule",
+  "name": "zone_rule",
+  "attributes": {
+    "zone_id": "0da42c8d2132a9ddaf714f9e7c920711",
+    "mode": "challenge",
+    "configuration": {
+      "target": "country",
+      "value": "CN"
+    }
+  },
+  "schema_version": 0
+}`,
+		},
+		{
+			Name: "Rule without notes field",
+			Input: `{
+  "type": "cloudflare_access_rule",
+  "name": "no_notes",
+  "attributes": {
+    "account_id": "f037e56e89293a057740de681ac9abbe",
+    "mode": "whitelist",
+    "configuration": [
+      {
+        "target": "ip_range",
+        "value": "10.0.0.0/8"
+      }
+    ]
+  }
+}`,
+			Expected: `{
+  "type": "cloudflare_access_rule",
+  "name": "no_notes",
+  "attributes": {
+    "account_id": "f037e56e89293a057740de681ac9abbe",
+    "mode": "whitelist",
+    "configuration": {
+      "target": "ip_range",
+      "value": "10.0.0.0/8"
+    }
+  },
+  "schema_version": 0
+}`,
+		},
+		{
+			Name: "Invalid instance without attributes",
+			Input: `{
+  "type": "cloudflare_access_rule",
+  "name": "invalid"
+}`,
+			Expected: `{
+  "type": "cloudflare_access_rule",
+  "name": "invalid",
+  "schema_version": 0
+}`,
+		},
+		{
+			Name: "All mode types in state",
+			Input: `{
+  "type": "cloudflare_access_rule",
+  "name": "all_modes",
+  "attributes": {
+    "account_id": "f037e56e89293a057740de681ac9abbe",
+    "mode": "js_challenge",
+    "configuration": [
+      {
+        "target": "ip",
+        "value": "1.2.3.4"
+      }
+    ]
+  }
+}`,
+			Expected: `{
+  "type": "cloudflare_access_rule",
+  "name": "all_modes",
+  "attributes": {
+    "account_id": "f037e56e89293a057740de681ac9abbe",
+    "mode": "js_challenge",
+    "configuration": {
+      "target": "ip",
+      "value": "1.2.3.4"
+    }
+  },
+  "schema_version": 0
+}`,
+		},
+		{
+			Name: "IPv6 and ASN targets in state",
+			Input: `{
+  "type": "cloudflare_access_rule",
+  "name": "ipv6_asn",
+  "attributes": {
+    "account_id": "f037e56e89293a057740de681ac9abbe",
+    "mode": "block",
+    "configuration": [
+      {
+        "target": "ip6",
+        "value": "2001:0db8::1"
+      }
+    ],
+    "notes": "Block IPv6"
+  }
+}`,
+			Expected: `{
+  "type": "cloudflare_access_rule",
+  "name": "ipv6_asn",
+  "attributes": {
+    "account_id": "f037e56e89293a057740de681ac9abbe",
+    "mode": "block",
+    "configuration": {
+      "target": "ip6",
+      "value": "2001:0db8::1"
+    },
+    "notes": "Block IPv6"
+  },
+  "schema_version": 0
+}`,
+		},
+		{
+			Name: "Empty notes string",
+			Input: `{
+  "type": "cloudflare_access_rule",
+  "name": "empty_notes",
+  "attributes": {
+    "account_id": "f037e56e89293a057740de681ac9abbe",
+    "mode": "whitelist",
+    "configuration": [
+      {
+        "target": "country",
+        "value": "US"
+      }
+    ],
+    "notes": ""
+  }
+}`,
+			Expected: `{
+  "type": "cloudflare_access_rule",
+  "name": "empty_notes",
+  "attributes": {
+    "account_id": "f037e56e89293a057740de681ac9abbe",
+    "mode": "whitelist",
+    "configuration": {
+      "target": "country",
+      "value": "US"
+    },
+    "notes": ""
+  },
+  "schema_version": 0
+}`,
+		},
+	}
+
+	testhelpers.RunStateTransformTests(t, tests, migrator)
+}

--- a/internal/resources/access_rule/v4_to_v5_test.go
+++ b/internal/resources/access_rule/v4_to_v5_test.go
@@ -457,6 +457,165 @@ func testStateTransformations(t *testing.T, migrator transform.ResourceTransform
   "schema_version": 0
 }`,
 		},
+		{
+			Name: "Account-level rule with empty zone_id (mutual exclusivity)",
+			Input: `{
+  "type": "cloudflare_access_rule",
+  "name": "account_with_empty_zone",
+  "attributes": {
+    "account_id": "f037e56e89293a057740de681ac9abbe",
+    "zone_id": "",
+    "mode": "block",
+    "configuration": [
+      {
+        "target": "ip",
+        "value": "198.51.100.50"
+      }
+    ],
+    "notes": "Account-level block"
+  }
+}`,
+			Expected: `{
+  "type": "cloudflare_access_rule",
+  "name": "account_with_empty_zone",
+  "attributes": {
+    "account_id": "f037e56e89293a057740de681ac9abbe",
+    "mode": "block",
+    "configuration": {
+      "target": "ip",
+      "value": "198.51.100.50"
+    },
+    "notes": "Account-level block"
+  },
+  "schema_version": 0
+}`,
+		},
+		{
+			Name: "Zone-level rule with empty account_id (mutual exclusivity)",
+			Input: `{
+  "type": "cloudflare_access_rule",
+  "name": "zone_with_empty_account",
+  "attributes": {
+    "account_id": "",
+    "zone_id": "0da42c8d2132a9ddaf714f9e7c920711",
+    "mode": "challenge",
+    "configuration": [
+      {
+        "target": "country",
+        "value": "TV"
+      }
+    ],
+    "notes": "Zone-level challenge"
+  }
+}`,
+			Expected: `{
+  "type": "cloudflare_access_rule",
+  "name": "zone_with_empty_account",
+  "attributes": {
+    "zone_id": "0da42c8d2132a9ddaf714f9e7c920711",
+    "mode": "challenge",
+    "configuration": {
+      "target": "country",
+      "value": "TV"
+    },
+    "notes": "Zone-level challenge"
+  },
+  "schema_version": 0
+}`,
+		},
+		{
+			Name: "Account-level rule with both fields populated (mutual exclusivity)",
+			Input: `{
+  "type": "cloudflare_access_rule",
+  "name": "both_fields_account",
+  "attributes": {
+    "account_id": "f037e56e89293a057740de681ac9abbe",
+    "zone_id": "0da42c8d2132a9ddaf714f9e7c920711",
+    "mode": "whitelist",
+    "configuration": [
+      {
+        "target": "ip_range",
+        "value": "198.51.100.0/24"
+      }
+    ]
+  }
+}`,
+			Expected: `{
+  "type": "cloudflare_access_rule",
+  "name": "both_fields_account",
+  "attributes": {
+    "account_id": "f037e56e89293a057740de681ac9abbe",
+    "mode": "whitelist",
+    "configuration": {
+      "target": "ip_range",
+      "value": "198.51.100.0/24"
+    }
+  },
+  "schema_version": 0
+}`,
+		},
+		{
+			Name: "Zone-level rule with only zone_id populated (mutual exclusivity)",
+			Input: `{
+  "type": "cloudflare_access_rule",
+  "name": "zone_only",
+  "attributes": {
+    "zone_id": "0da42c8d2132a9ddaf714f9e7c920711",
+    "mode": "js_challenge",
+    "configuration": [
+      {
+        "target": "asn",
+        "value": "AS13335"
+      }
+    ],
+    "notes": "Challenge ASN"
+  }
+}`,
+			Expected: `{
+  "type": "cloudflare_access_rule",
+  "name": "zone_only",
+  "attributes": {
+    "zone_id": "0da42c8d2132a9ddaf714f9e7c920711",
+    "mode": "js_challenge",
+    "configuration": {
+      "target": "asn",
+      "value": "AS13335"
+    },
+    "notes": "Challenge ASN"
+  },
+  "schema_version": 0
+}`,
+		},
+		{
+			Name: "Account-level rule with only account_id populated (mutual exclusivity)",
+			Input: `{
+  "type": "cloudflare_access_rule",
+  "name": "account_only",
+  "attributes": {
+    "account_id": "f037e56e89293a057740de681ac9abbe",
+    "mode": "managed_challenge",
+    "configuration": [
+      {
+        "target": "ip",
+        "value": "203.0.113.1"
+      }
+    ]
+  }
+}`,
+			Expected: `{
+  "type": "cloudflare_access_rule",
+  "name": "account_only",
+  "attributes": {
+    "account_id": "f037e56e89293a057740de681ac9abbe",
+    "mode": "managed_challenge",
+    "configuration": {
+      "target": "ip",
+      "value": "203.0.113.1"
+    }
+  },
+  "schema_version": 0
+}`,
+		},
 	}
 
 	testhelpers.RunStateTransformTests(t, tests, migrator)


### PR DESCRIPTION
Supports migration of access_rule from v4 to v5.

Updates to convert to v5:
- array to object
- block to attribute
- ensures either account_id or zone_id is set, not both