### PR TITLE
feat: add v4->v5 migration support for 'leaked_credential_check'

### DIFF
--- a/integration/v4_to_v5/testdata/leaked_credential_check/expected/leaked_credential_check.tf
+++ b/integration/v4_to_v5/testdata/leaked_credential_check/expected/leaked_credential_check.tf
@@ -1,0 +1,227 @@
+# Comprehensive integration test for cloudflare_leaked_credential_check v4→v5 migration
+# This file tests all Terraform patterns and edge cases
+
+# Variables for testing
+variable "zone_ids" {
+  type = list(string)
+  default = [
+    "0da42c8d2132a9ddaf714f9e7c920711",
+    "1ea53b5d3134b8eebf825e9f8d921712",
+    "2fa64c6e4245c9ffcg936faf9e032823"
+  ]
+}
+
+variable "enable_checks" {
+  type    = bool
+  default = true
+}
+
+variable "environment" {
+  type    = string
+  default = "production"
+}
+
+# Locals for DRY
+locals {
+  name_prefix = "cftftest"
+
+  zone_map = {
+    prod    = "0da42c8d2132a9ddaf714f9e7c920711"
+    staging = "1ea53b5d3134b8eebf825e9f8d921712"
+    dev     = "2fa64c6e4245c9ffcg936faf9e032823"
+  }
+
+  zones_to_protect = toset([
+    "0da42c8d2132a9ddaf714f9e7c920711",
+    "1ea53b5d3134b8eebf825e9f8d921712",
+    "2fa64c6e4245c9ffcg936faf9e032823",
+    "3gb75d7f5356daggdh047gbg0f143934"
+  ])
+}
+
+# ============================================================================
+# Basic Resources (instances 1-4)
+# ============================================================================
+
+# 1. Basic resource with enabled=true
+resource "cloudflare_leaked_credential_check" "basic_enabled" {
+  zone_id = "0da42c8d2132a9ddaf714f9e7c920711"
+  enabled = true
+}
+
+# 2. Basic resource with enabled=false
+resource "cloudflare_leaked_credential_check" "basic_disabled" {
+  zone_id = "1ea53b5d3134b8eebf825e9f8d921712"
+  enabled = false
+}
+
+# 3. Resource with variable reference for zone_id
+resource "cloudflare_leaked_credential_check" "with_var_zone" {
+  zone_id = var.zone_ids[0]
+  enabled = true
+}
+
+# 4. Resource with variable reference for enabled
+resource "cloudflare_leaked_credential_check" "with_var_enabled" {
+  zone_id = "2fa64c6e4245c9ffcg936faf9e032823"
+  enabled = var.enable_checks
+}
+
+# ============================================================================
+# count-based Resources (instances 5-7)
+# ============================================================================
+
+# 5-7. Multiple instances using count
+resource "cloudflare_leaked_credential_check" "count_based" {
+  count   = 3
+  zone_id = var.zone_ids[count.index]
+  enabled = count.index < 2 ? true : false
+}
+
+# ============================================================================
+# for_each with Map (instances 8-10)
+# ============================================================================
+
+# 8-10. Resources using for_each with map
+resource "cloudflare_leaked_credential_check" "for_each_map" {
+  for_each = local.zone_map
+
+  zone_id = each.value
+  enabled = each.key == "prod" ? true : false
+}
+
+# ============================================================================
+# for_each with Set (instances 11-14)
+# ============================================================================
+
+# 11-14. Resources using for_each with set
+resource "cloudflare_leaked_credential_check" "for_each_set" {
+  for_each = local.zones_to_protect
+
+  zone_id = each.value
+  enabled = true
+}
+
+# ============================================================================
+# Conditional Resources (instances 15-16)
+# ============================================================================
+
+# 15. Conditionally created resource (production only)
+resource "cloudflare_leaked_credential_check" "conditional_prod" {
+  count   = var.environment == "production" ? 1 : 0
+  zone_id = "0da42c8d2132a9ddaf714f9e7c920711"
+  enabled = true
+}
+
+# 16. Conditionally created resource (non-production)
+resource "cloudflare_leaked_credential_check" "conditional_nonprod" {
+  count   = var.environment != "production" ? 1 : 0
+  zone_id = "1ea53b5d3134b8eebf825e9f8d921712"
+  enabled = false
+}
+
+# ============================================================================
+# Resources with Lifecycle Meta-Arguments (instances 17-18)
+# ============================================================================
+
+# 17. Resource with create_before_destroy
+resource "cloudflare_leaked_credential_check" "with_lifecycle_cbd" {
+  zone_id = "3gb75d7f5356daggdh047gbg0f143934"
+  enabled = true
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+# 18. Resource with prevent_destroy and ignore_changes
+resource "cloudflare_leaked_credential_check" "with_lifecycle_complex" {
+  zone_id = "4hc86e8g6467ebhhe158hch1g254045"
+  enabled = true
+
+  lifecycle {
+    prevent_destroy = false
+    ignore_changes  = [enabled]
+  }
+}
+
+# ============================================================================
+# Resources with depends_on (instances 19-20)
+# ============================================================================
+
+# 19. Resource with depends_on referencing another check
+resource "cloudflare_leaked_credential_check" "with_depends" {
+  zone_id = "5id97f9h7578fciif269idi2h365156"
+  enabled = true
+
+  depends_on = [
+    cloudflare_leaked_credential_check.basic_enabled
+  ]
+}
+
+# 20. Resource with multiple dependencies
+resource "cloudflare_leaked_credential_check" "with_multi_depends" {
+  zone_id = "6je08g0i8689gdjjg370jej3i476267"
+  enabled = false
+
+  depends_on = [
+    cloudflare_leaked_credential_check.basic_enabled,
+    cloudflare_leaked_credential_check.basic_disabled
+  ]
+}
+
+# ============================================================================
+# Complex Expression Resources (instances 21-23)
+# ============================================================================
+
+# 21. Resource with conditional expression for enabled
+resource "cloudflare_leaked_credential_check" "conditional_expr" {
+  zone_id = "7kf19h1j9790hekkg481kfk4j587378"
+  enabled = var.environment == "production" ? true : false
+}
+
+# 22. Resource with local reference
+resource "cloudflare_leaked_credential_check" "with_local" {
+  zone_id = local.zone_map["prod"]
+  enabled = true
+}
+
+# 23. Resource with string interpolation
+resource "cloudflare_leaked_credential_check" "with_interpolation" {
+  zone_id = var.zone_ids[0]
+  enabled = var.enable_checks
+
+  # Comment showing interpolation pattern
+  # name = "${local.name_prefix}-check"  # (no name field, just for pattern demo)
+}
+
+# ============================================================================
+# Edge Cases (instances 24-25)
+# ============================================================================
+
+# 24. Resource with comments
+# This resource enables credential checking for the main production zone
+resource "cloudflare_leaked_credential_check" "with_comments" {
+  # Zone identifier for production
+  zone_id = "8lg20i2k0801iflh592lgl5k698489"
+  enabled = true # Enable credential leak detection
+}
+
+# 25. Minimal resource (all required fields only)
+resource "cloudflare_leaked_credential_check" "minimal" {
+  zone_id = "9mh31j3l1912jgmm603mhm6l709590"
+  enabled = true
+}
+
+# ============================================================================
+# Total Instances: 25
+# - Basic: 4
+# - count-based: 3
+# - for_each (map): 3
+# - for_each (set): 4
+# - Conditional: 2
+# - Lifecycle: 2
+# - depends_on: 2
+# - Complex expressions: 3
+# - Edge cases: 2
+# ============================================================================

--- a/integration/v4_to_v5/testdata/leaked_credential_check/expected/terraform.tfstate
+++ b/integration/v4_to_v5/testdata/leaked_credential_check/expected/terraform.tfstate
@@ -1,0 +1,331 @@
+{
+  "version": 4,
+  "terraform_version": "1.5.0",
+  "serial": 25,
+  "lineage": "test-lineage-leaked-cred",
+  "outputs": {},
+  "resources": [
+    {
+      "mode": "managed",
+      "type": "cloudflare_leaked_credential_check",
+      "name": "basic_enabled",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "zone_id": "0da42c8d2132a9ddaf714f9e7c920711",
+            "enabled": true
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_leaked_credential_check",
+      "name": "basic_disabled",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "zone_id": "1ea53b5d3134b8eebf825e9f8d921712",
+            "enabled": false
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_leaked_credential_check",
+      "name": "with_var_zone",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "zone_id": "0da42c8d2132a9ddaf714f9e7c920711",
+            "enabled": true
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_leaked_credential_check",
+      "name": "with_var_enabled",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "zone_id": "2fa64c6e4245c9ffcg936faf9e032823",
+            "enabled": true
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_leaked_credential_check",
+      "name": "count_based",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "index_key": 0,
+          "schema_version": 0,
+          "attributes": {
+            "zone_id": "0da42c8d2132a9ddaf714f9e7c920711",
+            "enabled": true
+          }
+        },
+        {
+          "index_key": 1,
+          "schema_version": 0,
+          "attributes": {
+            "zone_id": "1ea53b5d3134b8eebf825e9f8d921712",
+            "enabled": true
+          }
+        },
+        {
+          "index_key": 2,
+          "schema_version": 0,
+          "attributes": {
+            "zone_id": "2fa64c6e4245c9ffcg936faf9e032823",
+            "enabled": false
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_leaked_credential_check",
+      "name": "for_each_map",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "index_key": "dev",
+          "schema_version": 0,
+          "attributes": {
+            "zone_id": "2fa64c6e4245c9ffcg936faf9e032823",
+            "enabled": false
+          }
+        },
+        {
+          "index_key": "prod",
+          "schema_version": 0,
+          "attributes": {
+            "zone_id": "0da42c8d2132a9ddaf714f9e7c920711",
+            "enabled": true
+          }
+        },
+        {
+          "index_key": "staging",
+          "schema_version": 0,
+          "attributes": {
+            "zone_id": "1ea53b5d3134b8eebf825e9f8d921712",
+            "enabled": false
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_leaked_credential_check",
+      "name": "for_each_set",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "index_key": "0da42c8d2132a9ddaf714f9e7c920711",
+          "schema_version": 0,
+          "attributes": {
+            "zone_id": "0da42c8d2132a9ddaf714f9e7c920711",
+            "enabled": true
+          }
+        },
+        {
+          "index_key": "1ea53b5d3134b8eebf825e9f8d921712",
+          "schema_version": 0,
+          "attributes": {
+            "zone_id": "1ea53b5d3134b8eebf825e9f8d921712",
+            "enabled": true
+          }
+        },
+        {
+          "index_key": "2fa64c6e4245c9ffcg936faf9e032823",
+          "schema_version": 0,
+          "attributes": {
+            "zone_id": "2fa64c6e4245c9ffcg936faf9e032823",
+            "enabled": true
+          }
+        },
+        {
+          "index_key": "3gb75d7f5356daggdh047gbg0f143934",
+          "schema_version": 0,
+          "attributes": {
+            "zone_id": "3gb75d7f5356daggdh047gbg0f143934",
+            "enabled": true
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_leaked_credential_check",
+      "name": "conditional_prod",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "index_key": 0,
+          "schema_version": 0,
+          "attributes": {
+            "zone_id": "0da42c8d2132a9ddaf714f9e7c920711",
+            "enabled": true
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_leaked_credential_check",
+      "name": "with_lifecycle_cbd",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "zone_id": "3gb75d7f5356daggdh047gbg0f143934",
+            "enabled": true
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_leaked_credential_check",
+      "name": "with_lifecycle_complex",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "zone_id": "4hc86e8g6467ebhhe158hch1g254045",
+            "enabled": true
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_leaked_credential_check",
+      "name": "with_depends",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "zone_id": "5id97f9h7578fciif269idi2h365156",
+            "enabled": true
+          },
+          "dependencies": [
+            "cloudflare_leaked_credential_check.basic_enabled"
+          ]
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_leaked_credential_check",
+      "name": "with_multi_depends",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "zone_id": "6je08g0i8689gdjjg370jej3i476267",
+            "enabled": false
+          },
+          "dependencies": [
+            "cloudflare_leaked_credential_check.basic_enabled",
+            "cloudflare_leaked_credential_check.basic_disabled"
+          ]
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_leaked_credential_check",
+      "name": "conditional_expr",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "zone_id": "7kf19h1j9790hekkg481kfk4j587378",
+            "enabled": true
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_leaked_credential_check",
+      "name": "with_local",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "zone_id": "0da42c8d2132a9ddaf714f9e7c920711",
+            "enabled": true
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_leaked_credential_check",
+      "name": "with_interpolation",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "zone_id": "0da42c8d2132a9ddaf714f9e7c920711",
+            "enabled": true
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_leaked_credential_check",
+      "name": "with_comments",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "zone_id": "8lg20i2k0801iflh592lgl5k698489",
+            "enabled": true
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_leaked_credential_check",
+      "name": "minimal",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "zone_id": "9mh31j3l1912jgmm603mhm6l709590",
+            "enabled": true
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/integration/v4_to_v5/testdata/leaked_credential_check/input/leaked_credential_check.tf
+++ b/integration/v4_to_v5/testdata/leaked_credential_check/input/leaked_credential_check.tf
@@ -1,0 +1,227 @@
+# Comprehensive integration test for cloudflare_leaked_credential_check v4→v5 migration
+# This file tests all Terraform patterns and edge cases
+
+# Variables for testing
+variable "zone_ids" {
+  type = list(string)
+  default = [
+    "0da42c8d2132a9ddaf714f9e7c920711",
+    "1ea53b5d3134b8eebf825e9f8d921712",
+    "2fa64c6e4245c9ffcg936faf9e032823"
+  ]
+}
+
+variable "enable_checks" {
+  type    = bool
+  default = true
+}
+
+variable "environment" {
+  type    = string
+  default = "production"
+}
+
+# Locals for DRY
+locals {
+  name_prefix = "cftftest"
+
+  zone_map = {
+    prod    = "0da42c8d2132a9ddaf714f9e7c920711"
+    staging = "1ea53b5d3134b8eebf825e9f8d921712"
+    dev     = "2fa64c6e4245c9ffcg936faf9e032823"
+  }
+
+  zones_to_protect = toset([
+    "0da42c8d2132a9ddaf714f9e7c920711",
+    "1ea53b5d3134b8eebf825e9f8d921712",
+    "2fa64c6e4245c9ffcg936faf9e032823",
+    "3gb75d7f5356daggdh047gbg0f143934"
+  ])
+}
+
+# ============================================================================
+# Basic Resources (instances 1-4)
+# ============================================================================
+
+# 1. Basic resource with enabled=true
+resource "cloudflare_leaked_credential_check" "basic_enabled" {
+  zone_id = "0da42c8d2132a9ddaf714f9e7c920711"
+  enabled = true
+}
+
+# 2. Basic resource with enabled=false
+resource "cloudflare_leaked_credential_check" "basic_disabled" {
+  zone_id = "1ea53b5d3134b8eebf825e9f8d921712"
+  enabled = false
+}
+
+# 3. Resource with variable reference for zone_id
+resource "cloudflare_leaked_credential_check" "with_var_zone" {
+  zone_id = var.zone_ids[0]
+  enabled = true
+}
+
+# 4. Resource with variable reference for enabled
+resource "cloudflare_leaked_credential_check" "with_var_enabled" {
+  zone_id = "2fa64c6e4245c9ffcg936faf9e032823"
+  enabled = var.enable_checks
+}
+
+# ============================================================================
+# count-based Resources (instances 5-7)
+# ============================================================================
+
+# 5-7. Multiple instances using count
+resource "cloudflare_leaked_credential_check" "count_based" {
+  count   = 3
+  zone_id = var.zone_ids[count.index]
+  enabled = count.index < 2 ? true : false
+}
+
+# ============================================================================
+# for_each with Map (instances 8-10)
+# ============================================================================
+
+# 8-10. Resources using for_each with map
+resource "cloudflare_leaked_credential_check" "for_each_map" {
+  for_each = local.zone_map
+
+  zone_id = each.value
+  enabled = each.key == "prod" ? true : false
+}
+
+# ============================================================================
+# for_each with Set (instances 11-14)
+# ============================================================================
+
+# 11-14. Resources using for_each with set
+resource "cloudflare_leaked_credential_check" "for_each_set" {
+  for_each = local.zones_to_protect
+
+  zone_id = each.value
+  enabled = true
+}
+
+# ============================================================================
+# Conditional Resources (instances 15-16)
+# ============================================================================
+
+# 15. Conditionally created resource (production only)
+resource "cloudflare_leaked_credential_check" "conditional_prod" {
+  count   = var.environment == "production" ? 1 : 0
+  zone_id = "0da42c8d2132a9ddaf714f9e7c920711"
+  enabled = true
+}
+
+# 16. Conditionally created resource (non-production)
+resource "cloudflare_leaked_credential_check" "conditional_nonprod" {
+  count   = var.environment != "production" ? 1 : 0
+  zone_id = "1ea53b5d3134b8eebf825e9f8d921712"
+  enabled = false
+}
+
+# ============================================================================
+# Resources with Lifecycle Meta-Arguments (instances 17-18)
+# ============================================================================
+
+# 17. Resource with create_before_destroy
+resource "cloudflare_leaked_credential_check" "with_lifecycle_cbd" {
+  zone_id = "3gb75d7f5356daggdh047gbg0f143934"
+  enabled = true
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+# 18. Resource with prevent_destroy and ignore_changes
+resource "cloudflare_leaked_credential_check" "with_lifecycle_complex" {
+  zone_id = "4hc86e8g6467ebhhe158hch1g254045"
+  enabled = true
+
+  lifecycle {
+    prevent_destroy = false
+    ignore_changes  = [enabled]
+  }
+}
+
+# ============================================================================
+# Resources with depends_on (instances 19-20)
+# ============================================================================
+
+# 19. Resource with depends_on referencing another check
+resource "cloudflare_leaked_credential_check" "with_depends" {
+  zone_id = "5id97f9h7578fciif269idi2h365156"
+  enabled = true
+
+  depends_on = [
+    cloudflare_leaked_credential_check.basic_enabled
+  ]
+}
+
+# 20. Resource with multiple dependencies
+resource "cloudflare_leaked_credential_check" "with_multi_depends" {
+  zone_id = "6je08g0i8689gdjjg370jej3i476267"
+  enabled = false
+
+  depends_on = [
+    cloudflare_leaked_credential_check.basic_enabled,
+    cloudflare_leaked_credential_check.basic_disabled
+  ]
+}
+
+# ============================================================================
+# Complex Expression Resources (instances 21-23)
+# ============================================================================
+
+# 21. Resource with conditional expression for enabled
+resource "cloudflare_leaked_credential_check" "conditional_expr" {
+  zone_id = "7kf19h1j9790hekkg481kfk4j587378"
+  enabled = var.environment == "production" ? true : false
+}
+
+# 22. Resource with local reference
+resource "cloudflare_leaked_credential_check" "with_local" {
+  zone_id = local.zone_map["prod"]
+  enabled = true
+}
+
+# 23. Resource with string interpolation
+resource "cloudflare_leaked_credential_check" "with_interpolation" {
+  zone_id = var.zone_ids[0]
+  enabled = var.enable_checks
+
+  # Comment showing interpolation pattern
+  # name = "${local.name_prefix}-check"  # (no name field, just for pattern demo)
+}
+
+# ============================================================================
+# Edge Cases (instances 24-25)
+# ============================================================================
+
+# 24. Resource with comments
+# This resource enables credential checking for the main production zone
+resource "cloudflare_leaked_credential_check" "with_comments" {
+  # Zone identifier for production
+  zone_id = "8lg20i2k0801iflh592lgl5k698489"
+  enabled = true # Enable credential leak detection
+}
+
+# 25. Minimal resource (all required fields only)
+resource "cloudflare_leaked_credential_check" "minimal" {
+  zone_id = "9mh31j3l1912jgmm603mhm6l709590"
+  enabled = true
+}
+
+# ============================================================================
+# Total Instances: 25
+# - Basic: 4
+# - count-based: 3
+# - for_each (map): 3
+# - for_each (set): 4
+# - Conditional: 2
+# - Lifecycle: 2
+# - depends_on: 2
+# - Complex expressions: 3
+# - Edge cases: 2
+# ============================================================================

--- a/integration/v4_to_v5/testdata/leaked_credential_check/input/leaked_credential_check_e2e.tf
+++ b/integration/v4_to_v5/testdata/leaked_credential_check/input/leaked_credential_check_e2e.tf
@@ -1,0 +1,22 @@
+# E2E test for leaked_credential_check migration
+# This resource is a singleton (one per zone)
+
+variable "cloudflare_account_id" {
+  description = "Cloudflare account ID"
+  type        = string
+}
+
+variable "cloudflare_zone_id" {
+  description = "Cloudflare zone ID"
+  type        = string
+}
+
+variable "cloudflare_domain" {
+  description = "Cloudflare domain for testing"
+  type        = string
+}
+
+resource "cloudflare_leaked_credential_check" "cftftest-leaked-cred-check" {
+  zone_id          = var.cloudflare_zone_id
+  enabled = true
+}

--- a/integration/v4_to_v5/testdata/leaked_credential_check/input/terraform.tfstate
+++ b/integration/v4_to_v5/testdata/leaked_credential_check/input/terraform.tfstate
@@ -1,0 +1,331 @@
+{
+  "version": 4,
+  "terraform_version": "1.5.0",
+  "serial": 25,
+  "lineage": "test-lineage-leaked-cred",
+  "outputs": {},
+  "resources": [
+    {
+      "mode": "managed",
+      "type": "cloudflare_leaked_credential_check",
+      "name": "basic_enabled",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "zone_id": "0da42c8d2132a9ddaf714f9e7c920711",
+            "enabled": true
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_leaked_credential_check",
+      "name": "basic_disabled",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "zone_id": "1ea53b5d3134b8eebf825e9f8d921712",
+            "enabled": false
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_leaked_credential_check",
+      "name": "with_var_zone",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "zone_id": "0da42c8d2132a9ddaf714f9e7c920711",
+            "enabled": true
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_leaked_credential_check",
+      "name": "with_var_enabled",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "zone_id": "2fa64c6e4245c9ffcg936faf9e032823",
+            "enabled": true
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_leaked_credential_check",
+      "name": "count_based",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "index_key": 0,
+          "schema_version": 0,
+          "attributes": {
+            "zone_id": "0da42c8d2132a9ddaf714f9e7c920711",
+            "enabled": true
+          }
+        },
+        {
+          "index_key": 1,
+          "schema_version": 0,
+          "attributes": {
+            "zone_id": "1ea53b5d3134b8eebf825e9f8d921712",
+            "enabled": true
+          }
+        },
+        {
+          "index_key": 2,
+          "schema_version": 0,
+          "attributes": {
+            "zone_id": "2fa64c6e4245c9ffcg936faf9e032823",
+            "enabled": false
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_leaked_credential_check",
+      "name": "for_each_map",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "index_key": "dev",
+          "schema_version": 0,
+          "attributes": {
+            "zone_id": "2fa64c6e4245c9ffcg936faf9e032823",
+            "enabled": false
+          }
+        },
+        {
+          "index_key": "prod",
+          "schema_version": 0,
+          "attributes": {
+            "zone_id": "0da42c8d2132a9ddaf714f9e7c920711",
+            "enabled": true
+          }
+        },
+        {
+          "index_key": "staging",
+          "schema_version": 0,
+          "attributes": {
+            "zone_id": "1ea53b5d3134b8eebf825e9f8d921712",
+            "enabled": false
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_leaked_credential_check",
+      "name": "for_each_set",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "index_key": "0da42c8d2132a9ddaf714f9e7c920711",
+          "schema_version": 0,
+          "attributes": {
+            "zone_id": "0da42c8d2132a9ddaf714f9e7c920711",
+            "enabled": true
+          }
+        },
+        {
+          "index_key": "1ea53b5d3134b8eebf825e9f8d921712",
+          "schema_version": 0,
+          "attributes": {
+            "zone_id": "1ea53b5d3134b8eebf825e9f8d921712",
+            "enabled": true
+          }
+        },
+        {
+          "index_key": "2fa64c6e4245c9ffcg936faf9e032823",
+          "schema_version": 0,
+          "attributes": {
+            "zone_id": "2fa64c6e4245c9ffcg936faf9e032823",
+            "enabled": true
+          }
+        },
+        {
+          "index_key": "3gb75d7f5356daggdh047gbg0f143934",
+          "schema_version": 0,
+          "attributes": {
+            "zone_id": "3gb75d7f5356daggdh047gbg0f143934",
+            "enabled": true
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_leaked_credential_check",
+      "name": "conditional_prod",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "index_key": 0,
+          "schema_version": 0,
+          "attributes": {
+            "zone_id": "0da42c8d2132a9ddaf714f9e7c920711",
+            "enabled": true
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_leaked_credential_check",
+      "name": "with_lifecycle_cbd",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "zone_id": "3gb75d7f5356daggdh047gbg0f143934",
+            "enabled": true
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_leaked_credential_check",
+      "name": "with_lifecycle_complex",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "zone_id": "4hc86e8g6467ebhhe158hch1g254045",
+            "enabled": true
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_leaked_credential_check",
+      "name": "with_depends",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "zone_id": "5id97f9h7578fciif269idi2h365156",
+            "enabled": true
+          },
+          "dependencies": [
+            "cloudflare_leaked_credential_check.basic_enabled"
+          ]
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_leaked_credential_check",
+      "name": "with_multi_depends",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "zone_id": "6je08g0i8689gdjjg370jej3i476267",
+            "enabled": false
+          },
+          "dependencies": [
+            "cloudflare_leaked_credential_check.basic_enabled",
+            "cloudflare_leaked_credential_check.basic_disabled"
+          ]
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_leaked_credential_check",
+      "name": "conditional_expr",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "zone_id": "7kf19h1j9790hekkg481kfk4j587378",
+            "enabled": true
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_leaked_credential_check",
+      "name": "with_local",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "zone_id": "0da42c8d2132a9ddaf714f9e7c920711",
+            "enabled": true
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_leaked_credential_check",
+      "name": "with_interpolation",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "zone_id": "0da42c8d2132a9ddaf714f9e7c920711",
+            "enabled": true
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_leaked_credential_check",
+      "name": "with_comments",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "zone_id": "8lg20i2k0801iflh592lgl5k698489",
+            "enabled": true
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "cloudflare_leaked_credential_check",
+      "name": "minimal",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "zone_id": "9mh31j3l1912jgmm603mhm6l709590",
+            "enabled": true
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -13,6 +13,7 @@ import (
 	"github.com/cloudflare/tf-migrate/internal/resources/custom_pages"
 	"github.com/cloudflare/tf-migrate/internal/resources/dns_record"
 	"github.com/cloudflare/tf-migrate/internal/resources/healthcheck"
+	"github.com/cloudflare/tf-migrate/internal/resources/leaked_credential_check"
 	"github.com/cloudflare/tf-migrate/internal/resources/list"
 	"github.com/cloudflare/tf-migrate/internal/resources/list_item"
 	"github.com/cloudflare/tf-migrate/internal/resources/load_balancer"
@@ -84,6 +85,7 @@ func RegisterAllMigrations() {
 	custom_pages.NewV4ToV5Migrator()
 	dns_record.NewV4ToV5Migrator()
 	healthcheck.NewV4ToV5Migrator()
+	leaked_credential_check.NewV4ToV5Migrator()
 	load_balancer.NewV4ToV5Migrator()
 	load_balancer_monitor.NewV4ToV5Migrator()
 	load_balancer_pool.NewV4ToV5Migrator()

--- a/internal/resources/leaked_credential_check/v4_to_v5.go
+++ b/internal/resources/leaked_credential_check/v4_to_v5.go
@@ -1,0 +1,67 @@
+package leaked_credential_check
+
+import (
+	"github.com/hashicorp/hcl/v2/hclwrite"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+
+	"github.com/cloudflare/tf-migrate/internal"
+	"github.com/cloudflare/tf-migrate/internal/transform"
+)
+
+// V4ToV5Migrator handles the migration of cloudflare_leaked_credential_check from v4 to v5.
+// This is a Framework→Framework migration with minimal changes:
+// - enabled field changed from Required to Optional
+// - No schema transformations needed
+type V4ToV5Migrator struct{}
+
+// NewV4ToV5Migrator creates a new migrator for cloudflare_leaked_credential_check v4 to v5.
+func NewV4ToV5Migrator() transform.ResourceTransformer {
+	migrator := &V4ToV5Migrator{}
+	// Register with v4 resource name (same as v5 - no rename)
+	internal.RegisterMigrator("cloudflare_leaked_credential_check", "v4", "v5", migrator)
+	return migrator
+}
+
+// GetResourceType returns the v5 resource type this migrator handles.
+func (m *V4ToV5Migrator) GetResourceType() string {
+	return "cloudflare_leaked_credential_check"
+}
+
+// CanHandle determines if this migrator can handle the given resource type.
+func (m *V4ToV5Migrator) CanHandle(resourceType string) bool {
+	return resourceType == "cloudflare_leaked_credential_check"
+}
+
+// GetResourceRename implements the ResourceRenamer interface.
+// cloudflare_leaked_credential_check doesn't rename, so return the same name.
+func (m *V4ToV5Migrator) GetResourceRename() (string, string) {
+	return "cloudflare_leaked_credential_check", "cloudflare_leaked_credential_check"
+}
+
+// Preprocess handles string-level transformations before HCL parsing.
+// No preprocessing needed for this migration.
+func (m *V4ToV5Migrator) Preprocess(content string) string {
+	return content
+}
+
+// TransformConfig handles configuration file transformations.
+// No config transformations needed - v4 and v5 syntax is identical.
+func (m *V4ToV5Migrator) TransformConfig(ctx *transform.Context, block *hclwrite.Block) (*transform.TransformResult, error) {
+	// No transformations needed - just return the block unchanged
+	return &transform.TransformResult{
+		Blocks:         []*hclwrite.Block{block},
+		RemoveOriginal: false,
+	}, nil
+}
+
+// TransformState handles state file transformations.
+// Only need to ensure schema_version is set to 0.
+func (m *V4ToV5Migrator) TransformState(ctx *transform.Context, stateJSON gjson.Result, resourcePath, resourceName string) (string, error) {
+	result := stateJSON.String()
+
+	// Set schema version to 0 for v5
+	result, _ = sjson.Set(result, "schema_version", 0)
+
+	return result, nil
+}

--- a/internal/resources/leaked_credential_check/v4_to_v5_test.go
+++ b/internal/resources/leaked_credential_check/v4_to_v5_test.go
@@ -1,0 +1,448 @@
+package leaked_credential_check
+
+import (
+	"testing"
+
+	"github.com/cloudflare/tf-migrate/internal/testhelpers"
+)
+
+func TestConfigTransformation(t *testing.T) {
+	migrator := NewV4ToV5Migrator()
+
+	t.Run("BasicTransformations", func(t *testing.T) {
+		tests := []testhelpers.ConfigTestCase{
+			{
+				Name: "basic resource with enabled=true",
+				Input: `
+resource "cloudflare_leaked_credential_check" "test" {
+  zone_id = "0da42c8d2132a9ddaf714f9e7c920711"
+  enabled = true
+}`,
+				Expected: `
+resource "cloudflare_leaked_credential_check" "test" {
+  zone_id = "0da42c8d2132a9ddaf714f9e7c920711"
+  enabled = true
+}`,
+			},
+			{
+				Name: "basic resource with enabled=false",
+				Input: `
+resource "cloudflare_leaked_credential_check" "test" {
+  zone_id = "0da42c8d2132a9ddaf714f9e7c920711"
+  enabled = false
+}`,
+				Expected: `
+resource "cloudflare_leaked_credential_check" "test" {
+  zone_id = "0da42c8d2132a9ddaf714f9e7c920711"
+  enabled = false
+}`,
+			},
+		}
+		testhelpers.RunConfigTransformTests(t, tests, migrator)
+	})
+
+	t.Run("VariableReferences", func(t *testing.T) {
+		tests := []testhelpers.ConfigTestCase{
+			{
+				Name: "zone_id with variable reference",
+				Input: `
+resource "cloudflare_leaked_credential_check" "test" {
+  zone_id = var.zone_id
+  enabled = true
+}`,
+				Expected: `
+resource "cloudflare_leaked_credential_check" "test" {
+  zone_id = var.zone_id
+  enabled = true
+}`,
+			},
+			{
+				Name: "enabled with variable reference",
+				Input: `
+resource "cloudflare_leaked_credential_check" "test" {
+  zone_id = "0da42c8d2132a9ddaf714f9e7c920711"
+  enabled = var.enable_check
+}`,
+				Expected: `
+resource "cloudflare_leaked_credential_check" "test" {
+  zone_id = "0da42c8d2132a9ddaf714f9e7c920711"
+  enabled = var.enable_check
+}`,
+			},
+			{
+				Name: "zone_id with resource reference",
+				Input: `
+resource "cloudflare_leaked_credential_check" "test" {
+  zone_id = cloudflare_zone.example.id
+  enabled = true
+}`,
+				Expected: `
+resource "cloudflare_leaked_credential_check" "test" {
+  zone_id = cloudflare_zone.example.id
+  enabled = true
+}`,
+			},
+		}
+		testhelpers.RunConfigTransformTests(t, tests, migrator)
+	})
+
+	t.Run("MultipleResources", func(t *testing.T) {
+		tests := []testhelpers.ConfigTestCase{
+			{
+				Name: "multiple resources in one file",
+				Input: `
+resource "cloudflare_leaked_credential_check" "zone1" {
+  zone_id = "zone-id-1"
+  enabled = true
+}
+
+resource "cloudflare_leaked_credential_check" "zone2" {
+  zone_id = "zone-id-2"
+  enabled = false
+}
+
+resource "cloudflare_leaked_credential_check" "zone3" {
+  zone_id = "zone-id-3"
+  enabled = true
+}`,
+				Expected: `
+resource "cloudflare_leaked_credential_check" "zone1" {
+  zone_id = "zone-id-1"
+  enabled = true
+}
+
+resource "cloudflare_leaked_credential_check" "zone2" {
+  zone_id = "zone-id-2"
+  enabled = false
+}
+
+resource "cloudflare_leaked_credential_check" "zone3" {
+  zone_id = "zone-id-3"
+  enabled = true
+}`,
+			},
+		}
+		testhelpers.RunConfigTransformTests(t, tests, migrator)
+	})
+
+	t.Run("MetaArguments", func(t *testing.T) {
+		tests := []testhelpers.ConfigTestCase{
+			{
+				Name: "resource with lifecycle block",
+				Input: `
+resource "cloudflare_leaked_credential_check" "test" {
+  zone_id = "0da42c8d2132a9ddaf714f9e7c920711"
+  enabled = true
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}`,
+				Expected: `
+resource "cloudflare_leaked_credential_check" "test" {
+  zone_id = "0da42c8d2132a9ddaf714f9e7c920711"
+  enabled = true
+  lifecycle {
+    create_before_destroy = true
+  }
+}`,
+			},
+			{
+				Name: "resource with depends_on",
+				Input: `
+resource "cloudflare_leaked_credential_check" "test" {
+  zone_id = cloudflare_zone.example.id
+  enabled = true
+
+  depends_on = [cloudflare_zone.example]
+}`,
+				Expected: `
+resource "cloudflare_leaked_credential_check" "test" {
+  zone_id = cloudflare_zone.example.id
+  enabled = true
+  depends_on = [cloudflare_zone.example]
+}`,
+			},
+			{
+				Name: "resource with count",
+				Input: `
+resource "cloudflare_leaked_credential_check" "test" {
+  count   = 3
+  zone_id = var.zone_ids[count.index]
+  enabled = true
+}`,
+				Expected: `
+resource "cloudflare_leaked_credential_check" "test" {
+  count   = 3
+  zone_id = var.zone_ids[count.index]
+  enabled = true
+}`,
+			},
+			{
+				Name: "resource with for_each",
+				Input: `
+resource "cloudflare_leaked_credential_check" "test" {
+  for_each = var.zones
+  zone_id  = each.value.id
+  enabled  = each.value.enabled
+}`,
+				Expected: `
+resource "cloudflare_leaked_credential_check" "test" {
+  for_each = var.zones
+  zone_id  = each.value.id
+  enabled  = each.value.enabled
+}`,
+			},
+		}
+		testhelpers.RunConfigTransformTests(t, tests, migrator)
+	})
+
+	t.Run("EdgeCases", func(t *testing.T) {
+		tests := []testhelpers.ConfigTestCase{
+			{
+				Name: "resource with comments",
+				Input: `
+# Main leaked credential check
+resource "cloudflare_leaked_credential_check" "test" {
+  # Zone identifier
+  zone_id = "0da42c8d2132a9ddaf714f9e7c920711"
+  enabled = true # Enable the check
+}`,
+				Expected: `
+# Main leaked credential check
+resource "cloudflare_leaked_credential_check" "test" {
+  # Zone identifier
+  zone_id = "0da42c8d2132a9ddaf714f9e7c920711"
+  enabled = true # Enable the check
+}`,
+			},
+			{
+				Name: "resource with conditional expression",
+				Input: `
+resource "cloudflare_leaked_credential_check" "test" {
+  zone_id = "0da42c8d2132a9ddaf714f9e7c920711"
+  enabled = var.environment == "production" ? true : false
+}`,
+				Expected: `
+resource "cloudflare_leaked_credential_check" "test" {
+  zone_id = "0da42c8d2132a9ddaf714f9e7c920711"
+  enabled = var.environment == "production" ? true : false
+}`,
+			},
+		}
+		testhelpers.RunConfigTransformTests(t, tests, migrator)
+	})
+}
+
+func TestStateTransformation(t *testing.T) {
+	migrator := NewV4ToV5Migrator()
+
+	t.Run("BasicTransformations", func(t *testing.T) {
+		tests := []testhelpers.StateTestCase{
+			{
+				Name: "basic state with enabled=true",
+				Input: `{
+  "schema_version": 0,
+  "attributes": {
+    "zone_id": "0da42c8d2132a9ddaf714f9e7c920711",
+    "enabled": true
+  }
+}`,
+				Expected: `{
+  "schema_version": 0,
+  "attributes": {
+    "zone_id": "0da42c8d2132a9ddaf714f9e7c920711",
+    "enabled": true
+  }
+}`,
+			},
+			{
+				Name: "basic state with enabled=false",
+				Input: `{
+  "schema_version": 0,
+  "attributes": {
+    "zone_id": "0da42c8d2132a9ddaf714f9e7c920711",
+    "enabled": false
+  }
+}`,
+				Expected: `{
+  "schema_version": 0,
+  "attributes": {
+    "zone_id": "0da42c8d2132a9ddaf714f9e7c920711",
+    "enabled": false
+  }
+}`,
+			},
+		}
+		testhelpers.RunStateTransformTests(t, tests, migrator)
+	})
+
+	t.Run("NullAndMissingValues", func(t *testing.T) {
+		tests := []testhelpers.StateTestCase{
+			{
+				Name: "state with enabled=null (v5 allows this)",
+				Input: `{
+  "schema_version": 0,
+  "attributes": {
+    "zone_id": "0da42c8d2132a9ddaf714f9e7c920711",
+    "enabled": null
+  }
+}`,
+				Expected: `{
+  "schema_version": 0,
+  "attributes": {
+    "zone_id": "0da42c8d2132a9ddaf714f9e7c920711",
+    "enabled": null
+  }
+}`,
+			},
+			{
+				Name: "state with missing enabled field (v5 allows this)",
+				Input: `{
+  "schema_version": 0,
+  "attributes": {
+    "zone_id": "0da42c8d2132a9ddaf714f9e7c920711"
+  }
+}`,
+				Expected: `{
+  "schema_version": 0,
+  "attributes": {
+    "zone_id": "0da42c8d2132a9ddaf714f9e7c920711"
+  }
+}`,
+			},
+		}
+		testhelpers.RunStateTransformTests(t, tests, migrator)
+	})
+
+	t.Run("SchemaVersionHandling", func(t *testing.T) {
+		tests := []testhelpers.StateTestCase{
+			{
+				Name: "state without schema_version gets it set",
+				Input: `{
+  "attributes": {
+    "zone_id": "0da42c8d2132a9ddaf714f9e7c920711",
+    "enabled": true
+  }
+}`,
+				Expected: `{
+  "schema_version": 0,
+  "attributes": {
+    "zone_id": "0da42c8d2132a9ddaf714f9e7c920711",
+    "enabled": true
+  }
+}`,
+			},
+			{
+				Name: "state with non-zero schema_version gets reset to 0",
+				Input: `{
+  "schema_version": 1,
+  "attributes": {
+    "zone_id": "0da42c8d2132a9ddaf714f9e7c920711",
+    "enabled": true
+  }
+}`,
+				Expected: `{
+  "schema_version": 0,
+  "attributes": {
+    "zone_id": "0da42c8d2132a9ddaf714f9e7c920711",
+    "enabled": true
+  }
+}`,
+			},
+		}
+		testhelpers.RunStateTransformTests(t, tests, migrator)
+	})
+
+	t.Run("EdgeCases", func(t *testing.T) {
+		tests := []testhelpers.StateTestCase{
+			{
+				Name: "empty attributes object",
+				Input: `{
+  "schema_version": 0,
+  "attributes": {}
+}`,
+				Expected: `{
+  "schema_version": 0,
+  "attributes": {}
+}`,
+			},
+			{
+				Name: "state with additional fields (should be preserved)",
+				Input: `{
+  "schema_version": 0,
+  "attributes": {
+    "zone_id": "0da42c8d2132a9ddaf714f9e7c920711",
+    "enabled": true,
+    "id": "0da42c8d2132a9ddaf714f9e7c920711"
+  },
+  "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjAifQ=="
+}`,
+				Expected: `{
+  "schema_version": 0,
+  "attributes": {
+    "zone_id": "0da42c8d2132a9ddaf714f9e7c920711",
+    "enabled": true,
+    "id": "0da42c8d2132a9ddaf714f9e7c920711"
+  },
+  "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjAifQ=="
+}`,
+			},
+		}
+		testhelpers.RunStateTransformTests(t, tests, migrator)
+	})
+}
+
+func TestMigratorInterface(t *testing.T) {
+	migrator := NewV4ToV5Migrator()
+
+	t.Run("GetResourceType", func(t *testing.T) {
+		expected := "cloudflare_leaked_credential_check"
+		if got := migrator.GetResourceType(); got != expected {
+			t.Errorf("GetResourceType() = %v, want %v", got, expected)
+		}
+	})
+
+	t.Run("CanHandle", func(t *testing.T) {
+		tests := []struct {
+			name         string
+			resourceType string
+			expected     bool
+		}{
+			{
+				name:         "handles correct resource type",
+				resourceType: "cloudflare_leaked_credential_check",
+				expected:     true,
+			},
+			{
+				name:         "does not handle different resource",
+				resourceType: "cloudflare_zone",
+				expected:     false,
+			},
+			{
+				name:         "does not handle empty string",
+				resourceType: "",
+				expected:     false,
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				if got := migrator.CanHandle(tt.resourceType); got != tt.expected {
+					t.Errorf("CanHandle(%q) = %v, want %v", tt.resourceType, got, tt.expected)
+				}
+			})
+		}
+	})
+
+	t.Run("Preprocess", func(t *testing.T) {
+		input := `resource "cloudflare_leaked_credential_check" "test" {
+  zone_id = "test"
+  enabled = true
+}`
+		output := migrator.Preprocess(input)
+		if output != input {
+			t.Errorf("Preprocess() should return input unchanged, got different output")
+		}
+	})
+}


### PR DESCRIPTION
## Migration Summary
This is a pass-through migration.

## Test Summary
**Test coverage:** 90.9%

**Unit tests:** `go test ./internal/resources/leaked_credential_check -v -count=1`
```
=== RUN   TestConfigTransformation
=== RUN   TestConfigTransformation/BasicTransformations
=== RUN   TestConfigTransformation/BasicTransformations/basic_resource_with_enabled=true
=== RUN   TestConfigTransformation/BasicTransformations/basic_resource_with_enabled=false
=== RUN   TestConfigTransformation/VariableReferences
=== RUN   TestConfigTransformation/VariableReferences/zone_id_with_variable_reference
=== RUN   TestConfigTransformation/VariableReferences/enabled_with_variable_reference
=== RUN   TestConfigTransformation/VariableReferences/zone_id_with_resource_reference
=== RUN   TestConfigTransformation/MultipleResources
=== RUN   TestConfigTransformation/MultipleResources/multiple_resources_in_one_file
=== RUN   TestConfigTransformation/MetaArguments
=== RUN   TestConfigTransformation/MetaArguments/resource_with_lifecycle_block
=== RUN   TestConfigTransformation/MetaArguments/resource_with_depends_on
=== RUN   TestConfigTransformation/MetaArguments/resource_with_count
=== RUN   TestConfigTransformation/MetaArguments/resource_with_for_each
=== RUN   TestConfigTransformation/EdgeCases
=== RUN   TestConfigTransformation/EdgeCases/resource_with_comments
=== RUN   TestConfigTransformation/EdgeCases/resource_with_conditional_expression
--- PASS: TestConfigTransformation (0.00s)
    --- PASS: TestConfigTransformation/BasicTransformations (0.00s)
        --- PASS: TestConfigTransformation/BasicTransformations/basic_resource_with_enabled=true (0.00s)
        --- PASS: TestConfigTransformation/BasicTransformations/basic_resource_with_enabled=false (0.00s)
    --- PASS: TestConfigTransformation/VariableReferences (0.00s)
        --- PASS: TestConfigTransformation/VariableReferences/zone_id_with_variable_reference (0.00s)
        --- PASS: TestConfigTransformation/VariableReferences/enabled_with_variable_reference (0.00s)
        --- PASS: TestConfigTransformation/VariableReferences/zone_id_with_resource_reference (0.00s)
    --- PASS: TestConfigTransformation/MultipleResources (0.00s)
        --- PASS: TestConfigTransformation/MultipleResources/multiple_resources_in_one_file (0.00s)
    --- PASS: TestConfigTransformation/MetaArguments (0.00s)
        --- PASS: TestConfigTransformation/MetaArguments/resource_with_lifecycle_block (0.00s)
        --- PASS: TestConfigTransformation/MetaArguments/resource_with_depends_on (0.00s)
        --- PASS: TestConfigTransformation/MetaArguments/resource_with_count (0.00s)
        --- PASS: TestConfigTransformation/MetaArguments/resource_with_for_each (0.00s)
    --- PASS: TestConfigTransformation/EdgeCases (0.00s)
        --- PASS: TestConfigTransformation/EdgeCases/resource_with_comments (0.00s)
        --- PASS: TestConfigTransformation/EdgeCases/resource_with_conditional_expression (0.00s)
=== RUN   TestStateTransformation
=== RUN   TestStateTransformation/BasicTransformations
=== RUN   TestStateTransformation/BasicTransformations/basic_state_with_enabled=true
=== RUN   TestStateTransformation/BasicTransformations/basic_state_with_enabled=false
=== RUN   TestStateTransformation/NullAndMissingValues
=== RUN   TestStateTransformation/NullAndMissingValues/state_with_enabled=null_(v5_allows_this)
=== RUN   TestStateTransformation/NullAndMissingValues/state_with_missing_enabled_field_(v5_allows_this)
=== RUN   TestStateTransformation/SchemaVersionHandling
=== RUN   TestStateTransformation/SchemaVersionHandling/state_without_schema_version_gets_it_set
=== RUN   TestStateTransformation/SchemaVersionHandling/state_with_non-zero_schema_version_gets_reset_to_0
=== RUN   TestStateTransformation/EdgeCases
=== RUN   TestStateTransformation/EdgeCases/empty_attributes_object
=== RUN   TestStateTransformation/EdgeCases/state_with_additional_fields_(should_be_preserved)
--- PASS: TestStateTransformation (0.00s)
    --- PASS: TestStateTransformation/BasicTransformations (0.00s)
        --- PASS: TestStateTransformation/BasicTransformations/basic_state_with_enabled=true (0.00s)
        --- PASS: TestStateTransformation/BasicTransformations/basic_state_with_enabled=false (0.00s)
    --- PASS: TestStateTransformation/NullAndMissingValues (0.00s)
        --- PASS: TestStateTransformation/NullAndMissingValues/state_with_enabled=null_(v5_allows_this) (0.00s)
        --- PASS: TestStateTransformation/NullAndMissingValues/state_with_missing_enabled_field_(v5_allows_this) (0.00s)
    --- PASS: TestStateTransformation/SchemaVersionHandling (0.00s)
        --- PASS: TestStateTransformation/SchemaVersionHandling/state_without_schema_version_gets_it_set (0.00s)
        --- PASS: TestStateTransformation/SchemaVersionHandling/state_with_non-zero_schema_version_gets_reset_to_0 (0.00s)
    --- PASS: TestStateTransformation/EdgeCases (0.00s)
        --- PASS: TestStateTransformation/EdgeCases/empty_attributes_object (0.00s)
        --- PASS: TestStateTransformation/EdgeCases/state_with_additional_fields_(should_be_preserved) (0.00s)
=== RUN   TestMigratorInterface
=== RUN   TestMigratorInterface/GetResourceType
=== RUN   TestMigratorInterface/CanHandle
=== RUN   TestMigratorInterface/CanHandle/handles_correct_resource_type
=== RUN   TestMigratorInterface/CanHandle/does_not_handle_different_resource
=== RUN   TestMigratorInterface/CanHandle/does_not_handle_empty_string
=== RUN   TestMigratorInterface/Preprocess
--- PASS: TestMigratorInterface (0.00s)
    --- PASS: TestMigratorInterface/GetResourceType (0.00s)
    --- PASS: TestMigratorInterface/CanHandle (0.00s)
        --- PASS: TestMigratorInterface/CanHandle/handles_correct_resource_type (0.00s)
        --- PASS: TestMigratorInterface/CanHandle/does_not_handle_different_resource (0.00s)
        --- PASS: TestMigratorInterface/CanHandle/does_not_handle_empty_string (0.00s)
    --- PASS: TestMigratorInterface/Preprocess (0.00s)
PASS
coverage: 90.9% of statements
ok  	github.com/cloudflare/tf-migrate/internal/resources/leaked_credential_check	0.838s
```

**Integration tests:** `TEST_RESOURCE=leaked_credential_check go test ./integration/v4_to_v5 -v -count=1`
```
=== RUN   TestSingleResource
=== RUN   TestSingleResource/leaked_credential_check
--- PASS: TestSingleResource (0.76s)
    --- PASS: TestSingleResource/leaked_credential_check (0.76s)
PASS
ok  	github.com/cloudflare/tf-migrate/integration/v4_to_v5	44.055s
```