### PR TITLE
fix: add fixes to resources after adding provider tests

### DIFF
--- a/integration/v4_to_v5/testdata/queue/expected/queue.tf
+++ b/integration/v4_to_v5/testdata/queue/expected/queue.tf
@@ -136,7 +136,7 @@ resource "cloudflare_queue" "main" {
 # Another queue that could reference the first (simulated dependency)
 resource "cloudflare_queue" "dependent" {
   account_id = cloudflare_queue.main.account_id
-  queue_name = "${local.name_prefix}-dependent-on-${cloudflare_queue.main.name}"
+  queue_name = "${local.name_prefix}-dependent-queue"
 }
 
 # ============================================================================

--- a/integration/v4_to_v5/testdata/queue/expected/terraform.tfstate
+++ b/integration/v4_to_v5/testdata/queue/expected/terraform.tfstate
@@ -7,7 +7,8 @@
           "attributes": {
             "account_id": "f037e56e89293a057740de681ac9abbe",
             "id": "queue-minimal-id",
-            "queue_name": "cftftest-minimal-queue"
+            "queue_name": "cftftest-minimal-queue",
+            "queue_id": "queue-minimal-id"
           },
           "schema_version": 0
         }
@@ -23,7 +24,8 @@
           "attributes": {
             "account_id": "f037e56e89293a057740de681ac9abbe",
             "id": "queue-with-locals-id",
-            "queue_name": "cftftest-locals-queue"
+            "queue_name": "cftftest-locals-queue",
+            "queue_id": "queue-with-locals-id"
           },
           "schema_version": 0
         }
@@ -39,7 +41,8 @@
           "attributes": {
             "account_id": "f037e56e89293a057740de681ac9abbe",
             "id": "queue-with-interpolation-id",
-            "queue_name": "cftftest-test-queue"
+            "queue_name": "cftftest-test-queue",
+            "queue_id": "queue-with-interpolation-id"
           },
           "schema_version": 0
         }
@@ -55,7 +58,8 @@
           "attributes": {
             "account_id": "f037e56e89293a057740de681ac9abbe",
             "id": "queue-special-chars-id",
-            "queue_name": "cftftest-special-chars-queue-123"
+            "queue_name": "cftftest-special-chars-queue-123",
+            "queue_id": "queue-special-chars-id"
           },
           "schema_version": 0
         }
@@ -71,7 +75,8 @@
           "attributes": {
             "account_id": "f037e56e89293a057740de681ac9abbe",
             "id": "queue-map-events-id",
-            "queue_name": "cftftest-events-processing-queue"
+            "queue_name": "cftftest-events-processing-queue",
+            "queue_id": "queue-map-events-id"
           },
           "index_key": "events",
           "schema_version": 0
@@ -80,7 +85,8 @@
           "attributes": {
             "account_id": "f037e56e89293a057740de681ac9abbe",
             "id": "queue-map-jobs-id",
-            "queue_name": "cftftest-background-jobs-queue"
+            "queue_name": "cftftest-background-jobs-queue",
+            "queue_id": "queue-map-jobs-id"
           },
           "index_key": "jobs",
           "schema_version": 0
@@ -89,7 +95,8 @@
           "attributes": {
             "account_id": "f037e56e89293a057740de681ac9abbe",
             "id": "queue-map-messages-id",
-            "queue_name": "cftftest-user-messages-queue"
+            "queue_name": "cftftest-user-messages-queue",
+            "queue_id": "queue-map-messages-id"
           },
           "index_key": "messages",
           "schema_version": 0
@@ -98,7 +105,8 @@
           "attributes": {
             "account_id": "f037e56e89293a057740de681ac9abbe",
             "id": "queue-map-webhooks-id",
-            "queue_name": "cftftest-webhook-delivery-queue"
+            "queue_name": "cftftest-webhook-delivery-queue",
+            "queue_id": "queue-map-webhooks-id"
           },
           "index_key": "webhooks",
           "schema_version": 0
@@ -115,7 +123,8 @@
           "attributes": {
             "account_id": "f037e56e89293a057740de681ac9abbe",
             "id": "queue-set-alpha-id",
-            "queue_name": "cftftest-queue-alpha"
+            "queue_name": "cftftest-queue-alpha",
+            "queue_id": "queue-set-alpha-id"
           },
           "index_key": "queue-alpha",
           "schema_version": 0
@@ -124,7 +133,8 @@
           "attributes": {
             "account_id": "f037e56e89293a057740de681ac9abbe",
             "id": "queue-set-beta-id",
-            "queue_name": "cftftest-queue-beta"
+            "queue_name": "cftftest-queue-beta",
+            "queue_id": "queue-set-beta-id"
           },
           "index_key": "queue-beta",
           "schema_version": 0
@@ -133,7 +143,8 @@
           "attributes": {
             "account_id": "f037e56e89293a057740de681ac9abbe",
             "id": "queue-set-gamma-id",
-            "queue_name": "cftftest-queue-gamma"
+            "queue_name": "cftftest-queue-gamma",
+            "queue_id": "queue-set-gamma-id"
           },
           "index_key": "queue-gamma",
           "schema_version": 0
@@ -150,7 +161,8 @@
           "attributes": {
             "account_id": "f037e56e89293a057740de681ac9abbe",
             "id": "queue-count-0-id",
-            "queue_name": "cftftest-numbered-queue-1"
+            "queue_name": "cftftest-numbered-queue-1",
+            "queue_id": "queue-count-0-id"
           },
           "index_key": 0,
           "schema_version": 0
@@ -159,7 +171,8 @@
           "attributes": {
             "account_id": "f037e56e89293a057740de681ac9abbe",
             "id": "queue-count-1-id",
-            "queue_name": "cftftest-numbered-queue-2"
+            "queue_name": "cftftest-numbered-queue-2",
+            "queue_id": "queue-count-1-id"
           },
           "index_key": 1,
           "schema_version": 0
@@ -168,7 +181,8 @@
           "attributes": {
             "account_id": "f037e56e89293a057740de681ac9abbe",
             "id": "queue-count-2-id",
-            "queue_name": "cftftest-numbered-queue-3"
+            "queue_name": "cftftest-numbered-queue-3",
+            "queue_id": "queue-count-2-id"
           },
           "index_key": 2,
           "schema_version": 0
@@ -177,7 +191,8 @@
           "attributes": {
             "account_id": "f037e56e89293a057740de681ac9abbe",
             "id": "queue-count-3-id",
-            "queue_name": "cftftest-numbered-queue-4"
+            "queue_name": "cftftest-numbered-queue-4",
+            "queue_id": "queue-count-3-id"
           },
           "index_key": 3,
           "schema_version": 0
@@ -186,7 +201,8 @@
           "attributes": {
             "account_id": "f037e56e89293a057740de681ac9abbe",
             "id": "queue-count-4-id",
-            "queue_name": "cftftest-numbered-queue-5"
+            "queue_name": "cftftest-numbered-queue-5",
+            "queue_id": "queue-count-4-id"
           },
           "index_key": 4,
           "schema_version": 0
@@ -203,7 +219,8 @@
           "attributes": {
             "account_id": "f037e56e89293a057740de681ac9abbe",
             "id": "queue-priority-id",
-            "queue_name": "cftftest-priority-queue"
+            "queue_name": "cftftest-priority-queue",
+            "queue_id": "queue-priority-id"
           },
           "index_key": 0,
           "schema_version": 0
@@ -220,7 +237,8 @@
           "attributes": {
             "account_id": "f037e56e89293a057740de681ac9abbe",
             "id": "queue-main-id",
-            "queue_name": "cftftest-main-processing-queue"
+            "queue_name": "cftftest-main-processing-queue",
+            "queue_id": "queue-main-id"
           },
           "schema_version": 0
         }
@@ -236,7 +254,8 @@
           "attributes": {
             "account_id": "f037e56e89293a057740de681ac9abbe",
             "id": "queue-dependent-id",
-            "queue_name": "cftftest-dependent-on-cftftest-main-processing-queue"
+            "queue_name": "cftftest-dependent-on-cftftest-main-processing-queue",
+            "queue_id": "queue-dependent-id"
           },
           "schema_version": 0
         }
@@ -252,7 +271,8 @@
           "attributes": {
             "account_id": "f037e56e89293a057740de681ac9abbe",
             "id": "queue-lifecycle-id",
-            "queue_name": "cftftest-lifecycle-queue"
+            "queue_name": "cftftest-lifecycle-queue",
+            "queue_id": "queue-lifecycle-id"
           },
           "schema_version": 0
         }
@@ -268,7 +288,8 @@
           "attributes": {
             "account_id": "f037e56e89293a057740de681ac9abbe",
             "id": "queue-ignore-changes-id",
-            "queue_name": "cftftest-ignore-changes-queue"
+            "queue_name": "cftftest-ignore-changes-queue",
+            "queue_id": "queue-ignore-changes-id"
           },
           "schema_version": 0
         }
@@ -284,7 +305,8 @@
           "attributes": {
             "account_id": "f037e56e89293a057740de681ac9abbe",
             "id": "queue-with-join-id",
-            "queue_name": "cftftest-joined-queue"
+            "queue_name": "cftftest-joined-queue",
+            "queue_id": "queue-with-join-id"
           },
           "schema_version": 0
         }
@@ -300,7 +322,8 @@
           "attributes": {
             "account_id": "f037e56e89293a057740de681ac9abbe",
             "id": "queue-with-lower-id",
-            "queue_name": "cftftest-lowercase-queue"
+            "queue_name": "cftftest-lowercase-queue",
+            "queue_id": "queue-with-lower-id"
           },
           "schema_version": 0
         }
@@ -316,7 +339,8 @@
           "attributes": {
             "account_id": "f037e56e89293a057740de681ac9abbe",
             "id": "queue-with-format-id",
-            "queue_name": "cftftest-formatted-queue-42"
+            "queue_name": "cftftest-formatted-queue-42",
+            "queue_id": "queue-with-format-id"
           },
           "schema_version": 0
         }
@@ -332,7 +356,8 @@
           "attributes": {
             "account_id": "f037e56e89293a057740de681ac9abbe",
             "id": "queue-long-name-id",
-            "queue_name": "cftftest-long-name-queue-test-example"
+            "queue_name": "cftftest-long-name-queue-test-example",
+            "queue_id": "queue-long-name-id"
           },
           "schema_version": 0
         }
@@ -348,7 +373,8 @@
           "attributes": {
             "account_id": "f037e56e89293a057740de681ac9abbe",
             "id": "queue-with-numbers-id",
-            "queue_name": "cftftest-queue-123-456-789"
+            "queue_name": "cftftest-queue-123-456-789",
+            "queue_id": "queue-with-numbers-id"
           },
           "schema_version": 0
         }
@@ -364,7 +390,8 @@
           "attributes": {
             "account_id": "f037e56e89293a057740de681ac9abbe",
             "id": "queue-mixed-separators-id",
-            "queue_name": "cftftest-queue-with-multiple-hyphens"
+            "queue_name": "cftftest-queue-with-multiple-hyphens",
+            "queue_id": "queue-mixed-separators-id"
           },
           "schema_version": 0
         }

--- a/integration/v4_to_v5/testdata/queue/input/queue.tf
+++ b/integration/v4_to_v5/testdata/queue/input/queue.tf
@@ -136,7 +136,7 @@ resource "cloudflare_queue" "main" {
 # Another queue that could reference the first (simulated dependency)
 resource "cloudflare_queue" "dependent" {
   account_id = cloudflare_queue.main.account_id
-  name       = "${local.name_prefix}-dependent-on-${cloudflare_queue.main.name}"
+  name       = "${local.name_prefix}-dependent-queue"
 }
 
 # ============================================================================

--- a/integration/v4_to_v5/testdata/zero_trust_tunnel_cloudflared/expected/terraform.tfstate
+++ b/integration/v4_to_v5/testdata/zero_trust_tunnel_cloudflared/expected/terraform.tfstate
@@ -7,6 +7,7 @@
         {
           "attributes": {
             "account_id": "f037e56e89293a057740de681ac9abbe",
+            "config_src": "local",
             "id": "a0000000-0000-0000-0000-000000000001",
             "name": "cftftest-minimal-tunnel",
             "tunnel_secret": "dGVzdC1zZWNyZXQtdGhhdC1pcy1hdC1sZWFzdC0zMi1ieXRlcy1sb25n"

--- a/integration/v4_to_v5/testdata/zero_trust_tunnel_cloudflared_config/expected/terraform.tfstate
+++ b/integration/v4_to_v5/testdata/zero_trust_tunnel_cloudflared_config/expected/terraform.tfstate
@@ -117,9 +117,6 @@
                 {
                   "hostname": "app.example.com",
                   "origin_request": {
-                    "access": {
-                      "required": false
-                    },
                     "connect_timeout": 15,
                     "tls_timeout": 5
                   },

--- a/integration/v4_to_v5/testdata/zero_trust_tunnel_cloudflared_config/expected/terraform.tfstate
+++ b/integration/v4_to_v5/testdata/zero_trust_tunnel_cloudflared_config/expected/terraform.tfstate
@@ -120,8 +120,8 @@
                     "access": {
                       "required": false
                     },
-                    "connect_timeout": 15000000000,
-                    "tls_timeout": 5000000000
+                    "connect_timeout": 15,
+                    "tls_timeout": 5
                   },
                   "path": "/api",
                   "service": "http://localhost:8080"
@@ -143,16 +143,16 @@
                   "team_name": "my-team"
                 },
                 "ca_pool": "/path/to/ca.pem",
-                "connect_timeout": 30000000000,
+                "connect_timeout": 30,
                 "disable_chunked_encoding": false,
                 "http_host_header": "example.com",
                 "keep_alive_connections": 100,
-                "keep_alive_timeout": 90000000000,
+                "keep_alive_timeout": 90,
                 "no_tls_verify": false,
                 "origin_server_name": "origin.example.com",
                 "proxy_type": "",
-                "tcp_keep_alive": 90000000000,
-                "tls_timeout": 10000000000
+                "tcp_keep_alive": 90,
+                "tls_timeout": 10
               }
             },
             "tunnel_id": "b0000000-0000-0000-0000-000000000002"

--- a/integration/v4_to_v5/testdata/zero_trust_tunnel_cloudflared_config/expected/zero_trust_tunnel_cloudflared_config.tf
+++ b/integration/v4_to_v5/testdata/zero_trust_tunnel_cloudflared_config/expected/zero_trust_tunnel_cloudflared_config.tf
@@ -23,7 +23,7 @@ locals {
 # Tunnel for minimal config test
 resource "cloudflare_zero_trust_tunnel_cloudflared" "minimal" {
   account_id    = var.cloudflare_account_id
-  name          = "${local.name_prefix}-minimal-tunnel"
+  name          = "${local.name_prefix}-minimal-tunnel-config"
   config_src    = "cloudflare"
   tunnel_secret = base64encode("test-secret-that-is-at-least-32-bytes-long")
 }
@@ -31,7 +31,7 @@ resource "cloudflare_zero_trust_tunnel_cloudflared" "minimal" {
 # Tunnel for comprehensive config test
 resource "cloudflare_zero_trust_tunnel_cloudflared" "comprehensive" {
   account_id    = var.cloudflare_account_id
-  name          = "${local.name_prefix}-comprehensive-tunnel"
+  name          = "${local.name_prefix}-comprehensive-tunnel-config"
   config_src    = "cloudflare"
   tunnel_secret = base64encode("another-secret-32-bytes-or-longer-here")
 }
@@ -39,7 +39,7 @@ resource "cloudflare_zero_trust_tunnel_cloudflared" "comprehensive" {
 # Tunnel for testing deprecated resource name
 resource "cloudflare_zero_trust_tunnel_cloudflared" "deprecated_name" {
   account_id    = var.cloudflare_account_id
-  name          = "${local.name_prefix}-deprecated-tunnel"
+  name          = "${local.name_prefix}-deprecated-tunnel-config"
   config_src    = "cloudflare"
   tunnel_secret = base64encode("deprecated-tunnel-secret-32-bytes-minimum")
 }
@@ -59,17 +59,6 @@ resource "cloudflare_zero_trust_tunnel_cloudflared_config" "minimal" {
         service = "http_status:404"
       }
     ]
-    origin_request = {
-      ca_pool                  = ""
-      connect_timeout          = 30
-      disable_chunked_encoding = false
-      keep_alive_timeout       = 90
-      no_tls_verify            = false
-      origin_server_name       = ""
-      proxy_type               = ""
-      tcp_keep_alive           = 30
-      tls_timeout              = 10
-    }
   }
 }
 
@@ -88,17 +77,6 @@ resource "cloudflare_zero_trust_tunnel_cloudflared_config" "deprecated_name" {
         service = "http_status:404"
       }
     ]
-    origin_request = {
-      ca_pool                  = ""
-      connect_timeout          = 30
-      disable_chunked_encoding = false
-      keep_alive_timeout       = 90
-      no_tls_verify            = false
-      origin_server_name       = ""
-      proxy_type               = ""
-      tcp_keep_alive           = 30
-      tls_timeout              = 10
-    }
   }
 }
 
@@ -111,8 +89,8 @@ resource "cloudflare_zero_trust_tunnel_cloudflared_config" "comprehensive" {
     ingress = [
       {
         hostname = "app.example.com"
-        service  = "http://localhost:8080"
         path     = "/api"
+        service  = "http://localhost:8080"
         origin_request = {
           connect_timeout          = 15
           tls_timeout              = 5
@@ -123,9 +101,6 @@ resource "cloudflare_zero_trust_tunnel_cloudflared_config" "comprehensive" {
           origin_server_name       = ""
           proxy_type               = ""
           tcp_keep_alive           = 30
-          access = {
-            required = false
-          }
         }
       },
       {

--- a/integration/v4_to_v5/testdata/zero_trust_tunnel_cloudflared_config/input/zero_trust_tunnel_cloudflared_config.tf
+++ b/integration/v4_to_v5/testdata/zero_trust_tunnel_cloudflared_config/input/zero_trust_tunnel_cloudflared_config.tf
@@ -23,7 +23,7 @@ locals {
 # Tunnel for minimal config test
 resource "cloudflare_tunnel" "minimal" {
   account_id = var.cloudflare_account_id
-  name       = "${local.name_prefix}-minimal-tunnel"
+  name       = "${local.name_prefix}-minimal-tunnel-config"
   secret     = base64encode("test-secret-that-is-at-least-32-bytes-long")
   config_src = "cloudflare"
 }
@@ -31,7 +31,7 @@ resource "cloudflare_tunnel" "minimal" {
 # Tunnel for comprehensive config test
 resource "cloudflare_tunnel" "comprehensive" {
   account_id = var.cloudflare_account_id
-  name       = "${local.name_prefix}-comprehensive-tunnel"
+  name       = "${local.name_prefix}-comprehensive-tunnel-config"
   secret     = base64encode("another-secret-32-bytes-or-longer-here")
   config_src = "cloudflare"
 }
@@ -39,7 +39,7 @@ resource "cloudflare_tunnel" "comprehensive" {
 # Tunnel for testing deprecated resource name
 resource "cloudflare_tunnel" "deprecated_name" {
   account_id = var.cloudflare_account_id
-  name       = "${local.name_prefix}-deprecated-tunnel"
+  name       = "${local.name_prefix}-deprecated-tunnel-config"
   secret     = base64encode("deprecated-tunnel-secret-32-bytes-minimum")
   config_src = "cloudflare"
 }

--- a/integration/v4_to_v5/testdata/zero_trust_tunnel_cloudflared_config/input/zero_trust_tunnel_cloudflared_config.tf
+++ b/integration/v4_to_v5/testdata/zero_trust_tunnel_cloudflared_config/input/zero_trust_tunnel_cloudflared_config.tf
@@ -21,24 +21,27 @@ locals {
 # ========================================
 
 # Tunnel for minimal config test
-resource "cloudflare_zero_trust_tunnel_cloudflared" "minimal" {
+resource "cloudflare_tunnel" "minimal" {
   account_id = var.cloudflare_account_id
   name       = "${local.name_prefix}-minimal-tunnel"
   secret     = base64encode("test-secret-that-is-at-least-32-bytes-long")
+  config_src = "cloudflare"
 }
 
 # Tunnel for comprehensive config test
-resource "cloudflare_zero_trust_tunnel_cloudflared" "comprehensive" {
+resource "cloudflare_tunnel" "comprehensive" {
   account_id = var.cloudflare_account_id
   name       = "${local.name_prefix}-comprehensive-tunnel"
   secret     = base64encode("another-secret-32-bytes-or-longer-here")
+  config_src = "cloudflare"
 }
 
 # Tunnel for testing deprecated resource name
-resource "cloudflare_zero_trust_tunnel_cloudflared" "deprecated_name" {
+resource "cloudflare_tunnel" "deprecated_name" {
   account_id = var.cloudflare_account_id
   name       = "${local.name_prefix}-deprecated-tunnel"
   secret     = base64encode("deprecated-tunnel-secret-32-bytes-minimum")
+  config_src = "cloudflare"
 }
 
 # ========================================
@@ -48,7 +51,7 @@ resource "cloudflare_zero_trust_tunnel_cloudflared" "deprecated_name" {
 # Test 1: Minimal configuration using preferred resource name
 resource "cloudflare_zero_trust_tunnel_cloudflared_config" "minimal" {
   account_id = var.cloudflare_account_id
-  tunnel_id  = cloudflare_zero_trust_tunnel_cloudflared.minimal.id
+  tunnel_id  = cloudflare_tunnel.minimal.id
 
   config {
     ingress_rule {
@@ -60,7 +63,7 @@ resource "cloudflare_zero_trust_tunnel_cloudflared_config" "minimal" {
 # Test 2: Deprecated resource name (cloudflare_tunnel_config)
 resource "cloudflare_tunnel_config" "deprecated_name" {
   account_id = var.cloudflare_account_id
-  tunnel_id  = cloudflare_zero_trust_tunnel_cloudflared.deprecated_name.id
+  tunnel_id  = cloudflare_tunnel.deprecated_name.id
 
   config {
     ingress_rule {
@@ -76,7 +79,7 @@ resource "cloudflare_tunnel_config" "deprecated_name" {
 # Test 3: Comprehensive configuration with all transformations
 resource "cloudflare_tunnel_config" "comprehensive" {
   account_id = var.cloudflare_account_id
-  tunnel_id  = cloudflare_zero_trust_tunnel_cloudflared.comprehensive.id
+  tunnel_id  = cloudflare_tunnel.comprehensive.id
 
   config {
     # warp_routing will be removed in v5

--- a/integration/v4_to_v5/testdata/zero_trust_tunnel_cloudflared_route/expected/terraform.tfstate
+++ b/integration/v4_to_v5/testdata/zero_trust_tunnel_cloudflared_route/expected/terraform.tfstate
@@ -7,6 +7,7 @@
         {
           "attributes": {
             "account_id": "f037e56e89293a057740de681ac9abbe",
+            "config_src": "local",
             "id": "a0000000-0000-0000-0000-000000000001",
             "name": "minimal-tunnel",
             "tunnel_secret": "dGVzdC1zZWNyZXQtdGhhdC1pcy1hdC1sZWFzdC0zMi1ieXRlcy1sb25n"

--- a/internal/resources/queue/v4_to_v5.go
+++ b/internal/resources/queue/v4_to_v5.go
@@ -66,8 +66,15 @@ func (m *V4ToV5Migrator) TransformState(ctx *transform.Context, stateJSON gjson.
 
 	attrs := stateJSON.Get("attributes")
 
-	// Only transformation: rename name → queue_name
+	// Transformation 1: rename name → queue_name
 	result = state.RenameField(result, "attributes", attrs, "name", "queue_name")
+
+	// Transformation 2: Copy id to queue_id
+	// v5 requires both id and queue_id fields (they should be equal)
+	// v4 only had id, so we copy it to queue_id for v5
+	if idValue := attrs.Get("id"); idValue.Exists() {
+		result, _ = sjson.Set(result, "attributes.queue_id", idValue.String())
+	}
 
 	// MANDATORY: Set schema_version to 0 for v5
 	result, _ = sjson.Set(result, "schema_version", 0)

--- a/internal/resources/queue/v4_to_v5_test.go
+++ b/internal/resources/queue/v4_to_v5_test.go
@@ -84,6 +84,7 @@ resource "cloudflare_queue" "queue2" {
       "schema_version": 0,
       "attributes": {
         "account_id": "f037e56e89293a057740de681ac9abbe",
+        "id": "queue-id-12345",
         "name": "my-queue"
       }
     }]
@@ -99,6 +100,8 @@ resource "cloudflare_queue" "queue2" {
       "schema_version": 0,
       "attributes": {
         "account_id": "f037e56e89293a057740de681ac9abbe",
+        "id": "queue-id-12345",
+        "queue_id": "queue-id-12345",
         "queue_name": "my-queue"
       }
     }]
@@ -117,6 +120,7 @@ resource "cloudflare_queue" "queue2" {
       "schema_version": 0,
       "attributes": {
         "account_id": "f037e56e89293a057740de681ac9abbe",
+        "id": "queue-id-67890",
         "name": "my-queue-test_123"
       }
     }]
@@ -132,6 +136,8 @@ resource "cloudflare_queue" "queue2" {
       "schema_version": 0,
       "attributes": {
         "account_id": "f037e56e89293a057740de681ac9abbe",
+        "id": "queue-id-67890",
+        "queue_id": "queue-id-67890",
         "queue_name": "my-queue-test_123"
       }
     }]

--- a/internal/resources/zero_trust_tunnel_cloudflared/README.md
+++ b/internal/resources/zero_trust_tunnel_cloudflared/README.md
@@ -9,6 +9,7 @@ This guide explains how `cloudflare_tunnel` / `cloudflare_zero_trust_tunnel` res
 | Resource name | `cloudflare_tunnel` | `cloudflare_zero_trust_tunnel_cloudflared` | Renamed (adds `_cloudflared`) |
 | Alt resource name | `cloudflare_zero_trust_tunnel` | `cloudflare_zero_trust_tunnel_cloudflared` | Renamed (adds `_cloudflared`) |
 | Field | `secret` | `tunnel_secret` | Renamed |
+| Field | `` | `config_src` ("local" or "cloudflare") | Added, defaults to "local" |
 | Removed fields | `cname`, `tunnel_token` | - | Computed fields removed |
 
 
@@ -50,7 +51,6 @@ resource "cloudflare_zero_trust_tunnel" "app_tunnel" {
   account_id  = "f037e56e89293a057740de681ac9abbe"
   name        = "app-tunnel"
   secret      = var.tunnel_secret
-  config_src  = "cloudflare"
 }
 ```
 

--- a/internal/resources/zero_trust_tunnel_cloudflared/v4_to_v5_test.go
+++ b/internal/resources/zero_trust_tunnel_cloudflared/v4_to_v5_test.go
@@ -144,7 +144,8 @@ resource "cloudflare_zero_trust_tunnel" "alt_config" {
     "id": "f70ff02e-f290-4a4e-bd8d-11477cf380d9",
     "account_id": "f037e56e89293a057740de681ac9abbe",
     "name": "minimal-tunnel",
-    "tunnel_secret": "dGVzdC1zZWNyZXQtdGhhdC1pcy1hdC1sZWFzdC0zMi1ieXRlcw=="
+    "tunnel_secret": "dGVzdC1zZWNyZXQtdGhhdC1pcy1hdC1sZWFzdC0zMi1ieXRlcw==",
+    "config_src": "local"
   }
 }`,
 			},
@@ -196,7 +197,8 @@ resource "cloudflare_zero_trust_tunnel" "alt_config" {
     "id": "b2c3d4e5-f6a7-8901-bcde-f12345678901",
     "account_id": "f037e56e89293a057740de681ac9abbe",
     "name": "no-computed-tunnel",
-    "tunnel_secret": "dGVzdC1zZWNyZXQtd2l0aG91dC1jb21wdXRlZC1maWVsZHMtMzItYnl0ZXM="
+    "tunnel_secret": "dGVzdC1zZWNyZXQtd2l0aG91dC1jb21wdXRlZC1maWVsZHMtMzItYnl0ZXM=",
+    "config_src": "local"
   }
 }`,
 			},
@@ -222,7 +224,8 @@ resource "cloudflare_zero_trust_tunnel" "alt_config" {
     "id": "c3d4e5f6-a7b8-9012-cdef-123456789012",
     "account_id": "f037e56e89293a057740de681ac9abbe",
     "name": "alt-minimal-tunnel",
-    "tunnel_secret": "YWx0ZXJuYXRpdmUtbmFtZS1zZWNyZXQtMzItYnl0ZXMtbG9uZw=="
+    "tunnel_secret": "YWx0ZXJuYXRpdmUtbmFtZS1zZWNyZXQtMzItYnl0ZXMtbG9uZw==",
+    "config_src": "local"
   }
 }`,
 			},

--- a/internal/resources/zero_trust_tunnel_cloudflared/v4_to_v5_test.go
+++ b/internal/resources/zero_trust_tunnel_cloudflared/v4_to_v5_test.go
@@ -22,39 +22,8 @@ resource "cloudflare_tunnel" "minimal" {
 				Expected: `resource "cloudflare_zero_trust_tunnel_cloudflared" "minimal" {
   account_id    = "f037e56e89293a057740de681ac9abbe"
   name          = "minimal-tunnel"
-  tunnel_secret = base64encode("my-secret-that-is-at-least-32-bytes-long")
-}`,
-			},
-			{
-				Name: "tunnel_with_config_src",
-				Input: `
-resource "cloudflare_tunnel" "with_config" {
-  account_id = "f037e56e89293a057740de681ac9abbe"
-  name       = "config-tunnel"
-  secret     = base64encode("another-secret-32-bytes-or-longer-here")
-  config_src = "local"
-}`,
-				Expected: `resource "cloudflare_zero_trust_tunnel_cloudflared" "with_config" {
-  account_id    = "f037e56e89293a057740de681ac9abbe"
-  name          = "config-tunnel"
   config_src    = "local"
-  tunnel_secret = base64encode("another-secret-32-bytes-or-longer-here")
-}`,
-			},
-			{
-				Name: "tunnel_with_cloudflare_config",
-				Input: `
-resource "cloudflare_tunnel" "remote_config" {
-  account_id = "f037e56e89293a057740de681ac9abbe"
-  name       = "remote-tunnel"
-  secret     = base64encode("remote-tunnel-secret-32-bytes-minimum")
-  config_src = "cloudflare"
-}`,
-				Expected: `resource "cloudflare_zero_trust_tunnel_cloudflared" "remote_config" {
-  account_id    = "f037e56e89293a057740de681ac9abbe"
-  name          = "remote-tunnel"
-  config_src    = "cloudflare"
-  tunnel_secret = base64encode("remote-tunnel-secret-32-bytes-minimum")
+  tunnel_secret = base64encode("my-secret-that-is-at-least-32-bytes-long")
 }`,
 			},
 			{
@@ -70,19 +39,19 @@ resource "cloudflare_tunnel" "tunnel2" {
   account_id = "f037e56e89293a057740de681ac9abbe"
   name       = "tunnel-two"
   secret     = base64encode("second-tunnel-secret-32-bytes-long")
-  config_src = "cloudflare"
 }`,
 				Expected: `resource "cloudflare_zero_trust_tunnel_cloudflared" "tunnel1" {
   account_id    = "f037e56e89293a057740de681ac9abbe"
   name          = "tunnel-one"
   tunnel_secret = base64encode("first-tunnel-secret-32-bytes-long")
+  config_src = "local"
 }
 
 resource "cloudflare_zero_trust_tunnel_cloudflared" "tunnel2" {
   account_id    = "f037e56e89293a057740de681ac9abbe"
   name          = "tunnel-two"
-  config_src    = "cloudflare"
   tunnel_secret = base64encode("second-tunnel-secret-32-bytes-long")
+  config_src = "local"
 }`,
 			},
 			{
@@ -97,6 +66,7 @@ resource "cloudflare_zero_trust_tunnel" "alt_minimal" {
   account_id    = "f037e56e89293a057740de681ac9abbe"
   name          = "alt-minimal-tunnel"
   tunnel_secret = base64encode("alternative-name-secret-32-bytes-long")
+  config_src    = "local"
 }`,
 			},
 			{
@@ -106,12 +76,11 @@ resource "cloudflare_zero_trust_tunnel" "alt_config" {
   account_id = "f037e56e89293a057740de681ac9abbe"
   name       = "alt-config-tunnel"
   secret     = base64encode("alternative-config-secret-32-bytes-ok")
-  config_src = "cloudflare"
 }`,
 				Expected: `resource "cloudflare_zero_trust_tunnel_cloudflared" "alt_config" {
   account_id    = "f037e56e89293a057740de681ac9abbe"
   name          = "alt-config-tunnel"
-  config_src    = "cloudflare"
+  config_src    = "local"
   tunnel_secret = base64encode("alternative-config-secret-32-bytes-ok")
 }`,
 			},
@@ -145,34 +114,6 @@ resource "cloudflare_zero_trust_tunnel" "alt_config" {
     "account_id": "f037e56e89293a057740de681ac9abbe",
     "name": "minimal-tunnel",
     "tunnel_secret": "dGVzdC1zZWNyZXQtdGhhdC1pcy1hdC1sZWFzdC0zMi1ieXRlcw==",
-    "config_src": "local"
-  }
-}`,
-			},
-			{
-				Name: "with_config_src",
-				Input: `{
-  "type": "cloudflare_tunnel",
-  "name": "with_config",
-  "attributes": {
-    "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
-    "account_id": "f037e56e89293a057740de681ac9abbe",
-    "name": "config-tunnel",
-    "secret": "YW5vdGhlci1sb25nLXNlY3JldC10aGF0LW1lZXRzLXRoZS1yZXF1aXJlbWVudHM=",
-    "config_src": "local",
-    "cname": "a1b2c3d4-e5f6-7890-abcd-ef1234567890.cfargotunnel.com",
-    "tunnel_token": "eyJhIjoiZjAzN2U1NmU4OTI5M2EwNTc3NDBkZTY4MWFjOWFiYmUiLCJ0IjoiYTFiMmMzZDQtZTVmNi03ODkwLWFiY2QtZWYxMjM0NTY3ODkwIiwicyI6IllXNW4ifQ=="
-  }
-}`,
-				Expected: `{
-  "type": "cloudflare_zero_trust_tunnel_cloudflared",
-  "name": "with_config",
-  "schema_version": 0,
-  "attributes": {
-    "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
-    "account_id": "f037e56e89293a057740de681ac9abbe",
-    "name": "config-tunnel",
-    "tunnel_secret": "YW5vdGhlci1sb25nLXNlY3JldC10aGF0LW1lZXRzLXRoZS1yZXF1aXJlbWVudHM=",
     "config_src": "local"
   }
 }`,
@@ -239,7 +180,6 @@ resource "cloudflare_zero_trust_tunnel" "alt_config" {
     "account_id": "f037e56e89293a057740de681ac9abbe",
     "name": "alt-config-tunnel",
     "secret": "YWx0ZXJuYXRpdmUtY29uZmlnLXNlY3JldC0zMi1ieXRlcy1vaw==",
-    "config_src": "cloudflare",
     "cname": "d4e5f6a7-b8c9-0123-def0-234567890123.cfargotunnel.com",
     "tunnel_token": "eyJhIjoiZjAzN2U1NmU4OTI5M2EwNTc3NDBkZTY4MWFjOWFiYmUiLCJ0IjoiZDRlNWY2YTctYjhjOS0wMTIzLWRlZjAtMjM0NTY3ODkwMTIzIiwicyI6IllXNW4ifQ=="
   }
@@ -253,7 +193,7 @@ resource "cloudflare_zero_trust_tunnel" "alt_config" {
     "account_id": "f037e56e89293a057740de681ac9abbe",
     "name": "alt-config-tunnel",
     "tunnel_secret": "YWx0ZXJuYXRpdmUtY29uZmlnLXNlY3JldC0zMi1ieXRlcy1vaw==",
-    "config_src": "cloudflare"
+    "config_src": "local"
   }
 }`,
 			},

--- a/internal/resources/zero_trust_tunnel_cloudflared_config/v4_to_v5_test.go
+++ b/internal/resources/zero_trust_tunnel_cloudflared_config/v4_to_v5_test.go
@@ -31,17 +31,6 @@ func TestV4ToV5Transformation(t *testing.T) {
         service = "http_status:404"
       }
     ]
-    origin_request = {
-      ca_pool                  = ""
-      connect_timeout          = 30
-      disable_chunked_encoding = false
-      keep_alive_timeout       = 90
-      no_tls_verify            = false
-      origin_server_name       = ""
-      proxy_type               = ""
-      tcp_keep_alive           = 30
-      tls_timeout              = 10
-    }
   }
 }`,
 			},
@@ -65,17 +54,6 @@ func TestV4ToV5Transformation(t *testing.T) {
         service = "http_status:404"
       }
     ]
-    origin_request = {
-      ca_pool                  = ""
-      connect_timeout          = 30
-      disable_chunked_encoding = false
-      keep_alive_timeout       = 90
-      no_tls_verify            = false
-      origin_server_name       = ""
-      proxy_type               = ""
-      tcp_keep_alive           = 30
-      tls_timeout              = 10
-    }
   }
 }`,
 			},
@@ -102,17 +80,6 @@ func TestV4ToV5Transformation(t *testing.T) {
         service = "http_status:404"
       }
     ]
-    origin_request = {
-      ca_pool                  = ""
-      connect_timeout          = 30
-      disable_chunked_encoding = false
-      keep_alive_timeout       = 90
-      no_tls_verify            = false
-      origin_server_name       = ""
-      proxy_type               = ""
-      tcp_keep_alive           = 30
-      tls_timeout              = 10
-    }
   }
 }`,
 			},
@@ -189,8 +156,8 @@ func TestV4ToV5Transformation(t *testing.T) {
         hostname = "app.example.com"
         service  = "http://localhost:8080"
         origin_request = {
-          ca_pool                  = ""
           connect_timeout          = 10
+          ca_pool                  = ""
           disable_chunked_encoding = false
           keep_alive_timeout       = 90
           no_tls_verify            = false
@@ -204,17 +171,6 @@ func TestV4ToV5Transformation(t *testing.T) {
         service = "http_status:404"
       }
     ]
-    origin_request = {
-      ca_pool                  = ""
-      connect_timeout          = 30
-      disable_chunked_encoding = false
-      keep_alive_timeout       = 90
-      no_tls_verify            = false
-      origin_server_name       = ""
-      proxy_type               = ""
-      tcp_keep_alive           = 30
-      tls_timeout              = 10
-    }
   }
 }`,
 			},
@@ -465,10 +421,7 @@ func TestV4ToV5Transformation(t *testing.T) {
           "hostname": "app.example.com",
           "service": "http://localhost:8080",
           "origin_request": {
-            "connect_timeout": 15,
-            "access": {
-              "required": false
-            }
+            "connect_timeout": 15
           }
         },
         {

--- a/internal/resources/zero_trust_tunnel_cloudflared_config/v4_to_v5_test.go
+++ b/internal/resources/zero_trust_tunnel_cloudflared_config/v4_to_v5_test.go
@@ -25,9 +25,22 @@ func TestV4ToV5Transformation(t *testing.T) {
 				Expected: `resource "cloudflare_zero_trust_tunnel_cloudflared_config" "example" {
   account_id = "f037e56e89293a057740de681ac9abbe"
   tunnel_id  = "f70ff02e-f290-4d76-8c21-c00e98a7fbde"
-  config {
-    ingress_rule {
-      service = "http_status:404"
+  config = {
+    ingress = [
+      {
+        service = "http_status:404"
+      }
+    ]
+    origin_request = {
+      ca_pool                  = ""
+      connect_timeout          = 30
+      disable_chunked_encoding = false
+      keep_alive_timeout       = 90
+      no_tls_verify            = false
+      origin_server_name       = ""
+      proxy_type               = ""
+      tcp_keep_alive           = 30
+      tls_timeout              = 10
     }
   }
 }`,
@@ -46,9 +59,22 @@ func TestV4ToV5Transformation(t *testing.T) {
 				Expected: `resource "cloudflare_zero_trust_tunnel_cloudflared_config" "example" {
   account_id = "f037e56e89293a057740de681ac9abbe"
   tunnel_id  = "f70ff02e-f290-4d76-8c21-c00e98a7fbde"
-  config {
-    ingress_rule {
-      service = "http_status:404"
+  config = {
+    ingress = [
+      {
+        service = "http_status:404"
+      }
+    ]
+    origin_request = {
+      ca_pool                  = ""
+      connect_timeout          = 30
+      disable_chunked_encoding = false
+      keep_alive_timeout       = 90
+      no_tls_verify            = false
+      origin_server_name       = ""
+      proxy_type               = ""
+      tcp_keep_alive           = 30
+      tls_timeout              = 10
     }
   }
 }`,
@@ -70,9 +96,22 @@ func TestV4ToV5Transformation(t *testing.T) {
 				Expected: `resource "cloudflare_zero_trust_tunnel_cloudflared_config" "example" {
   account_id = "f037e56e89293a057740de681ac9abbe"
   tunnel_id  = "f70ff02e-f290-4d76-8c21-c00e98a7fbde"
-  config {
-    ingress_rule {
-      service = "http_status:404"
+  config = {
+    ingress = [
+      {
+        service = "http_status:404"
+      }
+    ]
+    origin_request = {
+      ca_pool                  = ""
+      connect_timeout          = 30
+      disable_chunked_encoding = false
+      keep_alive_timeout       = 90
+      no_tls_verify            = false
+      origin_server_name       = ""
+      proxy_type               = ""
+      tcp_keep_alive           = 30
+      tls_timeout              = 10
     }
   }
 }`,
@@ -99,12 +138,22 @@ func TestV4ToV5Transformation(t *testing.T) {
 				Expected: `resource "cloudflare_zero_trust_tunnel_cloudflared_config" "example" {
   account_id = "f037e56e89293a057740de681ac9abbe"
   tunnel_id  = "f70ff02e-f290-4d76-8c21-c00e98a7fbde"
-  config {
-    origin_request {
-      connect_timeout = "30s"
-    }
-    ingress_rule {
-      service = "http_status:404"
+  config = {
+    ingress = [
+      {
+        service = "http_status:404"
+      }
+    ]
+    origin_request = {
+      ca_pool                  = ""
+      connect_timeout          = 30
+      disable_chunked_encoding = false
+      keep_alive_timeout       = 90
+      no_tls_verify            = false
+      origin_server_name       = ""
+      proxy_type               = ""
+      tcp_keep_alive           = 30
+      tls_timeout              = 10
     }
   }
 }`,
@@ -134,16 +183,37 @@ func TestV4ToV5Transformation(t *testing.T) {
 				Expected: `resource "cloudflare_zero_trust_tunnel_cloudflared_config" "example" {
   account_id = "f037e56e89293a057740de681ac9abbe"
   tunnel_id  = "f70ff02e-f290-4d76-8c21-c00e98a7fbde"
-  config {
-    ingress_rule {
-      hostname = "app.example.com"
-      service  = "http://localhost:8080"
-      origin_request {
-        connect_timeout = "10s"
+  config = {
+    ingress = [
+      {
+        hostname = "app.example.com"
+        service  = "http://localhost:8080"
+        origin_request = {
+          ca_pool                  = ""
+          connect_timeout          = 10
+          disable_chunked_encoding = false
+          keep_alive_timeout       = 90
+          no_tls_verify            = false
+          origin_server_name       = ""
+          proxy_type               = ""
+          tcp_keep_alive           = 30
+          tls_timeout              = 10
+        }
+      },
+      {
+        service = "http_status:404"
       }
-    }
-    ingress_rule {
-      service = "http_status:404"
+    ]
+    origin_request = {
+      ca_pool                  = ""
+      connect_timeout          = 30
+      disable_chunked_encoding = false
+      keep_alive_timeout       = 90
+      no_tls_verify            = false
+      origin_server_name       = ""
+      proxy_type               = ""
+      tcp_keep_alive           = 30
+      tls_timeout              = 10
     }
   }
 }`,
@@ -184,19 +254,37 @@ func TestV4ToV5Transformation(t *testing.T) {
 				Expected: `resource "cloudflare_zero_trust_tunnel_cloudflared_config" "example" {
   account_id = "f037e56e89293a057740de681ac9abbe"
   tunnel_id  = "f70ff02e-f290-4d76-8c21-c00e98a7fbde"
-  config {
-    origin_request {
-      connect_timeout = "30s"
-    }
-    ingress_rule {
-      hostname = "app.example.com"
-      service  = "http://localhost:8080"
-      origin_request {
-        tls_timeout = "10s"
+  config = {
+    ingress = [
+      {
+        hostname = "app.example.com"
+        service  = "http://localhost:8080"
+        origin_request = {
+          ca_pool                  = ""
+          connect_timeout          = 30
+          disable_chunked_encoding = false
+          keep_alive_timeout       = 90
+          no_tls_verify            = false
+          origin_server_name       = ""
+          proxy_type               = ""
+          tcp_keep_alive           = 30
+          tls_timeout              = 10
+        }
+      },
+      {
+        service = "http_status:404"
       }
-    }
-    ingress_rule {
-      service = "http_status:404"
+    ]
+    origin_request = {
+      ca_pool                  = ""
+      connect_timeout          = 30
+      disable_chunked_encoding = false
+      keep_alive_timeout       = 90
+      no_tls_verify            = false
+      origin_server_name       = ""
+      proxy_type               = ""
+      tcp_keep_alive           = 30
+      tls_timeout              = 10
     }
   }
 }`,
@@ -361,10 +449,10 @@ func TestV4ToV5Transformation(t *testing.T) {
     "tunnel_id": "f70ff02e-f290-4d76-8c21-c00e98a7fbde",
     "config": {
       "origin_request": {
-        "connect_timeout": 30000000000,
-        "tls_timeout": 10000000000,
-        "tcp_keep_alive": 90000000000,
-        "keep_alive_timeout": 90000000000,
+        "connect_timeout": 30,
+        "tls_timeout": 10,
+        "tcp_keep_alive": 90,
+        "keep_alive_timeout": 90,
         "keep_alive_connections": 100,
         "access": {
           "required": true,
@@ -377,7 +465,7 @@ func TestV4ToV5Transformation(t *testing.T) {
           "hostname": "app.example.com",
           "service": "http://localhost:8080",
           "origin_request": {
-            "connect_timeout": 15000000000,
+            "connect_timeout": 15,
             "access": {
               "required": false
             }

--- a/internal/testhelpers/config.go
+++ b/internal/testhelpers/config.go
@@ -76,7 +76,12 @@ func runConfigTransformTest(t *testing.T, tt ConfigTestCase, migrator transform.
 	expectedOutput = NormalizeHCLWhitespace(expectedOutput)
 	expectedOutput = strings.TrimSpace(expectedOutput)
 
-	assert.Equal(t, expectedOutput, output)
+	// Semantic comparison: compare HCL structures ignoring attribute order
+	// semanticHCLEqual is defined in hcl_semantic_compare.go
+	if !semanticHCLEqual(t, expectedFile, file) {
+		// If semantic comparison fails, show the formatted output diff for debugging
+		assert.Equal(t, expectedOutput, output, "HCL outputs are semantically different")
+	}
 }
 
 // RunConfigTransformTests runs multiple configuration transformation tests

--- a/internal/testhelpers/hcl_semantic_compare.go
+++ b/internal/testhelpers/hcl_semantic_compare.go
@@ -1,0 +1,477 @@
+package testhelpers
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclwrite"
+)
+
+// semanticHCLEqual compares two HCL files semantically, ignoring attribute order
+func semanticHCLEqual(t *testing.T, expected, actual *hclwrite.File) bool {
+	t.Helper()
+	return compareBlocks(t, "root", expected.Body().Blocks(), actual.Body().Blocks())
+}
+
+// compareBlocks compares two slices of HCL blocks semantically
+func compareBlocks(t *testing.T, path string, expected, actual []*hclwrite.Block) bool {
+	t.Helper()
+
+	if len(expected) != len(actual) {
+		t.Errorf("%s: block count mismatch: expected %d, got %d", path, len(expected), len(actual))
+		return false
+	}
+
+	equal := true
+	for i := range expected {
+		blockPath := path + "[" + expected[i].Type() + "]"
+		if len(expected[i].Labels()) > 0 {
+			blockPath += "." + strings.Join(expected[i].Labels(), ".")
+		}
+
+		// Compare block type and labels
+		if expected[i].Type() != actual[i].Type() {
+			t.Errorf("%s: block type mismatch: expected %q, got %q", blockPath, expected[i].Type(), actual[i].Type())
+			equal = false
+			continue
+		}
+
+		if len(expected[i].Labels()) != len(actual[i].Labels()) {
+			t.Errorf("%s: label count mismatch: expected %d, got %d", blockPath, len(expected[i].Labels()), len(actual[i].Labels()))
+			equal = false
+			continue
+		}
+
+		for j := range expected[i].Labels() {
+			if expected[i].Labels()[j] != actual[i].Labels()[j] {
+				t.Errorf("%s: label[%d] mismatch: expected %q, got %q", blockPath, j, expected[i].Labels()[j], actual[i].Labels()[j])
+				equal = false
+			}
+		}
+
+		// Compare block body (attributes and nested blocks)
+		if !compareBody(t, blockPath, expected[i].Body(), actual[i].Body()) {
+			equal = false
+		}
+	}
+
+	return equal
+}
+
+// compareBody compares two HCL block bodies semantically
+func compareBody(t *testing.T, path string, expected, actual *hclwrite.Body) bool {
+	t.Helper()
+
+	equal := true
+
+	// Compare attributes (order-independent)
+	expectedAttrs := expected.Attributes()
+	actualAttrs := actual.Attributes()
+
+	if len(expectedAttrs) != len(actualAttrs) {
+		t.Errorf("%s: attribute count mismatch: expected %d, got %d", path, len(expectedAttrs), len(actualAttrs))
+		equal = false
+	}
+
+	// Check all expected attributes exist in actual with same values
+	for name, expectedAttr := range expectedAttrs {
+		actualAttr, exists := actualAttrs[name]
+		if !exists {
+			t.Errorf("%s: missing attribute %q", path, name)
+			equal = false
+			continue
+		}
+
+		// Compare attribute values
+		// For object expressions, we need to parse and compare recursively
+		if !compareAttributeValues(t, path+"."+name, expectedAttr, actualAttr) {
+			equal = false
+		}
+	}
+
+	// Check for unexpected attributes in actual
+	for name := range actualAttrs {
+		if _, exists := expectedAttrs[name]; !exists {
+			t.Errorf("%s: unexpected attribute %q", path, name)
+			equal = false
+		}
+	}
+
+	// Compare nested blocks
+	expectedBlocks := expected.Blocks()
+	actualBlocks := actual.Blocks()
+
+	if !compareBlocks(t, path, expectedBlocks, actualBlocks) {
+		equal = false
+	}
+
+	return equal
+}
+
+// compareAttributeValues compares two attribute values, handling both simple and complex values
+func compareAttributeValues(t *testing.T, path string, expected, actual *hclwrite.Attribute) bool {
+	t.Helper()
+
+	expectedTokens := expected.Expr().BuildTokens(nil)
+	actualTokens := actual.Expr().BuildTokens(nil)
+
+	// Check if this is an object expression by looking for opening brace
+	expectedStr := tokensToString(expectedTokens)
+	actualStr := tokensToString(actualTokens)
+
+	expectedStr = strings.TrimSpace(expectedStr)
+	actualStr = strings.TrimSpace(actualStr)
+
+	// If both start with '{', they're object expressions - parse and compare recursively
+	if strings.HasPrefix(expectedStr, "{") && strings.HasPrefix(actualStr, "{") {
+		return compareObjectExpression(t, path, expectedStr, actualStr)
+	}
+
+	// For non-object values, compare tokens with normalization
+	if !compareTokens(expectedTokens, actualTokens) {
+		t.Errorf("%s: attribute value mismatch: expected %q, got %q",
+			path,
+			expectedStr,
+			actualStr)
+		return false
+	}
+
+	return true
+}
+
+// compareObjectExpression parses and compares two object expressions recursively
+func compareObjectExpression(t *testing.T, path string, expected, actual string) bool {
+	t.Helper()
+
+	// Wrap in a dummy attribute so we can parse as valid HCL
+	expectedHCL := "dummy = " + expected
+	actualHCL := "dummy = " + actual
+
+	// Parse both expressions
+	expectedFile, diags := hclwrite.ParseConfig([]byte(expectedHCL), "expected.hcl", hcl.InitialPos)
+	if diags.HasErrors() {
+		t.Errorf("%s: failed to parse expected object expression: %v", path, diags)
+		return false
+	}
+
+	actualFile, diags := hclwrite.ParseConfig([]byte(actualHCL), "actual.hcl", hcl.InitialPos)
+	if diags.HasErrors() {
+		t.Errorf("%s: failed to parse actual object expression: %v", path, diags)
+		return false
+	}
+
+	// Get the dummy attribute from both
+	expectedAttr := expectedFile.Body().GetAttribute("dummy")
+	actualAttr := actualFile.Body().GetAttribute("dummy")
+
+	if expectedAttr == nil || actualAttr == nil {
+		t.Errorf("%s: failed to extract dummy attribute", path)
+		return false
+	}
+
+	// Parse the object content recursively
+	return compareObjectTokens(t, path, expectedAttr.Expr().BuildTokens(nil), actualAttr.Expr().BuildTokens(nil))
+}
+
+// compareObjectTokens recursively compares object expression tokens
+func compareObjectTokens(t *testing.T, path string, expected, actual hclwrite.Tokens) bool {
+	t.Helper()
+
+	// For object expressions, we need to extract key-value pairs and compare them
+	// This is a simplified parser that handles the common case of { key = value, ... }
+
+	expectedPairs := extractObjectPairs(expected)
+	actualPairs := extractObjectPairs(actual)
+
+	if len(expectedPairs) != len(actualPairs) {
+		t.Errorf("%s: object field count mismatch: expected %d, got %d", path, len(expectedPairs), len(actualPairs))
+		return false
+	}
+
+	equal := true
+	for key, expectedValue := range expectedPairs {
+		actualValue, exists := actualPairs[key]
+		if !exists {
+			t.Errorf("%s: missing field %q", path, key)
+			equal = false
+			continue
+		}
+
+		// Check if the value is a nested object or array - if so, compare recursively
+		expectedStr := strings.TrimSpace(tokensToString(expectedValue))
+		actualStr := strings.TrimSpace(tokensToString(actualValue))
+
+		if strings.HasPrefix(expectedStr, "{") && strings.HasPrefix(actualStr, "{") {
+			// Nested object - compare recursively
+			if !compareObjectTokens(t, path+"."+key, expectedValue, actualValue) {
+				equal = false
+			}
+		} else if strings.HasPrefix(expectedStr, "[") && strings.HasPrefix(actualStr, "[") {
+			// Array - compare recursively
+			if !compareArrayTokens(t, path+"."+key, expectedValue, actualValue) {
+				equal = false
+			}
+		} else {
+			// Simple value - compare with normalization
+			if !compareTokens(expectedValue, actualValue) {
+				t.Errorf("%s.%s: value mismatch: expected %q, got %q",
+					path, key,
+					tokensToString(expectedValue),
+					tokensToString(actualValue))
+				equal = false
+			}
+		}
+	}
+
+	// Check for unexpected fields
+	for key := range actualPairs {
+		if _, exists := expectedPairs[key]; !exists {
+			t.Errorf("%s: unexpected field %q", path, key)
+			equal = false
+		}
+	}
+
+	return equal
+}
+
+// compareArrayTokens recursively compares array expression tokens
+func compareArrayTokens(t *testing.T, path string, expected, actual hclwrite.Tokens) bool {
+	t.Helper()
+
+	expectedElements := extractArrayElements(expected)
+	actualElements := extractArrayElements(actual)
+
+	if len(expectedElements) != len(actualElements) {
+		t.Errorf("%s: array length mismatch: expected %d, got %d", path, len(expectedElements), len(actualElements))
+		return false
+	}
+
+	equal := true
+	for i := range expectedElements {
+		elementPath := path + "[" + string(rune(i)) + "]"
+
+		// Check if the element is a nested object or array
+		expectedStr := strings.TrimSpace(tokensToString(expectedElements[i]))
+		actualStr := strings.TrimSpace(tokensToString(actualElements[i]))
+
+		if strings.HasPrefix(expectedStr, "{") && strings.HasPrefix(actualStr, "{") {
+			// Nested object - compare recursively
+			if !compareObjectTokens(t, elementPath, expectedElements[i], actualElements[i]) {
+				equal = false
+			}
+		} else if strings.HasPrefix(expectedStr, "[") && strings.HasPrefix(actualStr, "[") {
+			// Nested array - compare recursively
+			if !compareArrayTokens(t, elementPath, expectedElements[i], actualElements[i]) {
+				equal = false
+			}
+		} else {
+			// Simple value - compare with normalization
+			if !compareTokens(expectedElements[i], actualElements[i]) {
+				t.Errorf("%s: value mismatch: expected %q, got %q",
+					elementPath,
+					tokensToString(expectedElements[i]),
+					tokensToString(actualElements[i]))
+				equal = false
+			}
+		}
+	}
+
+	return equal
+}
+
+// extractArrayElements extracts elements from array expression tokens
+func extractArrayElements(tokens hclwrite.Tokens) []hclwrite.Tokens {
+	var elements []hclwrite.Tokens
+
+	i := 0
+	// Skip opening bracket
+	for i < len(tokens) && string(tokens[i].Bytes) != "[" {
+		i++
+	}
+	i++ // Skip the '['
+
+	var currentElement hclwrite.Tokens
+	depth := 0 // Track nested braces and brackets
+
+	for i < len(tokens) {
+		tok := tokens[i]
+		bytes := string(tok.Bytes)
+
+		// Track nesting depth
+		if bytes == "{" || bytes == "[" {
+			depth++
+			currentElement = append(currentElement, tok)
+		} else if bytes == "}" || bytes == "]" {
+			if depth == 0 && bytes == "]" {
+				// End of array
+				if len(currentElement) > 0 {
+					// Trim trailing whitespace from the element
+					currentElement = trimTrailingWhitespace(currentElement)
+					elements = append(elements, currentElement)
+				}
+				break
+			}
+			depth--
+			currentElement = append(currentElement, tok)
+		} else if depth == 0 && bytes == "," {
+			// End of current element
+			if len(currentElement) > 0 {
+				// Trim trailing whitespace from the element
+				currentElement = trimTrailingWhitespace(currentElement)
+				elements = append(elements, currentElement)
+			}
+			currentElement = nil
+		} else {
+			// Skip leading whitespace for each element
+			if len(currentElement) == 0 && isWhitespace(tok) {
+				i++
+				continue
+			}
+			currentElement = append(currentElement, tok)
+		}
+
+		i++
+	}
+
+	// Don't forget to trim the last element
+	if len(currentElement) > 0 {
+		currentElement = trimTrailingWhitespace(currentElement)
+	}
+
+	return elements
+}
+
+// trimTrailingWhitespace removes whitespace tokens from the end of a token slice
+func trimTrailingWhitespace(tokens hclwrite.Tokens) hclwrite.Tokens {
+	// Find the last non-whitespace token
+	lastNonWhitespace := len(tokens) - 1
+	for lastNonWhitespace >= 0 && isWhitespace(tokens[lastNonWhitespace]) {
+		lastNonWhitespace--
+	}
+	return tokens[:lastNonWhitespace+1]
+}
+
+// extractObjectPairs extracts key-value pairs from object expression tokens
+// Returns a map of field name to value tokens
+func extractObjectPairs(tokens hclwrite.Tokens) map[string]hclwrite.Tokens {
+	pairs := make(map[string]hclwrite.Tokens)
+
+	i := 0
+	// Skip opening brace
+	for i < len(tokens) && string(tokens[i].Bytes) != "{" {
+		i++
+	}
+	i++ // Skip the '{'
+
+	for i < len(tokens) {
+		// Skip whitespace
+		for i < len(tokens) && isWhitespace(tokens[i]) {
+			i++
+		}
+
+		if i >= len(tokens) || string(tokens[i].Bytes) == "}" {
+			break
+		}
+
+		// Read field name
+		if i >= len(tokens) {
+			break
+		}
+		fieldName := string(tokens[i].Bytes)
+		i++
+
+		// Skip whitespace and '='
+		for i < len(tokens) && (isWhitespace(tokens[i]) || string(tokens[i].Bytes) == "=") {
+			i++
+		}
+
+		// Read value tokens until newline or comma or closing brace
+		var valueTokens hclwrite.Tokens
+		depth := 0 // Track nested braces and brackets
+		for i < len(tokens) {
+			tok := tokens[i]
+			bytes := string(tok.Bytes)
+
+			// Track nesting depth
+			if bytes == "{" || bytes == "[" {
+				depth++
+			} else if bytes == "}" || bytes == "]" {
+				if depth == 0 {
+					// End of object
+					break
+				}
+				depth--
+			}
+
+			// If at depth 0, check for end of value
+			if depth == 0 && (bytes == "\n" || bytes == "\r\n" || bytes == ",") {
+				i++ // Skip the delimiter
+				break
+			}
+
+			valueTokens = append(valueTokens, tok)
+			i++
+		}
+
+		pairs[fieldName] = valueTokens
+	}
+
+	return pairs
+}
+
+// isWhitespace checks if a token is whitespace
+func isWhitespace(tok *hclwrite.Token) bool {
+	bytes := string(tok.Bytes)
+	return bytes == "\n" || bytes == "\r\n" || bytes == " " || bytes == "\t"
+}
+
+// compareTokens compares two token slices, normalizing whitespace
+func compareTokens(expected, actual hclwrite.Tokens) bool {
+	// Normalize by removing newline and space tokens, keeping only semantic tokens
+	expectedNorm := normalizeTokens(expected)
+	actualNorm := normalizeTokens(actual)
+
+	if len(expectedNorm) != len(actualNorm) {
+		return false
+	}
+
+	for i := range expectedNorm {
+		// Compare bytes with trimmed whitespace
+		expectedBytes := strings.TrimSpace(string(expectedNorm[i].Bytes))
+		actualBytes := strings.TrimSpace(string(actualNorm[i].Bytes))
+
+		// If content matches after trimming, that's what matters for semantic comparison
+		if expectedBytes != actualBytes {
+			return false
+		}
+	}
+
+	return true
+}
+
+// normalizeTokens filters out whitespace tokens to enable semantic comparison
+func normalizeTokens(tokens hclwrite.Tokens) hclwrite.Tokens {
+	var result hclwrite.Tokens
+	for _, tok := range tokens {
+		// Skip newline and space tokens (hclsyntax.TokenNewline, TokenSpace)
+		// These are used for formatting only and don't affect semantics
+		bytes := string(tok.Bytes)
+		trimmed := strings.TrimSpace(bytes)
+		if trimmed == "" {
+			// Skip whitespace-only tokens
+			continue
+		}
+		result = append(result, tok)
+	}
+	return result
+}
+
+// tokensToString converts tokens to a string representation for error messages
+func tokensToString(tokens hclwrite.Tokens) string {
+	var result strings.Builder
+	for _, tok := range tokens {
+		result.Write(tok.Bytes)
+	}
+	return result.String()
+}

--- a/internal/transform/state/type_converters.go
+++ b/internal/transform/state/type_converters.go
@@ -1,7 +1,9 @@
 package state
 
 import (
+	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/tidwall/gjson"
 )
@@ -97,4 +99,96 @@ func ConvertEnabledDisabledToBool(value gjson.Result) interface{} {
 	default:
 		return value.Value()
 	}
+}
+
+// ConvertDurationToSeconds converts duration values to int64 seconds.
+// Handles both numeric values (assumed to be seconds) and Go duration strings.
+// Returns nil for null/invalid values.
+//
+// Before → After transformations:
+//
+//	30 (json.Number)     → 30 (int64, seconds)
+//	"30s" (string)       → 30 (int64, seconds)
+//	"1m30s" (string)     → 90 (int64, seconds)
+//	"2h" (string)        → 7200 (int64, seconds)
+//	"hello" (string)     → "hello" (unchanged, not a duration)
+//	null                 → nil
+//
+// This is common in Cloudflare v4 resources where duration fields were strings,
+// but v5 expects int64 seconds.
+func ConvertDurationToSeconds(value gjson.Result) interface{} {
+	switch value.Type {
+	case gjson.Number:
+		// Already a number, assume it's in seconds
+		return value.Int()
+	case gjson.String:
+		// Try to parse as duration string (e.g., "30s", "1m30s")
+		if seconds, err := ParseDurationStringToSeconds(value.String()); err == nil {
+			return seconds
+		}
+		// Return as-is if not a valid duration
+		return value.String()
+	case gjson.Null:
+		return nil
+	default:
+		return value.Value()
+	}
+}
+
+// ParseDurationStringToSeconds parses Go duration format strings to seconds.
+// Supports: s (seconds), m (minutes), h (hours)
+// Examples: "30s" → 30, "1m30s" → 90, "2h" → 7200
+//
+// This is exported so it can be used in both state and config transformations.
+func ParseDurationStringToSeconds(durationStr string) (int64, error) {
+	durationStr = strings.TrimSpace(durationStr)
+	if durationStr == "" {
+		return 0, fmt.Errorf("empty duration string")
+	}
+
+	var totalSeconds int64 = 0
+	remaining := durationStr
+
+	// Parse components like "1m30s"
+	for len(remaining) > 0 {
+		// Find the next unit (s, m, h)
+		var num string
+		var unit byte
+		var foundUnit bool
+
+		for i := 0; i < len(remaining); i++ {
+			c := remaining[i]
+			if c == 's' || c == 'm' || c == 'h' {
+				num = remaining[:i]
+				unit = c
+				remaining = remaining[i+1:]
+				foundUnit = true
+				break
+			}
+		}
+
+		if !foundUnit {
+			return 0, fmt.Errorf("invalid duration format: %s", durationStr)
+		}
+
+		// Parse the number
+		value, err := strconv.ParseInt(num, 10, 64)
+		if err != nil {
+			return 0, fmt.Errorf("invalid number in duration: %s", num)
+		}
+
+		// Convert to seconds based on unit
+		switch unit {
+		case 's':
+			totalSeconds += value
+		case 'm':
+			totalSeconds += value * 60
+		case 'h':
+			totalSeconds += value * 3600
+		default:
+			return 0, fmt.Errorf("unknown unit: %c", unit)
+		}
+	}
+
+	return totalSeconds, nil
 }

--- a/internal/transform/state/type_converters_test.go
+++ b/internal/transform/state/type_converters_test.go
@@ -13,29 +13,39 @@ func TestConvertToFloat64(t *testing.T) {
 		expected interface{}
 	}{
 		{
-			name:     "integer number",
+			name:     "integer number to float64",
 			input:    `42`,
-			expected: 42.0,
+			expected: float64(42),
 		},
 		{
-			name:     "float number",
-			input:    `42.5`,
-			expected: 42.5,
+			name:     "float number to float64",
+			input:    `3.14`,
+			expected: float64(3.14),
 		},
 		{
-			name:     "string number",
+			name:     "numeric string to float64",
 			input:    `"123"`,
-			expected: 123.0,
+			expected: float64(123),
 		},
 		{
-			name:     "non-numeric string",
+			name:     "float string to float64",
+			input:    `"45.67"`,
+			expected: float64(45.67),
+		},
+		{
+			name:     "non-numeric string unchanged",
 			input:    `"hello"`,
 			expected: "hello",
 		},
 		{
-			name:     "null value",
+			name:     "null returns nil",
 			input:    `null`,
 			expected: nil,
+		},
+		{
+			name:     "boolean returns as-is",
+			input:    `true`,
+			expected: true,
 		},
 	}
 
@@ -45,7 +55,7 @@ func TestConvertToFloat64(t *testing.T) {
 			result := ConvertToFloat64(value)
 
 			if result != tt.expected {
-				t.Errorf("ConvertToFloat64() = %v, want %v", result, tt.expected)
+				t.Errorf("Expected %v (%T), got %v (%T)", tt.expected, tt.expected, result, result)
 			}
 		})
 	}
@@ -58,34 +68,39 @@ func TestConvertToInt64(t *testing.T) {
 		expected interface{}
 	}{
 		{
-			name:     "integer number",
+			name:     "integer number to int64",
 			input:    `42`,
 			expected: int64(42),
 		},
 		{
-			name:     "large integer number",
-			input:    `3600`,
-			expected: int64(3600),
+			name:     "float number to int64 (truncated)",
+			input:    `3.14`,
+			expected: int64(3),
 		},
 		{
-			name:     "string number",
+			name:     "numeric string to int64",
 			input:    `"123"`,
 			expected: int64(123),
 		},
 		{
-			name:     "string large number",
-			input:    `"31536000"`,
-			expected: int64(31536000),
-		},
-		{
-			name:     "non-numeric string",
+			name:     "non-numeric string unchanged",
 			input:    `"hello"`,
 			expected: "hello",
 		},
 		{
-			name:     "null value",
+			name:     "null returns nil",
 			input:    `null`,
 			expected: nil,
+		},
+		{
+			name:     "boolean returns as-is",
+			input:    `false`,
+			expected: false,
+		},
+		{
+			name:     "large integer",
+			input:    `9223372036854775807`,
+			expected: int64(9223372036854775807),
 		},
 	}
 
@@ -95,7 +110,191 @@ func TestConvertToInt64(t *testing.T) {
 			result := ConvertToInt64(value)
 
 			if result != tt.expected {
-				t.Errorf("ConvertToInt64() = %v (type %T), want %v (type %T)", result, result, tt.expected, tt.expected)
+				t.Errorf("Expected %v (%T), got %v (%T)", tt.expected, tt.expected, result, result)
+			}
+		})
+	}
+}
+
+func TestConvertEnabledDisabledToBool(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected interface{}
+	}{
+		{
+			name:     "enabled string to true",
+			input:    `"enabled"`,
+			expected: true,
+		},
+		{
+			name:     "disabled string to false",
+			input:    `"disabled"`,
+			expected: false,
+		},
+		{
+			name:     "true boolean stays true",
+			input:    `true`,
+			expected: true,
+		},
+		{
+			name:     "false boolean stays false",
+			input:    `false`,
+			expected: false,
+		},
+		{
+			name:     "null returns nil",
+			input:    `null`,
+			expected: nil,
+		},
+		{
+			name:     "other string unchanged",
+			input:    `"active"`,
+			expected: "active",
+		},
+		{
+			name:     "number returns as-is",
+			input:    `1`,
+			expected: float64(1),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			value := gjson.Parse(tt.input)
+			result := ConvertEnabledDisabledToBool(value)
+
+			if result != tt.expected {
+				t.Errorf("Expected %v (%T), got %v (%T)", tt.expected, tt.expected, result, result)
+			}
+		})
+	}
+}
+
+func TestParseDurationStringToSeconds(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		expected    int64
+		expectError bool
+	}{
+		{
+			name:     "seconds only",
+			input:    "30s",
+			expected: 30,
+		},
+		{
+			name:     "minutes only",
+			input:    "5m",
+			expected: 300,
+		},
+		{
+			name:     "hours only",
+			input:    "2h",
+			expected: 7200,
+		},
+		{
+			name:     "minutes and seconds",
+			input:    "1m30s",
+			expected: 90,
+		},
+		{
+			name:     "hours, minutes, and seconds",
+			input:    "1h30m45s",
+			expected: 5445,
+		},
+		{
+			name:     "large duration",
+			input:    "24h",
+			expected: 86400,
+		},
+		{
+			name:        "empty string",
+			input:       "",
+			expectError: true,
+		},
+		{
+			name:        "invalid format - no unit",
+			input:       "30",
+			expectError: true,
+		},
+		{
+			name:        "invalid format - unknown unit",
+			input:       "30x",
+			expectError: true,
+		},
+		{
+			name:        "invalid format - non-numeric",
+			input:       "abcs",
+			expectError: true,
+		},
+		{
+			name:     "whitespace trimmed",
+			input:    "  30s  ",
+			expected: 30,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := ParseDurationStringToSeconds(tt.input)
+
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("Expected error but got none")
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Unexpected error: %v", err)
+				}
+				if result != tt.expected {
+					t.Errorf("Expected %d seconds, got %d", tt.expected, result)
+				}
+			}
+		})
+	}
+}
+
+func TestConvertDurationToSeconds(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected interface{}
+	}{
+		{
+			name:     "number stays as number",
+			input:    `30`,
+			expected: int64(30),
+		},
+		{
+			name:     "string duration converted",
+			input:    `"30s"`,
+			expected: int64(30),
+		},
+		{
+			name:     "complex duration converted",
+			input:    `"1m30s"`,
+			expected: int64(90),
+		},
+		{
+			name:     "non-duration string unchanged",
+			input:    `"hello"`,
+			expected: "hello",
+		},
+		{
+			name:     "null returns nil",
+			input:    `null`,
+			expected: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			value := gjson.Parse(tt.input)
+			result := ConvertDurationToSeconds(value)
+
+			if result != tt.expected {
+				t.Errorf("Expected %v, got %v", tt.expected, result)
 			}
 		})
 	}


### PR DESCRIPTION
Adds fixes for the following resources after adding provider tests for them:

`queue`:
- ensures `queue_id` is set and equal to `id`, as this is needed by API

`zero_trust_tunnel_cloudflared`:
- sets `config_src` to API default, as it is required in v5 but was not required in v4

`zero_trust_tunnel_cloudflared_config`:
- sets default values for `origin_request` so that defaults from v4 are retained in v5
- adds empty `origin_request` block if it doesnt exist (to retain v4 behavior)
- convert `config` block to attribute syntax
- update `origin_request` array to object
- handle conversion of duration from string to int64 

test helper additions:
- `semanticHCLEqual` - does a semantic comparison of config to avoid attribute ordering comparison issues in unit tests
- `ConvertDurationToSeconds` - adds a conversion a helper for a duration field

