### PR TITLE
tf-migrate updates for missing provider tests

### DIFF
--- a/integration/v4_to_v5/testdata/zero_trust_gateway_certificate/expected/terraform.tfstate
+++ b/integration/v4_to_v5/testdata/zero_trust_gateway_certificate/expected/terraform.tfstate
@@ -59,7 +59,6 @@
           "attributes": {
             "id": "cert-uuid-003",
             "account_id": "f037e56e89293a057740de681ac9abbe",
-            "validity_period_days": 1826.0,
             "activate": false,
             "in_use": false,
             "binding_status": "inactive"

--- a/internal/resources/zero_trust_gateway_certificate/v4_to_v5.go
+++ b/internal/resources/zero_trust_gateway_certificate/v4_to_v5.go
@@ -48,19 +48,19 @@ func (m *V4ToV5Migrator) TransformState(ctx *transform.Context, stateJSON gjson.
 	result := stateJSON.String()
 
 	if stateJSON.Get("resources").Exists() {
-		return m.transformFullState(result, stateJSON)
+		return m.transformFullState(ctx, result, stateJSON)
 	}
 
 	if !stateJSON.Exists() || !stateJSON.Get("attributes").Exists() {
 		return result, nil
 	}
 
-	result = m.transformSingleInstance(result, stateJSON)
+	result = m.transformSingleInstance(ctx, result, stateJSON, resourceName)
 
 	return result, nil
 }
 
-func (m *V4ToV5Migrator) transformFullState(result string, stateJSON gjson.Result) (string, error) {
+func (m *V4ToV5Migrator) transformFullState(ctx *transform.Context, result string, stateJSON gjson.Result) (string, error) {
 	resources := stateJSON.Get("resources")
 	if !resources.Exists() {
 		return result, nil
@@ -73,6 +73,7 @@ func (m *V4ToV5Migrator) transformFullState(result string, stateJSON gjson.Resul
 			return true
 		}
 
+		resourceName := resource.Get("name").String()
 		instances := resource.Get("instances")
 		instances.ForEach(func(instKey, instance gjson.Result) bool {
 			instPath := "resources." + key.String() + ".instances." + instKey.String()
@@ -80,7 +81,7 @@ func (m *V4ToV5Migrator) transformFullState(result string, stateJSON gjson.Resul
 			attrs := instance.Get("attributes")
 			if attrs.Exists() {
 				instJSON := instance.String()
-				transformedInst := m.transformSingleInstance(instJSON, instance)
+				transformedInst := m.transformSingleInstance(ctx, instJSON, instance, resourceName)
 				transformedInstParsed := gjson.Parse(transformedInst)
 				result, _ = sjson.SetRaw(result, instPath, transformedInstParsed.Raw)
 			}
@@ -93,17 +94,42 @@ func (m *V4ToV5Migrator) transformFullState(result string, stateJSON gjson.Resul
 	return result, nil
 }
 
-func (m *V4ToV5Migrator) transformSingleInstance(result string, instance gjson.Result) string {
+func (m *V4ToV5Migrator) transformSingleInstance(ctx *transform.Context, result string, instance gjson.Result, resourceName string) string {
 	attrs := instance.Get("attributes")
 
 	// Remove v4-only fields that don't exist in v5 or changed behavior:
-	// Note: We keep 'id' in state as it's still used for resource identification
 	result = state.RemoveFields(result, "attributes", attrs, "custom", "gateway_managed", "qs_pack_id")
 
-	// Convert validity_period_days from TypeInt to Int64Attribute (int → float64)
+	// Handle validity_period_days:
+	// - If it was explicitly set in v4 config: keep it in state (convert to Int64)
+	// - If it was just the v4 default: remove it from state
 	validityPeriodDays := instance.Get("attributes.validity_period_days")
 	if validityPeriodDays.Exists() {
-		result, _ = sjson.Set(result, "attributes.validity_period_days", state.ConvertToFloat64(validityPeriodDays))
+		wasExplicitlySet := false
+		if ctx.CFGFiles != nil {
+			for _, cfgFile := range ctx.CFGFiles {
+				body := cfgFile.Body()
+				for _, block := range body.Blocks() {
+					if block.Type() == "resource" && len(block.Labels()) >= 2 {
+						if block.Labels()[0] == "cloudflare_zero_trust_gateway_certificate" && block.Labels()[1] == resourceName {
+							if tfhcl.HasAttribute(block.Body(), "validity_period_days") {
+								wasExplicitlySet = true
+								break
+							}
+						}
+					}
+				}
+				if wasExplicitlySet {
+					break
+				}
+			}
+		}
+
+		if wasExplicitlySet {
+			result, _ = sjson.Set(result, "attributes.validity_period_days", state.ConvertToFloat64(validityPeriodDays))
+		} else {
+			result = state.RemoveFields(result, "attributes", attrs, "validity_period_days")
+		}
 	}
 
 	return result


### PR DESCRIPTION
This PR encapsulates any migration updates needed for issues found while adding missing provider tests in this PR: 
https://github.com/cloudflare/terraform-provider-cloudflare/pull/6653

Resources that required updates: 
 - zero_trust_gateway_certificate
   - Fixed an issue where V4 was setting a default for validity_period_days which was then triggering a replace. The migration now transforms that V4 default to null in state if it was not set in config. 