### PR TITLE
feat(regional_tiered_cache): add v4 to v5 migrator

### DIFF
--- a/integration/v4_to_v5/testdata/regional_tiered_cache/expected/regional_tiered_cache.tf
+++ b/integration/v4_to_v5/testdata/regional_tiered_cache/expected/regional_tiered_cache.tf
@@ -1,0 +1,161 @@
+# Terraform Provider v4 to v5 Migration Test
+# Resource: cloudflare_regional_tiered_cache
+# Test Coverage: All Terraform patterns for simple zone-level settings
+
+# ============================================================================
+# Standard Variables (Auto-provided by test infrastructure)
+# ============================================================================
+variable "cloudflare_account_id" {
+  description = "Cloudflare account ID"
+  type        = string
+}
+
+variable "cloudflare_zone_id" {
+  description = "Cloudflare zone ID"
+  type        = string
+}
+
+variable "cloudflare_domain" {
+  description = "Cloudflare domain for testing"
+  type        = string
+}
+
+# Locals for common values
+locals {
+  test_zones = {
+    zone1 = var.cloudflare_zone_id
+    zone2 = var.cloudflare_zone_id
+    zone3 = var.cloudflare_zone_id
+  }
+  name_prefix         = "cftftest"
+  enable_cache        = true
+  enable_experimental = false
+}
+
+# Pattern 1: Basic resource with value="on"
+resource "cloudflare_regional_tiered_cache" "basic_on" {
+  zone_id = var.cloudflare_zone_id
+  value   = "on"
+}
+
+# Pattern 2: Basic resource with value="off"
+resource "cloudflare_regional_tiered_cache" "basic_off" {
+  zone_id = var.cloudflare_zone_id
+  value   = "off"
+}
+
+# Pattern 3: for_each with map (3 instances)
+resource "cloudflare_regional_tiered_cache" "for_each_map" {
+  for_each = {
+    "enabled" = {
+      zone_id = var.cloudflare_zone_id
+      value   = "on"
+    }
+    "disabled" = {
+      zone_id = var.cloudflare_zone_id
+      value   = "off"
+    }
+    "testing" = {
+      zone_id = var.cloudflare_zone_id
+      value   = "on"
+    }
+  }
+
+  zone_id = each.value.zone_id
+  value   = each.value.value
+}
+
+# Pattern 4: for_each with set using toset() (4 instances)
+resource "cloudflare_regional_tiered_cache" "for_each_set" {
+  for_each = toset(["alpha", "beta", "gamma", "delta"])
+
+  zone_id = var.cloudflare_zone_id
+  value   = "on"
+}
+
+# Pattern 5: count-based resources (3 instances)
+resource "cloudflare_regional_tiered_cache" "counted" {
+  count = 3
+
+  zone_id = var.cloudflare_zone_id
+  value   = count.index == 0 ? "on" : "off"
+}
+
+# Pattern 6: Conditional creation - enabled (1 instance created)
+resource "cloudflare_regional_tiered_cache" "conditional_enabled" {
+  count = local.enable_cache ? 1 : 0
+
+  zone_id = var.cloudflare_zone_id
+  value   = "on"
+}
+
+# Pattern 7: Conditional creation - disabled (0 instances created)
+resource "cloudflare_regional_tiered_cache" "conditional_disabled" {
+  count = local.enable_experimental ? 1 : 0
+
+  zone_id = var.cloudflare_zone_id
+  value   = "off"
+}
+
+# Pattern 8: Using terraform functions
+resource "cloudflare_regional_tiered_cache" "with_functions" {
+  zone_id = var.cloudflare_zone_id
+  value   = join("", ["o", "n"]) # Results in "on"
+}
+
+# Pattern 9: String interpolation
+resource "cloudflare_regional_tiered_cache" "with_interpolation" {
+  zone_id = "${var.cloudflare_zone_id}"
+  value   = "on"
+}
+
+# Pattern 10: Lifecycle meta-arguments
+resource "cloudflare_regional_tiered_cache" "with_lifecycle" {
+  zone_id = var.cloudflare_zone_id
+  value   = "on"
+
+  lifecycle {
+    create_before_destroy = true
+    ignore_changes        = [value]
+  }
+}
+
+# Pattern 11: Prevent destroy lifecycle
+resource "cloudflare_regional_tiered_cache" "with_prevent_destroy" {
+  zone_id = var.cloudflare_zone_id
+  value   = "off"
+
+  lifecycle {
+    prevent_destroy = false # Set to false for testing
+  }
+}
+
+# Pattern 12: Using local reference
+resource "cloudflare_regional_tiered_cache" "from_local" {
+  zone_id = local.test_zones["zone1"]
+  value   = "on"
+}
+
+# Pattern 13: Mixed patterns - for_each with conditional value
+resource "cloudflare_regional_tiered_cache" "mixed_pattern" {
+  for_each = local.test_zones
+
+  zone_id = each.value
+  value   = each.key == "zone1" ? "on" : "off"
+}
+
+# Total resource instances in this test:
+# basic_on: 1
+# basic_off: 1
+# for_each_map: 3
+# for_each_set: 4
+# counted: 3
+# conditional_enabled: 1
+# conditional_disabled: 0
+# with_functions: 1
+# with_interpolation: 1
+# with_lifecycle: 1
+# with_prevent_destroy: 1
+# from_local: 1
+# mixed_pattern: 3
+# TOTAL: 21 instances

--- a/integration/v4_to_v5/testdata/regional_tiered_cache/expected/regional_tiered_cache_e2e.tf
+++ b/integration/v4_to_v5/testdata/regional_tiered_cache/expected/regional_tiered_cache_e2e.tf
@@ -1,0 +1,25 @@
+# E2E test for regional_tiered_cache migration
+# This is a simplified version for actual API testing (singleton resource)
+
+variable "cloudflare_account_id" {
+  description = "Cloudflare account ID"
+  type        = string
+}
+
+variable "cloudflare_zone_id" {
+  description = "Cloudflare zone ID"
+  type        = string
+}
+
+variable "cloudflare_domain" {
+  description = "Cloudflare domain for testing"
+  type        = string
+}
+
+# Test: Single instance (singleton resource - only one per zone)
+# Note: This is a SINGLETON resource - only ONE instance per zone
+# Note: Regional Tiered Cache requires Enterprise plan
+resource "cloudflare_regional_tiered_cache" "test" {
+  zone_id = var.cloudflare_zone_id
+  value   = "on"
+}

--- a/integration/v4_to_v5/testdata/regional_tiered_cache/expected/terraform.tfstate
+++ b/integration/v4_to_v5/testdata/regional_tiered_cache/expected/terraform.tfstate
@@ -1,0 +1,287 @@
+{
+  "lineage": "test-regional-tiered-cache-lineage",
+  "outputs": {},
+  "resources": [
+    {
+      "instances": [
+        {
+          "attributes": {
+            "id": "test-zone-id-1",
+            "value": "on",
+            "zone_id": "test-zone-id-1"
+          },
+          "schema_version": 0
+        }
+      ],
+      "mode": "managed",
+      "name": "basic_on",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_regional_tiered_cache"
+    },
+    {
+      "instances": [
+        {
+          "attributes": {
+            "id": "test-zone-id-2",
+            "value": "off",
+            "zone_id": "test-zone-id-2"
+          },
+          "schema_version": 0
+        }
+      ],
+      "mode": "managed",
+      "name": "basic_off",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_regional_tiered_cache"
+    },
+    {
+      "instances": [
+        {
+          "attributes": {
+            "id": "test-zone-id-3",
+            "value": "off",
+            "zone_id": "test-zone-id-3"
+          },
+          "index_key": "disabled",
+          "schema_version": 0
+        },
+        {
+          "attributes": {
+            "id": "test-zone-id-4",
+            "value": "on",
+            "zone_id": "test-zone-id-4"
+          },
+          "index_key": "enabled",
+          "schema_version": 0
+        },
+        {
+          "attributes": {
+            "id": "test-zone-id-5",
+            "value": "on",
+            "zone_id": "test-zone-id-5"
+          },
+          "index_key": "testing",
+          "schema_version": 0
+        }
+      ],
+      "mode": "managed",
+      "name": "for_each_map",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_regional_tiered_cache"
+    },
+    {
+      "instances": [
+        {
+          "attributes": {
+            "id": "test-zone-id-6",
+            "value": "on",
+            "zone_id": "test-zone-id-6"
+          },
+          "index_key": "alpha",
+          "schema_version": 0
+        },
+        {
+          "attributes": {
+            "id": "test-zone-id-7",
+            "value": "on",
+            "zone_id": "test-zone-id-7"
+          },
+          "index_key": "beta",
+          "schema_version": 0
+        },
+        {
+          "attributes": {
+            "id": "test-zone-id-8",
+            "value": "on",
+            "zone_id": "test-zone-id-8"
+          },
+          "index_key": "delta",
+          "schema_version": 0
+        },
+        {
+          "attributes": {
+            "id": "test-zone-id-9",
+            "value": "on",
+            "zone_id": "test-zone-id-9"
+          },
+          "index_key": "gamma",
+          "schema_version": 0
+        }
+      ],
+      "mode": "managed",
+      "name": "for_each_set",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_regional_tiered_cache"
+    },
+    {
+      "instances": [
+        {
+          "attributes": {
+            "id": "test-zone-id-10",
+            "value": "on",
+            "zone_id": "test-zone-id-10"
+          },
+          "index_key": 0,
+          "schema_version": 0
+        },
+        {
+          "attributes": {
+            "id": "test-zone-id-11",
+            "value": "off",
+            "zone_id": "test-zone-id-11"
+          },
+          "index_key": 1,
+          "schema_version": 0
+        },
+        {
+          "attributes": {
+            "id": "test-zone-id-12",
+            "value": "off",
+            "zone_id": "test-zone-id-12"
+          },
+          "index_key": 2,
+          "schema_version": 0
+        }
+      ],
+      "mode": "managed",
+      "name": "counted",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_regional_tiered_cache"
+    },
+    {
+      "instances": [
+        {
+          "attributes": {
+            "id": "test-zone-id-13",
+            "value": "on",
+            "zone_id": "test-zone-id-13"
+          },
+          "index_key": 0,
+          "schema_version": 0
+        }
+      ],
+      "mode": "managed",
+      "name": "conditional_enabled",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_regional_tiered_cache"
+    },
+    {
+      "instances": [
+        {
+          "attributes": {
+            "id": "test-zone-id-14",
+            "value": "on",
+            "zone_id": "test-zone-id-14"
+          },
+          "schema_version": 0
+        }
+      ],
+      "mode": "managed",
+      "name": "with_functions",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_regional_tiered_cache"
+    },
+    {
+      "instances": [
+        {
+          "attributes": {
+            "id": "test-zone-id-15",
+            "value": "on",
+            "zone_id": "test-zone-id-15"
+          },
+          "schema_version": 0
+        }
+      ],
+      "mode": "managed",
+      "name": "with_interpolation",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_regional_tiered_cache"
+    },
+    {
+      "instances": [
+        {
+          "attributes": {
+            "id": "test-zone-id-16",
+            "value": "on",
+            "zone_id": "test-zone-id-16"
+          },
+          "schema_version": 0
+        }
+      ],
+      "mode": "managed",
+      "name": "with_lifecycle",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_regional_tiered_cache"
+    },
+    {
+      "instances": [
+        {
+          "attributes": {
+            "id": "test-zone-id-17",
+            "value": "off",
+            "zone_id": "test-zone-id-17"
+          },
+          "schema_version": 0
+        }
+      ],
+      "mode": "managed",
+      "name": "with_prevent_destroy",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_regional_tiered_cache"
+    },
+    {
+      "instances": [
+        {
+          "attributes": {
+            "id": "test-zone-id-18",
+            "value": "on",
+            "zone_id": "test-zone-id-18"
+          },
+          "schema_version": 0
+        }
+      ],
+      "mode": "managed",
+      "name": "from_local",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_regional_tiered_cache"
+    },
+    {
+      "instances": [
+        {
+          "attributes": {
+            "id": "test-zone-id-19",
+            "value": "on",
+            "zone_id": "test-zone-id-19"
+          },
+          "index_key": "zone1",
+          "schema_version": 0
+        },
+        {
+          "attributes": {
+            "id": "test-zone-id-20",
+            "value": "off",
+            "zone_id": "test-zone-id-20"
+          },
+          "index_key": "zone2",
+          "schema_version": 0
+        },
+        {
+          "attributes": {
+            "id": "test-zone-id-21",
+            "value": "off",
+            "zone_id": "test-zone-id-21"
+          },
+          "index_key": "zone3",
+          "schema_version": 0
+        }
+      ],
+      "mode": "managed",
+      "name": "mixed_pattern",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_regional_tiered_cache"
+    }
+  ],
+  "serial": 1,
+  "terraform_version": "1.5.0",
+  "version": 4
+}

--- a/integration/v4_to_v5/testdata/regional_tiered_cache/input/regional_tiered_cache.tf
+++ b/integration/v4_to_v5/testdata/regional_tiered_cache/input/regional_tiered_cache.tf
@@ -1,0 +1,161 @@
+# Terraform Provider v4 to v5 Migration Test
+# Resource: cloudflare_regional_tiered_cache
+# Test Coverage: All Terraform patterns for simple zone-level settings
+
+# ============================================================================
+# Standard Variables (Auto-provided by test infrastructure)
+# ============================================================================
+variable "cloudflare_account_id" {
+  description = "Cloudflare account ID"
+  type        = string
+}
+
+variable "cloudflare_zone_id" {
+  description = "Cloudflare zone ID"
+  type        = string
+}
+
+variable "cloudflare_domain" {
+  description = "Cloudflare domain for testing"
+  type        = string
+}
+
+# Locals for common values
+locals {
+  test_zones = {
+    zone1 = var.cloudflare_zone_id
+    zone2 = var.cloudflare_zone_id
+    zone3 = var.cloudflare_zone_id
+  }
+  name_prefix        = "cftftest"
+  enable_cache       = true
+  enable_experimental = false
+}
+
+# Pattern 1: Basic resource with value="on"
+resource "cloudflare_regional_tiered_cache" "basic_on" {
+  zone_id = var.cloudflare_zone_id
+  value   = "on"
+}
+
+# Pattern 2: Basic resource with value="off"
+resource "cloudflare_regional_tiered_cache" "basic_off" {
+  zone_id = var.cloudflare_zone_id
+  value   = "off"
+}
+
+# Pattern 3: for_each with map (3 instances)
+resource "cloudflare_regional_tiered_cache" "for_each_map" {
+  for_each = {
+    "enabled" = {
+      zone_id = var.cloudflare_zone_id
+      value   = "on"
+    }
+    "disabled" = {
+      zone_id = var.cloudflare_zone_id
+      value   = "off"
+    }
+    "testing" = {
+      zone_id = var.cloudflare_zone_id
+      value   = "on"
+    }
+  }
+
+  zone_id = each.value.zone_id
+  value   = each.value.value
+}
+
+# Pattern 4: for_each with set using toset() (4 instances)
+resource "cloudflare_regional_tiered_cache" "for_each_set" {
+  for_each = toset(["alpha", "beta", "gamma", "delta"])
+
+  zone_id = var.cloudflare_zone_id
+  value   = "on"
+}
+
+# Pattern 5: count-based resources (3 instances)
+resource "cloudflare_regional_tiered_cache" "counted" {
+  count = 3
+
+  zone_id = var.cloudflare_zone_id
+  value   = count.index == 0 ? "on" : "off"
+}
+
+# Pattern 6: Conditional creation - enabled (1 instance created)
+resource "cloudflare_regional_tiered_cache" "conditional_enabled" {
+  count = local.enable_cache ? 1 : 0
+
+  zone_id = var.cloudflare_zone_id
+  value   = "on"
+}
+
+# Pattern 7: Conditional creation - disabled (0 instances created)
+resource "cloudflare_regional_tiered_cache" "conditional_disabled" {
+  count = local.enable_experimental ? 1 : 0
+
+  zone_id = var.cloudflare_zone_id
+  value   = "off"
+}
+
+# Pattern 8: Using terraform functions
+resource "cloudflare_regional_tiered_cache" "with_functions" {
+  zone_id = var.cloudflare_zone_id
+  value   = join("", ["o", "n"]) # Results in "on"
+}
+
+# Pattern 9: String interpolation
+resource "cloudflare_regional_tiered_cache" "with_interpolation" {
+  zone_id = "${var.cloudflare_zone_id}"
+  value   = "on"
+}
+
+# Pattern 10: Lifecycle meta-arguments
+resource "cloudflare_regional_tiered_cache" "with_lifecycle" {
+  zone_id = var.cloudflare_zone_id
+  value   = "on"
+
+  lifecycle {
+    create_before_destroy = true
+    ignore_changes        = [value]
+  }
+}
+
+# Pattern 11: Prevent destroy lifecycle
+resource "cloudflare_regional_tiered_cache" "with_prevent_destroy" {
+  zone_id = var.cloudflare_zone_id
+  value   = "off"
+
+  lifecycle {
+    prevent_destroy = false # Set to false for testing
+  }
+}
+
+# Pattern 12: Using local reference
+resource "cloudflare_regional_tiered_cache" "from_local" {
+  zone_id = local.test_zones["zone1"]
+  value   = "on"
+}
+
+# Pattern 13: Mixed patterns - for_each with conditional value
+resource "cloudflare_regional_tiered_cache" "mixed_pattern" {
+  for_each = local.test_zones
+
+  zone_id = each.value
+  value   = each.key == "zone1" ? "on" : "off"
+}
+
+# Total resource instances in this test:
+# basic_on: 1
+# basic_off: 1
+# for_each_map: 3
+# for_each_set: 4
+# counted: 3
+# conditional_enabled: 1
+# conditional_disabled: 0
+# with_functions: 1
+# with_interpolation: 1
+# with_lifecycle: 1
+# with_prevent_destroy: 1
+# from_local: 1
+# mixed_pattern: 3
+# TOTAL: 21 instances

--- a/integration/v4_to_v5/testdata/regional_tiered_cache/input/regional_tiered_cache_e2e.tf
+++ b/integration/v4_to_v5/testdata/regional_tiered_cache/input/regional_tiered_cache_e2e.tf
@@ -1,0 +1,25 @@
+# E2E test for regional_tiered_cache migration
+# This is a simplified version for actual API testing (singleton resource)
+
+variable "cloudflare_account_id" {
+  description = "Cloudflare account ID"
+  type        = string
+}
+
+variable "cloudflare_zone_id" {
+  description = "Cloudflare zone ID"
+  type        = string
+}
+
+variable "cloudflare_domain" {
+  description = "Cloudflare domain for testing"
+  type        = string
+}
+
+# Test: Single instance (singleton resource - only one per zone)
+# Note: This is a SINGLETON resource - only ONE instance per zone
+# Note: Regional Tiered Cache requires Enterprise plan
+resource "cloudflare_regional_tiered_cache" "test" {
+  zone_id = var.cloudflare_zone_id
+  value   = "on"
+}

--- a/integration/v4_to_v5/testdata/regional_tiered_cache/input/terraform.tfstate
+++ b/integration/v4_to_v5/testdata/regional_tiered_cache/input/terraform.tfstate
@@ -1,0 +1,287 @@
+{
+  "version": 4,
+  "terraform_version": "1.5.0",
+  "serial": 1,
+  "lineage": "test-regional-tiered-cache-lineage",
+  "outputs": {},
+  "resources": [
+    {
+      "mode": "managed",
+      "type": "cloudflare_regional_tiered_cache",
+      "name": "basic_on",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "test-zone-id-1",
+            "zone_id": "test-zone-id-1",
+            "value": "on"
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_regional_tiered_cache",
+      "name": "basic_off",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "test-zone-id-2",
+            "zone_id": "test-zone-id-2",
+            "value": "off"
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_regional_tiered_cache",
+      "name": "for_each_map",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "index_key": "disabled",
+          "schema_version": 0,
+          "attributes": {
+            "id": "test-zone-id-3",
+            "zone_id": "test-zone-id-3",
+            "value": "off"
+          }
+        },
+        {
+          "index_key": "enabled",
+          "schema_version": 0,
+          "attributes": {
+            "id": "test-zone-id-4",
+            "zone_id": "test-zone-id-4",
+            "value": "on"
+          }
+        },
+        {
+          "index_key": "testing",
+          "schema_version": 0,
+          "attributes": {
+            "id": "test-zone-id-5",
+            "zone_id": "test-zone-id-5",
+            "value": "on"
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_regional_tiered_cache",
+      "name": "for_each_set",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "index_key": "alpha",
+          "schema_version": 0,
+          "attributes": {
+            "id": "test-zone-id-6",
+            "zone_id": "test-zone-id-6",
+            "value": "on"
+          }
+        },
+        {
+          "index_key": "beta",
+          "schema_version": 0,
+          "attributes": {
+            "id": "test-zone-id-7",
+            "zone_id": "test-zone-id-7",
+            "value": "on"
+          }
+        },
+        {
+          "index_key": "delta",
+          "schema_version": 0,
+          "attributes": {
+            "id": "test-zone-id-8",
+            "zone_id": "test-zone-id-8",
+            "value": "on"
+          }
+        },
+        {
+          "index_key": "gamma",
+          "schema_version": 0,
+          "attributes": {
+            "id": "test-zone-id-9",
+            "zone_id": "test-zone-id-9",
+            "value": "on"
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_regional_tiered_cache",
+      "name": "counted",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "index_key": 0,
+          "schema_version": 0,
+          "attributes": {
+            "id": "test-zone-id-10",
+            "zone_id": "test-zone-id-10",
+            "value": "on"
+          }
+        },
+        {
+          "index_key": 1,
+          "schema_version": 0,
+          "attributes": {
+            "id": "test-zone-id-11",
+            "zone_id": "test-zone-id-11",
+            "value": "off"
+          }
+        },
+        {
+          "index_key": 2,
+          "schema_version": 0,
+          "attributes": {
+            "id": "test-zone-id-12",
+            "zone_id": "test-zone-id-12",
+            "value": "off"
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_regional_tiered_cache",
+      "name": "conditional_enabled",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "index_key": 0,
+          "schema_version": 0,
+          "attributes": {
+            "id": "test-zone-id-13",
+            "zone_id": "test-zone-id-13",
+            "value": "on"
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_regional_tiered_cache",
+      "name": "with_functions",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "test-zone-id-14",
+            "zone_id": "test-zone-id-14",
+            "value": "on"
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_regional_tiered_cache",
+      "name": "with_interpolation",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "test-zone-id-15",
+            "zone_id": "test-zone-id-15",
+            "value": "on"
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_regional_tiered_cache",
+      "name": "with_lifecycle",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "test-zone-id-16",
+            "zone_id": "test-zone-id-16",
+            "value": "on"
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_regional_tiered_cache",
+      "name": "with_prevent_destroy",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "test-zone-id-17",
+            "zone_id": "test-zone-id-17",
+            "value": "off"
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_regional_tiered_cache",
+      "name": "from_local",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "test-zone-id-18",
+            "zone_id": "test-zone-id-18",
+            "value": "on"
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_regional_tiered_cache",
+      "name": "mixed_pattern",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "index_key": "zone1",
+          "schema_version": 0,
+          "attributes": {
+            "id": "test-zone-id-19",
+            "zone_id": "test-zone-id-19",
+            "value": "on"
+          }
+        },
+        {
+          "index_key": "zone2",
+          "schema_version": 0,
+          "attributes": {
+            "id": "test-zone-id-20",
+            "zone_id": "test-zone-id-20",
+            "value": "off"
+          }
+        },
+        {
+          "index_key": "zone3",
+          "schema_version": 0,
+          "attributes": {
+            "id": "test-zone-id-21",
+            "zone_id": "test-zone-id-21",
+            "value": "off"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cloudflare/tf-migrate/internal/resources/queue"
 	"github.com/cloudflare/tf-migrate/internal/resources/r2_bucket"
 	"github.com/cloudflare/tf-migrate/internal/resources/regional_hostname"
+	"github.com/cloudflare/tf-migrate/internal/resources/regional_tiered_cache"
 	"github.com/cloudflare/tf-migrate/internal/resources/ruleset"
 	"github.com/cloudflare/tf-migrate/internal/resources/snippet"
 	"github.com/cloudflare/tf-migrate/internal/resources/spectrum_application"
@@ -99,6 +100,7 @@ func RegisterAllMigrations() {
 	queue.NewV4ToV5Migrator()
 	r2_bucket.NewV4ToV5Migrator()
 	regional_hostname.NewV4ToV5Migrator()
+	regional_tiered_cache.NewV4ToV5Migrator()
 	ruleset.NewV4ToV5Migrator()
 	snippet.NewV4ToV5Migrator()
 	tiered_cache.NewV4ToV5Migrator()

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cloudflare/tf-migrate/internal/resources/queue"
 	"github.com/cloudflare/tf-migrate/internal/resources/r2_bucket"
 	"github.com/cloudflare/tf-migrate/internal/resources/regional_hostname"
+	"github.com/cloudflare/tf-migrate/internal/resources/regional_tiered_cache"
 	"github.com/cloudflare/tf-migrate/internal/resources/ruleset"
 	"github.com/cloudflare/tf-migrate/internal/resources/snippet"
 	"github.com/cloudflare/tf-migrate/internal/resources/spectrum_application"
@@ -96,6 +97,7 @@ func RegisterAllMigrations() {
 	queue.NewV4ToV5Migrator()
 	r2_bucket.NewV4ToV5Migrator()
 	regional_hostname.NewV4ToV5Migrator()
+	regional_tiered_cache.NewV4ToV5Migrator()
 	ruleset.NewV4ToV5Migrator()
 	snippet.NewV4ToV5Migrator()
 	tiered_cache.NewV4ToV5Migrator()

--- a/internal/resources/regional_tiered_cache/v4_to_v5.go
+++ b/internal/resources/regional_tiered_cache/v4_to_v5.go
@@ -1,0 +1,79 @@
+package regional_tiered_cache
+
+import (
+	"github.com/hashicorp/hcl/v2/hclwrite"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+
+	"github.com/cloudflare/tf-migrate/internal"
+	"github.com/cloudflare/tf-migrate/internal/transform"
+	"github.com/cloudflare/tf-migrate/internal/transform/state"
+)
+
+// V4ToV5Migrator handles the migration of cloudflare_regional_tiered_cache from v4 to v5.
+type V4ToV5Migrator struct{}
+
+// NewV4ToV5Migrator creates a new migrator for cloudflare_regional_tiered_cache v4 to v5.
+func NewV4ToV5Migrator() transform.ResourceTransformer {
+	migrator := &V4ToV5Migrator{}
+	// Register with v4 resource name (same as v5 name in this case)
+	internal.RegisterMigrator("cloudflare_regional_tiered_cache", "v4", "v5", migrator)
+	return migrator
+}
+
+// GetResourceType returns the v5 resource type this migrator handles.
+func (m *V4ToV5Migrator) GetResourceType() string {
+	// Resource name doesn't change
+	return "cloudflare_regional_tiered_cache"
+}
+
+// CanHandle determines if this migrator can handle the given resource type.
+func (m *V4ToV5Migrator) CanHandle(resourceType string) bool {
+	return resourceType == "cloudflare_regional_tiered_cache"
+}
+
+// Preprocess handles string-level transformations before HCL parsing.
+// Not needed for regional_tiered_cache - config is pass-through.
+func (m *V4ToV5Migrator) Preprocess(content string) string {
+	return content
+}
+
+// GetResourceRename implements the ResourceRenamer interface.
+// cloudflare_regional_tiered_cache doesn't rename, so return the same name.
+func (m *V4ToV5Migrator) GetResourceRename() (string, string) {
+	return "cloudflare_regional_tiered_cache", "cloudflare_regional_tiered_cache"
+}
+
+// TransformConfig handles configuration file transformations.
+// For regional_tiered_cache, config is pass-through - no transformations needed.
+func (m *V4ToV5Migrator) TransformConfig(ctx *transform.Context, block *hclwrite.Block) (*transform.TransformResult, error) {
+	// NO transformations needed!
+	// Resource name stays the same, all fields stay the same.
+	return &transform.TransformResult{
+		Blocks:         []*hclwrite.Block{block},
+		RemoveOriginal: false,
+	}, nil
+}
+
+// TransformState handles state file transformations.
+func (m *V4ToV5Migrator) TransformState(ctx *transform.Context, instance gjson.Result, resourcePath, resourceName string) (string, error) {
+	result := instance.String()
+	attrs := instance.Get("attributes")
+
+	// Defensive: if no attributes, just set schema_version and return
+	if !attrs.Exists() {
+		result, _ = sjson.Set(result, "schema_version", 0)
+		return result, nil
+	}
+
+	// Defensive: ensure value exists with default "off"
+	// This is unlikely since v4 requires value, but be defensive
+	if !attrs.Get("value").Exists() {
+		result = state.EnsureField(result, "attributes", attrs, "value", "off")
+	}
+
+	// Set schema version to 0 (MANDATORY for all v5 resources)
+	result, _ = sjson.Set(result, "schema_version", 0)
+
+	return result, nil
+}

--- a/internal/resources/regional_tiered_cache/v4_to_v5_test.go
+++ b/internal/resources/regional_tiered_cache/v4_to_v5_test.go
@@ -1,0 +1,144 @@
+package regional_tiered_cache
+
+import (
+	"testing"
+
+	"github.com/cloudflare/tf-migrate/internal/testhelpers"
+)
+
+func TestV4ToV5Transformation(t *testing.T) {
+	migrator := NewV4ToV5Migrator()
+
+	t.Run("ConfigTransformation", func(t *testing.T) {
+		tests := []testhelpers.ConfigTestCase{
+			{
+				Name: "basic resource with value on",
+				Input: `
+resource "cloudflare_regional_tiered_cache" "example" {
+  zone_id = "0da42c8d2132a9ddaf714f9e7c920711"
+  value   = "on"
+}`,
+				Expected: `
+resource "cloudflare_regional_tiered_cache" "example" {
+  zone_id = "0da42c8d2132a9ddaf714f9e7c920711"
+  value   = "on"
+}`,
+			},
+			{
+				Name: "basic resource with value off",
+				Input: `
+resource "cloudflare_regional_tiered_cache" "example" {
+  zone_id = "test-zone-id"
+  value   = "off"
+}`,
+				Expected: `
+resource "cloudflare_regional_tiered_cache" "example" {
+  zone_id = "test-zone-id"
+  value   = "off"
+}`,
+			},
+			{
+				Name: "multiple resources",
+				Input: `
+resource "cloudflare_regional_tiered_cache" "first" {
+  zone_id = "zone1"
+  value   = "on"
+}
+
+resource "cloudflare_regional_tiered_cache" "second" {
+  zone_id = "zone2"
+  value   = "off"
+}`,
+				Expected: `
+resource "cloudflare_regional_tiered_cache" "first" {
+  zone_id = "zone1"
+  value   = "on"
+}
+
+resource "cloudflare_regional_tiered_cache" "second" {
+  zone_id = "zone2"
+  value   = "off"
+}`,
+			},
+			{
+				Name: "with variable reference",
+				Input: `
+resource "cloudflare_regional_tiered_cache" "example" {
+  zone_id = var.cloudflare_zone_id
+  value   = var.cache_value
+}`,
+				Expected: `
+resource "cloudflare_regional_tiered_cache" "example" {
+  zone_id = var.cloudflare_zone_id
+  value   = var.cache_value
+}`,
+			},
+		}
+
+		testhelpers.RunConfigTransformTests(t, tests, migrator)
+	})
+
+	t.Run("StateTransformation", func(t *testing.T) {
+		tests := []testhelpers.StateTestCase{
+			{
+				Name: "value on",
+				Input: `{
+  "attributes": {
+    "zone_id": "0da42c8d2132a9ddaf714f9e7c920711",
+    "value": "on"
+  }
+}`,
+				Expected: `{
+  "attributes": {
+    "zone_id": "0da42c8d2132a9ddaf714f9e7c920711",
+    "value": "on"
+  },
+  "schema_version": 0
+}`,
+			},
+			{
+				Name: "value off",
+				Input: `{
+  "attributes": {
+    "zone_id": "test-zone",
+    "value": "off"
+  }
+}`,
+				Expected: `{
+  "attributes": {
+    "zone_id": "test-zone",
+    "value": "off"
+  },
+  "schema_version": 0
+}`,
+			},
+			{
+				Name: "missing value adds default",
+				Input: `{
+  "attributes": {
+    "zone_id": "test-zone"
+  }
+}`,
+				Expected: `{
+  "attributes": {
+    "zone_id": "test-zone",
+    "value": "off"
+  },
+  "schema_version": 0
+}`,
+			},
+			{
+				Name: "missing attributes object",
+				Input: `{
+  "type": "cloudflare_regional_tiered_cache"
+}`,
+				Expected: `{
+  "type": "cloudflare_regional_tiered_cache",
+  "schema_version": 0
+}`,
+			},
+		}
+
+		testhelpers.RunStateTransformTests(t, tests, migrator)
+	})
+}


### PR DESCRIPTION
Add regional_tiered_cache v4→v5 migration with comprehensive tests

  - Implement pass-through config transformation (no changes needed)
  - Add minimal state transformation
  - Create 8 unit tests (4 config + 4 state, 100% coverage)
  - Add 21 integration test instances covering all 9 mandatory patterns
  - Create 3 provider migration tests
  - Complete migration retrospective with lessons learned

  All tests passing.

/assign_reviewer @cloudflare/sdks 