### PR TITLE
refactor(hcl): extract array sorting into common helper function

### DIFF
--- a/integration/v4_to_v5/testdata/turnstile_widget/input/terraform.tfstate
+++ b/integration/v4_to_v5/testdata/turnstile_widget/input/terraform.tfstate
@@ -1,461 +1,471 @@
 {
-  "version": 4,
-  "terraform_version": "1.5.0",
-  "serial": 1,
   "lineage": "test-turnstile-widget-lineage",
   "outputs": {},
   "resources": [
     {
-      "mode": "managed",
-      "type": "cloudflare_turnstile_widget",
-      "name": "minimal",
-      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
       "instances": [
         {
-          "schema_version": 1,
           "attributes": {
-            "id": "widget-id-001",
             "account_id": "f037e56e89293a057740de681ac9abbe",
-            "name": "cftftest-minimal",
             "domains": [
               "minimal.cf-tf-test.com"
             ],
+            "id": "widget-id-001",
             "mode": "managed",
-            "secret": "secret-key-001"
-          }
+            "name": "cftftest-minimal",
+            "secret": "secret-key-001",
+            "sitekey": "widget-id-001"
+          },
+          "schema_version": 0
         }
-      ]
+      ],
+      "mode": "managed",
+      "name": "minimal",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_turnstile_widget"
     },
     {
+      "instances": [
+        {
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "bot_fight_mode": true,
+            "domains": [
+              "max2.cf-tf-test.com",
+              "maximal.cf-tf-test.com"
+            ],
+            "id": "widget-id-002",
+            "mode": "invisible",
+            "name": "cftftest-maximal",
+            "offlabel": true,
+            "region": "world",
+            "secret": "secret-key-002",
+            "sitekey": "widget-id-002"
+          },
+          "schema_version": 0
+        }
+      ],
       "mode": "managed",
-      "type": "cloudflare_turnstile_widget",
       "name": "maximal",
       "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
-      "instances": [
-        {
-          "schema_version": 1,
-          "attributes": {
-            "id": "widget-id-002",
-            "account_id": "f037e56e89293a057740de681ac9abbe",
-            "name": "cftftest-maximal",
-            "domains": [
-              "maximal.cf-tf-test.com",
-              "max2.cf-tf-test.com"
-            ],
-            "mode": "invisible",
-            "secret": "secret-key-002",
-            "region": "world",
-            "bot_fight_mode": true,
-            "offlabel": true
-          }
-        }
-      ]
+      "type": "cloudflare_turnstile_widget"
     },
     {
-      "mode": "managed",
-      "type": "cloudflare_turnstile_widget",
-      "name": "with_defaults",
-      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
       "instances": [
         {
-          "schema_version": 1,
           "attributes": {
-            "id": "widget-id-003",
             "account_id": "f037e56e89293a057740de681ac9abbe",
-            "name": "cftftest-defaults",
+            "bot_fight_mode": false,
             "domains": [
               "defaults.cf-tf-test.com"
             ],
+            "id": "widget-id-003",
             "mode": "non-interactive",
-            "secret": "secret-key-003",
+            "name": "cftftest-defaults",
+            "offlabel": false,
             "region": "world",
-            "bot_fight_mode": false,
-            "offlabel": false
-          }
+            "secret": "secret-key-003",
+            "sitekey": "widget-id-003"
+          },
+          "schema_version": 0
         }
-      ]
+      ],
+      "mode": "managed",
+      "name": "with_defaults",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_turnstile_widget"
     },
     {
-      "mode": "managed",
-      "type": "cloudflare_turnstile_widget",
-      "name": "foreach_map",
-      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
       "instances": [
         {
-          "schema_version": 1,
-          "index_key": "dev",
           "attributes": {
-            "id": "widget-id-004",
             "account_id": "f037e56e89293a057740de681ac9abbe",
-            "name": "cftftest-map-dev",
             "domains": [
               "dev.cf-tf-test.com"
             ],
+            "id": "widget-id-004",
             "mode": "non-interactive",
-            "secret": "secret-key-004"
-          }
+            "name": "cftftest-map-dev",
+            "secret": "secret-key-004",
+            "sitekey": "widget-id-004"
+          },
+          "index_key": "dev",
+          "schema_version": 0
         }
-      ]
-    },
-    {
+      ],
       "mode": "managed",
-      "type": "cloudflare_turnstile_widget",
       "name": "foreach_map",
       "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_turnstile_widget"
+    },
+    {
       "instances": [
         {
-          "schema_version": 1,
-          "index_key": "prod",
           "attributes": {
-            "id": "widget-id-005",
             "account_id": "f037e56e89293a057740de681ac9abbe",
-            "name": "cftftest-map-prod",
             "domains": [
               "prod.cf-tf-test.com"
             ],
+            "id": "widget-id-005",
             "mode": "managed",
-            "secret": "secret-key-005"
-          }
+            "name": "cftftest-map-prod",
+            "secret": "secret-key-005",
+            "sitekey": "widget-id-005"
+          },
+          "index_key": "prod",
+          "schema_version": 0
         }
-      ]
-    },
-    {
+      ],
       "mode": "managed",
-      "type": "cloudflare_turnstile_widget",
       "name": "foreach_map",
       "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_turnstile_widget"
+    },
+    {
       "instances": [
         {
-          "schema_version": 1,
-          "index_key": "staging",
           "attributes": {
-            "id": "widget-id-006",
             "account_id": "f037e56e89293a057740de681ac9abbe",
-            "name": "cftftest-map-staging",
             "domains": [
               "staging.cf-tf-test.com"
             ],
+            "id": "widget-id-006",
             "mode": "invisible",
-            "secret": "secret-key-006"
-          }
+            "name": "cftftest-map-staging",
+            "secret": "secret-key-006",
+            "sitekey": "widget-id-006"
+          },
+          "index_key": "staging",
+          "schema_version": 0
         }
-      ]
+      ],
+      "mode": "managed",
+      "name": "foreach_map",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_turnstile_widget"
     },
     {
-      "mode": "managed",
-      "type": "cloudflare_turnstile_widget",
-      "name": "foreach_set",
-      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
       "instances": [
         {
-          "schema_version": 1,
-          "index_key": "alpha",
           "attributes": {
-            "id": "widget-id-007",
             "account_id": "f037e56e89293a057740de681ac9abbe",
-            "name": "cftftest-set-alpha",
             "domains": [
               "alpha.cf-tf-test.com"
             ],
+            "id": "widget-id-007",
             "mode": "managed",
-            "secret": "secret-key-007"
-          }
+            "name": "cftftest-set-alpha",
+            "secret": "secret-key-007",
+            "sitekey": "widget-id-007"
+          },
+          "index_key": "alpha",
+          "schema_version": 0
         }
-      ]
-    },
-    {
+      ],
       "mode": "managed",
-      "type": "cloudflare_turnstile_widget",
       "name": "foreach_set",
       "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_turnstile_widget"
+    },
+    {
       "instances": [
         {
-          "schema_version": 1,
-          "index_key": "beta",
           "attributes": {
-            "id": "widget-id-008",
             "account_id": "f037e56e89293a057740de681ac9abbe",
-            "name": "cftftest-set-beta",
             "domains": [
               "beta.cf-tf-test.com"
             ],
+            "id": "widget-id-008",
             "mode": "managed",
-            "secret": "secret-key-008"
-          }
+            "name": "cftftest-set-beta",
+            "secret": "secret-key-008",
+            "sitekey": "widget-id-008"
+          },
+          "index_key": "beta",
+          "schema_version": 0
         }
-      ]
-    },
-    {
+      ],
       "mode": "managed",
-      "type": "cloudflare_turnstile_widget",
       "name": "foreach_set",
       "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_turnstile_widget"
+    },
+    {
       "instances": [
         {
-          "schema_version": 1,
-          "index_key": "delta",
           "attributes": {
-            "id": "widget-id-009",
             "account_id": "f037e56e89293a057740de681ac9abbe",
-            "name": "cftftest-set-delta",
             "domains": [
               "delta.cf-tf-test.com"
             ],
+            "id": "widget-id-009",
             "mode": "managed",
-            "secret": "secret-key-009"
-          }
+            "name": "cftftest-set-delta",
+            "secret": "secret-key-009",
+            "sitekey": "widget-id-009"
+          },
+          "index_key": "delta",
+          "schema_version": 0
         }
-      ]
-    },
-    {
+      ],
       "mode": "managed",
-      "type": "cloudflare_turnstile_widget",
       "name": "foreach_set",
       "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_turnstile_widget"
+    },
+    {
       "instances": [
         {
-          "schema_version": 1,
-          "index_key": "gamma",
           "attributes": {
-            "id": "widget-id-010",
             "account_id": "f037e56e89293a057740de681ac9abbe",
-            "name": "cftftest-set-gamma",
             "domains": [
               "gamma.cf-tf-test.com"
             ],
+            "id": "widget-id-010",
             "mode": "managed",
-            "secret": "secret-key-010"
-          }
+            "name": "cftftest-set-gamma",
+            "secret": "secret-key-010",
+            "sitekey": "widget-id-010"
+          },
+          "index_key": "gamma",
+          "schema_version": 0
         }
-      ]
+      ],
+      "mode": "managed",
+      "name": "foreach_set",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_turnstile_widget"
     },
     {
-      "mode": "managed",
-      "type": "cloudflare_turnstile_widget",
-      "name": "counted",
-      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
       "instances": [
         {
-          "schema_version": 1,
-          "index_key": 0,
           "attributes": {
-            "id": "widget-id-011",
             "account_id": "f037e56e89293a057740de681ac9abbe",
-            "name": "cftftest-count-0",
             "domains": [
               "count0.cf-tf-test.com"
             ],
+            "id": "widget-id-011",
             "mode": "managed",
-            "secret": "secret-key-011"
-          }
+            "name": "cftftest-count-0",
+            "secret": "secret-key-011",
+            "sitekey": "widget-id-011"
+          },
+          "index_key": 0,
+          "schema_version": 0
         }
-      ]
-    },
-    {
+      ],
       "mode": "managed",
-      "type": "cloudflare_turnstile_widget",
       "name": "counted",
       "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_turnstile_widget"
+    },
+    {
       "instances": [
         {
-          "schema_version": 1,
-          "index_key": 1,
           "attributes": {
-            "id": "widget-id-012",
             "account_id": "f037e56e89293a057740de681ac9abbe",
-            "name": "cftftest-count-1",
             "domains": [
               "count1.cf-tf-test.com"
             ],
+            "id": "widget-id-012",
             "mode": "invisible",
-            "secret": "secret-key-012"
-          }
+            "name": "cftftest-count-1",
+            "secret": "secret-key-012",
+            "sitekey": "widget-id-012"
+          },
+          "index_key": 1,
+          "schema_version": 0
         }
-      ]
-    },
-    {
+      ],
       "mode": "managed",
-      "type": "cloudflare_turnstile_widget",
       "name": "counted",
       "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_turnstile_widget"
+    },
+    {
       "instances": [
         {
-          "schema_version": 1,
-          "index_key": 2,
           "attributes": {
-            "id": "widget-id-013",
             "account_id": "f037e56e89293a057740de681ac9abbe",
-            "name": "cftftest-count-2",
             "domains": [
               "count2.cf-tf-test.com"
             ],
+            "id": "widget-id-013",
             "mode": "non-interactive",
-            "secret": "secret-key-013"
-          }
+            "name": "cftftest-count-2",
+            "secret": "secret-key-013",
+            "sitekey": "widget-id-013"
+          },
+          "index_key": 2,
+          "schema_version": 0
         }
-      ]
+      ],
+      "mode": "managed",
+      "name": "counted",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_turnstile_widget"
     },
     {
-      "mode": "managed",
-      "type": "cloudflare_turnstile_widget",
-      "name": "conditional_enabled",
-      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
       "instances": [
         {
-          "schema_version": 1,
-          "index_key": 0,
           "attributes": {
-            "id": "widget-id-014",
             "account_id": "f037e56e89293a057740de681ac9abbe",
-            "name": "cftftest-conditional-enabled",
             "domains": [
               "enabled.cf-tf-test.com"
             ],
+            "id": "widget-id-014",
             "mode": "managed",
-            "secret": "secret-key-014"
-          }
+            "name": "cftftest-conditional-enabled",
+            "secret": "secret-key-014",
+            "sitekey": "widget-id-014"
+          },
+          "index_key": 0,
+          "schema_version": 0
         }
-      ]
+      ],
+      "mode": "managed",
+      "name": "conditional_enabled",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_turnstile_widget"
     },
     {
-      "mode": "managed",
-      "type": "cloudflare_turnstile_widget",
-      "name": "with_join",
-      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
       "instances": [
         {
-          "schema_version": 1,
           "attributes": {
-            "id": "widget-id-016",
             "account_id": "f037e56e89293a057740de681ac9abbe",
-            "name": "cftftest-join-test",
             "domains": [
               "join.cf-tf-test.com"
             ],
+            "id": "widget-id-016",
             "mode": "managed",
-            "secret": "secret-key-016"
-          }
+            "name": "cftftest-join-test",
+            "secret": "secret-key-016",
+            "sitekey": "widget-id-016"
+          },
+          "schema_version": 0
         }
-      ]
+      ],
+      "mode": "managed",
+      "name": "with_join",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_turnstile_widget"
     },
     {
-      "mode": "managed",
-      "type": "cloudflare_turnstile_widget",
-      "name": "with_interpolation",
-      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
       "instances": [
         {
-          "schema_version": 1,
           "attributes": {
-            "id": "widget-id-017",
             "account_id": "f037e56e89293a057740de681ac9abbe",
-            "name": "cftftest-interp",
             "domains": [
               "interp.cf-tf-test.com"
             ],
+            "id": "widget-id-017",
             "mode": "invisible",
-            "secret": "secret-key-017"
-          }
+            "name": "cftftest-interp",
+            "secret": "secret-key-017",
+            "sitekey": "widget-id-017"
+          },
+          "schema_version": 0
         }
-      ]
+      ],
+      "mode": "managed",
+      "name": "with_interpolation",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_turnstile_widget"
     },
     {
-      "mode": "managed",
-      "type": "cloudflare_turnstile_widget",
-      "name": "with_lifecycle_cbd",
-      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
       "instances": [
         {
-          "schema_version": 1,
           "attributes": {
-            "id": "widget-id-018",
             "account_id": "f037e56e89293a057740de681ac9abbe",
-            "name": "cftftest-lifecycle-cbd",
             "domains": [
               "lifecycle-cbd.cf-tf-test.com"
             ],
+            "id": "widget-id-018",
             "mode": "managed",
-            "secret": "secret-key-018"
-          }
+            "name": "cftftest-lifecycle-cbd",
+            "secret": "secret-key-018",
+            "sitekey": "widget-id-018"
+          },
+          "schema_version": 0
         }
-      ]
+      ],
+      "mode": "managed",
+      "name": "with_lifecycle_cbd",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_turnstile_widget"
     },
     {
-      "mode": "managed",
-      "type": "cloudflare_turnstile_widget",
-      "name": "with_lifecycle_ignore",
-      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
       "instances": [
         {
-          "schema_version": 1,
           "attributes": {
-            "id": "widget-id-019",
             "account_id": "f037e56e89293a057740de681ac9abbe",
-            "name": "cftftest-lifecycle-ignore",
             "domains": [
               "lifecycle-ignore.cf-tf-test.com"
             ],
+            "id": "widget-id-019",
             "mode": "invisible",
-            "secret": "secret-key-019"
-          }
+            "name": "cftftest-lifecycle-ignore",
+            "secret": "secret-key-019",
+            "sitekey": "widget-id-019"
+          },
+          "schema_version": 0
         }
-      ]
+      ],
+      "mode": "managed",
+      "name": "with_lifecycle_ignore",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_turnstile_widget"
     },
     {
-      "mode": "managed",
-      "type": "cloudflare_turnstile_widget",
-      "name": "with_lifecycle_prevent",
-      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
       "instances": [
         {
-          "schema_version": 1,
           "attributes": {
-            "id": "widget-id-020",
             "account_id": "f037e56e89293a057740de681ac9abbe",
-            "name": "cftftest-lifecycle-prevent",
             "domains": [
               "lifecycle-prevent.cf-tf-test.com"
             ],
+            "id": "widget-id-020",
             "mode": "non-interactive",
-            "secret": "secret-key-020"
-          }
+            "name": "cftftest-lifecycle-prevent",
+            "secret": "secret-key-020",
+            "sitekey": "widget-id-020"
+          },
+          "schema_version": 0
         }
-      ]
+      ],
+      "mode": "managed",
+      "name": "with_lifecycle_prevent",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_turnstile_widget"
     },
     {
-      "mode": "managed",
-      "type": "cloudflare_turnstile_widget",
-      "name": "multi_domain_2",
-      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
       "instances": [
         {
-          "schema_version": 1,
           "attributes": {
-            "id": "widget-id-021",
             "account_id": "f037e56e89293a057740de681ac9abbe",
-            "name": "cftftest-multi-2",
             "domains": [
               "multi1.cf-tf-test.com",
               "multi2.cf-tf-test.com"
             ],
+            "id": "widget-id-021",
             "mode": "managed",
-            "secret": "secret-key-021"
-          }
+            "name": "cftftest-multi-2",
+            "secret": "secret-key-021",
+            "sitekey": "widget-id-021"
+          },
+          "schema_version": 0
         }
-      ]
+      ],
+      "mode": "managed",
+      "name": "multi_domain_2",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_turnstile_widget"
     },
     {
-      "mode": "managed",
-      "type": "cloudflare_turnstile_widget",
-      "name": "multi_domain_5",
-      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
       "instances": [
         {
-          "schema_version": 1,
           "attributes": {
-            "id": "widget-id-022",
             "account_id": "f037e56e89293a057740de681ac9abbe",
-            "name": "cftftest-multi-5",
             "domains": [
               "md1.cf-tf-test.com",
               "md2.cf-tf-test.com",
@@ -463,95 +473,110 @@
               "md4.cf-tf-test.com",
               "md5.cf-tf-test.com"
             ],
+            "id": "widget-id-022",
             "mode": "invisible",
-            "secret": "secret-key-022"
-          }
+            "name": "cftftest-multi-5",
+            "secret": "secret-key-022",
+            "sitekey": "widget-id-022"
+          },
+          "schema_version": 0
         }
-      ]
+      ],
+      "mode": "managed",
+      "name": "multi_domain_5",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_turnstile_widget"
     },
     {
-      "mode": "managed",
-      "type": "cloudflare_turnstile_widget",
-      "name": "with_var_domains",
-      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
       "instances": [
         {
-          "schema_version": 1,
           "attributes": {
-            "id": "widget-id-023",
             "account_id": "f037e56e89293a057740de681ac9abbe",
-            "name": "cftftest-var-domains",
             "domains": [
               "prod.cf-tf-test.com"
             ],
+            "id": "widget-id-023",
             "mode": "managed",
-            "secret": "secret-key-023"
-          }
+            "name": "cftftest-var-domains",
+            "secret": "secret-key-023",
+            "sitekey": "widget-id-023"
+          },
+          "schema_version": 0
         }
-      ]
+      ],
+      "mode": "managed",
+      "name": "with_var_domains",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_turnstile_widget"
     },
     {
-      "mode": "managed",
-      "type": "cloudflare_turnstile_widget",
-      "name": "mode_managed",
-      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
       "instances": [
         {
-          "schema_version": 1,
           "attributes": {
-            "id": "widget-id-024",
             "account_id": "f037e56e89293a057740de681ac9abbe",
-            "name": "cftftest-mode-managed",
             "domains": [
               "managed.cf-tf-test.com"
             ],
+            "id": "widget-id-024",
             "mode": "managed",
-            "secret": "secret-key-024"
-          }
+            "name": "cftftest-mode-managed",
+            "secret": "secret-key-024",
+            "sitekey": "widget-id-024"
+          },
+          "schema_version": 0
         }
-      ]
+      ],
+      "mode": "managed",
+      "name": "mode_managed",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_turnstile_widget"
     },
     {
-      "mode": "managed",
-      "type": "cloudflare_turnstile_widget",
-      "name": "mode_invisible",
-      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
       "instances": [
         {
-          "schema_version": 1,
           "attributes": {
-            "id": "widget-id-025",
             "account_id": "f037e56e89293a057740de681ac9abbe",
-            "name": "cftftest-mode-invisible",
             "domains": [
               "invisible.cf-tf-test.com"
             ],
+            "id": "widget-id-025",
             "mode": "invisible",
-            "secret": "secret-key-025"
-          }
+            "name": "cftftest-mode-invisible",
+            "secret": "secret-key-025",
+            "sitekey": "widget-id-025"
+          },
+          "schema_version": 0
         }
-      ]
+      ],
+      "mode": "managed",
+      "name": "mode_invisible",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_turnstile_widget"
     },
     {
-      "mode": "managed",
-      "type": "cloudflare_turnstile_widget",
-      "name": "mode_noninteractive",
-      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
       "instances": [
         {
-          "schema_version": 1,
           "attributes": {
-            "id": "widget-id-026",
             "account_id": "f037e56e89293a057740de681ac9abbe",
-            "name": "cftftest-mode-noninteractive",
             "domains": [
               "noninteractive.cf-tf-test.com"
             ],
+            "id": "widget-id-026",
             "mode": "non-interactive",
-            "secret": "secret-key-026"
-          }
+            "name": "cftftest-mode-noninteractive",
+            "secret": "secret-key-026",
+            "sitekey": "widget-id-026"
+          },
+          "schema_version": 0
         }
-      ]
+      ],
+      "mode": "managed",
+      "name": "mode_noninteractive",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_turnstile_widget"
     }
-  ]
+  ],
+  "serial": 1,
+  "terraform_version": "1.5.0",
+  "version": 4
 }

--- a/integration/v4_to_v5/testdata/turnstile_widget/input/turnstile_widget.tf
+++ b/integration/v4_to_v5/testdata/turnstile_widget/input/turnstile_widget.tf
@@ -4,15 +4,15 @@
 
 # Standard variables (auto-provided by E2E infrastructure)
 variable "cloudflare_account_id" {
-  type        = string
+  type = string
 }
 
 variable "cloudflare_zone_id" {
-  type        = string
+  type = string
 }
 
 variable "cloudflare_domain" {
-  type        = string
+  type = string
 }
 
 # Locals for DRY testing
@@ -39,15 +39,17 @@ locals {
 resource "cloudflare_turnstile_widget" "minimal" {
   account_id = var.cloudflare_account_id
   name       = "${local.name_prefix}-minimal"
-  domains    = toset(["minimal.cf-tf-test.com"])
-  mode       = "managed"
+  domains    = ["minimal.cf-tf-test.com"]
+
+  mode = "managed"
 }
 
 # Test Case 2: Maximal configuration (all optional fields)
 resource "cloudflare_turnstile_widget" "maximal" {
-  account_id     = var.cloudflare_account_id
-  name           = "${local.name_prefix}-maximal"
-  domains        = toset(["maximal.cf-tf-test.com", "max2.cf-tf-test.com"])
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-maximal"
+  domains    = ["max2.cf-tf-test.com", "maximal.cf-tf-test.com"]
+
   mode           = "invisible"
   region         = "world"
   bot_fight_mode = false
@@ -56,9 +58,10 @@ resource "cloudflare_turnstile_widget" "maximal" {
 
 # Test Case 3: With explicit defaults
 resource "cloudflare_turnstile_widget" "with_defaults" {
-  account_id     = var.cloudflare_account_id
-  name           = "${local.name_prefix}-defaults"
-  domains        = toset(["defaults.cf-tf-test.com"])
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-defaults"
+  domains    = ["defaults.cf-tf-test.com"]
+
   mode           = "non-interactive"
   region         = "world"
   bot_fight_mode = false
@@ -88,7 +91,7 @@ resource "cloudflare_turnstile_widget" "foreach_map" {
 
   account_id = var.cloudflare_account_id
   name       = "${local.name_prefix}-map-${each.key}"
-  domains    = toset([each.value.domain])
+  domains    = [each.value.domain]
   mode       = each.value.mode
 }
 
@@ -107,7 +110,7 @@ resource "cloudflare_turnstile_widget" "foreach_set" {
 
   account_id = var.cloudflare_account_id
   name       = "${local.name_prefix}-set-${each.value}"
-  domains    = toset(["${each.value}.cf-tf-test.com"])
+  domains    = ["${each.value}.cf-tf-test.com"]
   mode       = "managed"
 }
 
@@ -119,10 +122,10 @@ resource "cloudflare_turnstile_widget" "foreach_set" {
 resource "cloudflare_turnstile_widget" "counted" {
   count = 3
 
-  account_id  = var.cloudflare_account_id
-  name        = "${local.name_prefix}-count-${count.index}"
-  domains     = toset(["count${count.index}.cf-tf-test.com"])
-  mode        = local.widget_modes[count.index]
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-count-${count.index}"
+  domains    = ["count${count.index}.cf-tf-test.com"]
+  mode       = local.widget_modes[count.index]
 }
 
 # ==================================================
@@ -140,8 +143,9 @@ resource "cloudflare_turnstile_widget" "conditional_enabled" {
 
   account_id = var.cloudflare_account_id
   name       = "${local.name_prefix}-conditional-enabled"
-  domains    = toset(["enabled.cf-tf-test.com"])
-  mode       = "managed"
+  domains    = ["enabled.cf-tf-test.com"]
+
+  mode = "managed"
 }
 
 # Test Case 15: Conditional disabled (will NOT be created - no instance in state)
@@ -150,8 +154,9 @@ resource "cloudflare_turnstile_widget" "conditional_disabled" {
 
   account_id = var.cloudflare_account_id
   name       = "${local.name_prefix}-conditional-disabled"
-  domains    = toset(["disabled.cf-tf-test.com"])
-  mode       = "invisible"
+  domains    = ["disabled.cf-tf-test.com"]
+
+  mode = "invisible"
 }
 
 # ==================================================
@@ -160,18 +165,20 @@ resource "cloudflare_turnstile_widget" "conditional_disabled" {
 
 # Test Case 16: Using join() function
 resource "cloudflare_turnstile_widget" "with_join" {
-  account_id  = var.cloudflare_account_id
-  name        = join("-", [local.name_prefix, "join", "test"])
-  domains     = toset(["join.cf-tf-test.com"])
-  mode        = "managed"
+  account_id = var.cloudflare_account_id
+  name       = join("-", [local.name_prefix, "join", "test"])
+  domains    = ["join.cf-tf-test.com"]
+
+  mode = "managed"
 }
 
 # Test Case 17: String interpolation
 resource "cloudflare_turnstile_widget" "with_interpolation" {
-  account_id  = var.cloudflare_account_id
-  name        = "${local.name_prefix}-interp"
-  domains     = toset(["interp.cf-tf-test.com"])
-  mode        = "invisible"
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-interp"
+  domains    = ["interp.cf-tf-test.com"]
+
+  mode = "invisible"
 }
 
 # ==================================================
@@ -182,8 +189,9 @@ resource "cloudflare_turnstile_widget" "with_interpolation" {
 resource "cloudflare_turnstile_widget" "with_lifecycle_cbd" {
   account_id = var.cloudflare_account_id
   name       = "${local.name_prefix}-lifecycle-cbd"
-  domains    = toset(["lifecycle-cbd.cf-tf-test.com"])
-  mode       = "managed"
+  domains    = ["lifecycle-cbd.cf-tf-test.com"]
+
+  mode = "managed"
 
   lifecycle {
     create_before_destroy = true
@@ -192,10 +200,11 @@ resource "cloudflare_turnstile_widget" "with_lifecycle_cbd" {
 
 # Test Case 19: Lifecycle with ignore_changes
 resource "cloudflare_turnstile_widget" "with_lifecycle_ignore" {
-  account_id  = var.cloudflare_account_id
-  name        = "${local.name_prefix}-lifecycle-ignore"
-  domains     = toset(["lifecycle-ignore.cf-tf-test.com"])
-  mode        = "invisible"
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-lifecycle-ignore"
+  domains    = ["lifecycle-ignore.cf-tf-test.com"]
+
+  mode = "invisible"
 
   lifecycle {
     ignore_changes = [name]
@@ -206,11 +215,12 @@ resource "cloudflare_turnstile_widget" "with_lifecycle_ignore" {
 resource "cloudflare_turnstile_widget" "with_lifecycle_prevent" {
   account_id = var.cloudflare_account_id
   name       = "${local.name_prefix}-lifecycle-prevent"
-  domains    = toset(["lifecycle-prevent.cf-tf-test.com"])
-  mode       = "non-interactive"
+  domains    = ["lifecycle-prevent.cf-tf-test.com"]
+
+  mode = "non-interactive"
 
   lifecycle {
-    prevent_destroy = false  # Set to false for testing purposes
+    prevent_destroy = false # Set to false for testing purposes
   }
 }
 
@@ -222,21 +232,17 @@ resource "cloudflare_turnstile_widget" "with_lifecycle_prevent" {
 resource "cloudflare_turnstile_widget" "multi_domain_2" {
   account_id = var.cloudflare_account_id
   name       = "${local.name_prefix}-multi-2"
-  domains    = toset(["multi1.cf-tf-test.com", "multi2.cf-tf-test.com"])
-  mode       = "managed"
+  domains    = ["multi1.cf-tf-test.com", "multi2.cf-tf-test.com"]
+
+  mode = "managed"
 }
 
 # Test Case 22: Multiple domains (5)
 resource "cloudflare_turnstile_widget" "multi_domain_5" {
   account_id = var.cloudflare_account_id
   name       = "${local.name_prefix}-multi-5"
-  domains = toset([
-    "md1.cf-tf-test.com",
-    "md2.cf-tf-test.com",
-    "md3.cf-tf-test.com",
-    "md4.cf-tf-test.com",
-    "md5.cf-tf-test.com"
-  ])
+  domains    = ["md1.cf-tf-test.com", "md2.cf-tf-test.com", "md3.cf-tf-test.com", "md4.cf-tf-test.com", "md5.cf-tf-test.com"]
+
   mode = "invisible"
 }
 
@@ -248,7 +254,7 @@ resource "cloudflare_turnstile_widget" "multi_domain_5" {
 resource "cloudflare_turnstile_widget" "with_var_domains" {
   account_id = local.account_id
   name       = "${local.name_prefix}-var-domains"
-  domains    = toset([local.test_domains.prod])
+  domains    = [local.test_domains.prod]
   mode       = "managed"
 }
 
@@ -260,24 +266,27 @@ resource "cloudflare_turnstile_widget" "with_var_domains" {
 resource "cloudflare_turnstile_widget" "mode_managed" {
   account_id = var.cloudflare_account_id
   name       = "${local.name_prefix}-mode-managed"
-  domains    = toset(["managed.cf-tf-test.com"])
-  mode       = "managed"
+  domains    = ["managed.cf-tf-test.com"]
+
+  mode = "managed"
 }
 
 # Test Case 25: invisible mode
 resource "cloudflare_turnstile_widget" "mode_invisible" {
   account_id = var.cloudflare_account_id
   name       = "${local.name_prefix}-mode-invisible"
-  domains    = toset(["invisible.cf-tf-test.com"])
-  mode       = "invisible"
+  domains    = ["invisible.cf-tf-test.com"]
+
+  mode = "invisible"
 }
 
 # Test Case 26: non-interactive mode
 resource "cloudflare_turnstile_widget" "mode_noninteractive" {
   account_id = var.cloudflare_account_id
   name       = "${local.name_prefix}-mode-noninteractive"
-  domains    = toset(["noninteractive.cf-tf-test.com"])
-  mode       = "non-interactive"
+  domains    = ["noninteractive.cf-tf-test.com"]
+
+  mode = "non-interactive"
 }
 
 # ==================================================


### PR DESCRIPTION
Changes:
  - Add SortStringArrayAttribute() to hcl/attributes.go with support for
    custom sort functions
  - Refactor turnstile_widget migration to use common helper
  - Refactor zero_trust_access_application migration to use common helper
  - Create sortOIDCScopes() helper for custom OIDC scope ordering