### PR TITLE
feat(zero_trust_device_posture_rule): improve v4 to v5 migration

### DIFF
--- a/cmd/tf-migrate/main.go
+++ b/cmd/tf-migrate/main.go
@@ -203,10 +203,16 @@ func runMigration(log hclog.Logger, cfg config) error {
 	if cfg.stateFile != "" {
 		content, err := os.ReadFile(cfg.stateFile)
 		if err != nil {
-			log.Debug("failed to read state file: %w", err)
+			log.Warn("Failed to read state file", "file", cfg.stateFile, "error", err)
+			fmt.Printf("⚠  Failed to read state file: %s (error: %v)\n", cfg.stateFile, err)
+		} else {
+			stateJSON = string(content)
+			log.Info("Loaded state file for cross-referencing", "file", cfg.stateFile, "size", len(stateJSON))
+			fmt.Printf("✓ Loaded state file for config cross-referencing: %s\n", cfg.stateFile)
 		}
-		stateJSON = string(content)
-		log.Debug("Loaded state file for cross-referencing", "file", cfg.stateFile)
+	} else {
+		log.Info("No state file specified")
+		fmt.Println("ℹ No state file specified - config transformations will proceed without state")
 	}
 
 	// Initialize API client if credentials are available


### PR DESCRIPTION
## Summary

  Implements migration support for the `name` field in `zero_trust_device_posture_rule` resource when upgrading from provider v4 to v5. The name field was optional in v4 but became required in v5, requiring special handling during migration.

  ## Problem

  In v4, the `name` field was optional for device posture rules. When users didn't provide a name, the API stored an empty string. In v5, the name field is required, causing migration failures for resources that were created without names.

  ## Solution

  Implements a three-tier fallback strategy to automatically populate missing names during migration:

  1. **State lookup**: Check v4 state for existing name
  2. **API fallback**: Query Cloudflare API for the actual resource name if state is empty
  3. **Resource name fallback**: Use Terraform resource name as last resort

  This ensures all v4 configurations migrate successfully to v5 without requiring manual intervention.

  ## Implementation Details

  ### Core Changes

  **`v4_to_v5.go`**:
  - Added name field detection and population logic in `TransformConfig()`
  - Implemented `fetchNameFromAPI()` to retrieve resource names from Cloudflare API
  - Direct parsing of `ctx.StateJSON` using gjson for state lookups
  - Fallback chain ensures valid config generation in all scenarios

  **`main.go`**:
  - Added user-visible logging for state file operations:
    - `✓ Loaded state file for config cross-referencing`
    - `⚠ Failed to read state file`
    - `ℹ No state file specified`

  ### Test Coverage

  **`v4_to_v5_test.go`**:
  - Test: Name field populated from state when missing in config
  - Test: Name field not overwritten when present in config
  - Test: Graceful fallback to resource name when state is nil
  - Simplified test structure to use standard `TransformConfig()` method

  ## Testing

  All unit tests pass:
  ✓ TestConfigTransformation (11 subtests)
  ✓ TestConfigTransformationWithState (3 subtests)
  ✓ TestStateTransformation (12 subtests)

  Acceptance test passes with real API:
  ✓ TestMigrateDevicePostureRuleWithoutName - Verifies v4 resources without names successfully migrate to v5

  ## Migration Behavior

  **Before**:
  ```hcl
  # v4 config (name optional, not specified)
  resource "cloudflare_device_posture_rule" "example" {
    account_id = "abc123"
    type       = "os_version"
    # name not specified
  }

  After Migration:
  # v5 config (name required, auto-generated)
  resource "cloudflare_zero_trust_device_posture_rule" "example" {
    account_id = "abc123"
    type       = "os_version"
    name       = "example"  # ← Automatically added using resource name
  }

  The migration tool now handles this transformation automatically, preventing migration failures.