### PR TITLE
feat: add v4->v5 migration support for 'rulesets' data source

### DIFF
--- a/integration/v4_to_v5/testdata/rulesets_datasource/expected/rulesets.tf
+++ b/integration/v4_to_v5/testdata/rulesets_datasource/expected/rulesets.tf
@@ -1,0 +1,121 @@
+# Comprehensive integration test for cloudflare_rulesets datasource migration
+# This file tests various scenarios for v4 to v5 migration
+
+# Variables (no defaults - integration tests should provide these)
+variable "cloudflare_account_id" {
+  type        = string
+  description = "Cloudflare account ID"
+}
+
+variable "cloudflare_zone_id" {
+  type        = string
+  description = "Cloudflare zone ID"
+}
+
+variable "cloudflare_domain" {
+  type        = string
+  description = "Domain for testing"
+}
+
+# Scenario 1: Basic datasource with account_id only
+data "cloudflare_rulesets" "account_all" {
+  account_id = var.cloudflare_account_id
+}
+
+# Scenario 2: Basic datasource with zone_id only
+data "cloudflare_rulesets" "zone_all" {
+  zone_id = var.cloudflare_zone_id
+}
+
+# Scenario 3: Datasource with filter block (simple filter)
+data "cloudflare_rulesets" "filtered_by_name" {
+  account_id = var.cloudflare_account_id
+}
+
+# Scenario 4: Datasource with filter block (complex filter - all fields)
+data "cloudflare_rulesets" "filtered_complex" {
+  account_id = var.cloudflare_account_id
+}
+
+# Scenario 5: Datasource with include_rules only
+data "cloudflare_rulesets" "with_rules" {
+  account_id = var.cloudflare_account_id
+}
+
+# Scenario 6: Datasource with both filter and include_rules
+data "cloudflare_rulesets" "filtered_with_rules" {
+  zone_id = var.cloudflare_zone_id
+}
+
+# Scenario 7: Datasource with include_rules = false
+data "cloudflare_rulesets" "without_rules" {
+  account_id = var.cloudflare_account_id
+}
+
+# Scenario 8: Multiple filters testing different phases
+data "cloudflare_rulesets" "firewall_managed" {
+  account_id = var.cloudflare_account_id
+}
+
+data "cloudflare_rulesets" "firewall_custom" {
+  account_id = var.cloudflare_account_id
+}
+
+data "cloudflare_rulesets" "rate_limit" {
+  zone_id = var.cloudflare_zone_id
+}
+
+# Scenario 9: Cross-resource references (datasource output used elsewhere)
+output "all_account_rulesets" {
+  value       = data.cloudflare_rulesets.account_all.rulesets
+  description = "All rulesets for the account"
+}
+
+output "filtered_rulesets" {
+  value       = data.cloudflare_rulesets.filtered_by_name.rulesets
+  description = "Filtered rulesets (filter will be removed in v5)"
+}
+
+output "ruleset_count" {
+  value       = length(data.cloudflare_rulesets.account_all.rulesets)
+  description = "Number of rulesets in account"
+}
+
+# Scenario 10: Conditional datasource usage
+locals {
+  use_account_scope = true
+}
+
+data "cloudflare_rulesets" "conditional" {
+  count      = local.use_account_scope ? 1 : 0
+  account_id = var.cloudflare_account_id
+}
+
+# Scenario 11: Datasource with for_each (using a set)
+locals {
+  phases_to_check = toset([
+    "http_request_firewall_managed",
+    "http_request_firewall_custom",
+    "http_ratelimit"
+  ])
+}
+
+data "cloudflare_rulesets" "by_phase" {
+  for_each   = local.phases_to_check
+  account_id = var.cloudflare_account_id
+}
+
+# Scenario 12: Datasource with for_each (using a map)
+locals {
+  scope_config = {
+    account = var.cloudflare_account_id
+    zone    = var.cloudflare_zone_id
+  }
+}
+
+data "cloudflare_rulesets" "by_scope" {
+  for_each = local.scope_config
+  # Using dynamic attribute selection
+  account_id = each.key == "account" ? each.value : null
+  zone_id    = each.key == "zone" ? each.value : null
+}

--- a/integration/v4_to_v5/testdata/rulesets_datasource/expected/terraform.tfstate
+++ b/integration/v4_to_v5/testdata/rulesets_datasource/expected/terraform.tfstate
@@ -1,0 +1,278 @@
+{
+  "lineage": "integration-test-rulesets",
+  "outputs": {
+    "all_account_rulesets": {
+      "type": [
+        "list",
+        [
+          "object",
+          {
+            "id": "string",
+            "name": "string"
+          }
+        ]
+      ],
+      "value": []
+    },
+    "filtered_rulesets": {
+      "type": [
+        "list",
+        [
+          "object",
+          {
+            "id": "string",
+            "name": "string"
+          }
+        ]
+      ],
+      "value": []
+    },
+    "ruleset_count": {
+      "type": "number",
+      "value": 0
+    }
+  },
+  "resources": [
+    {
+      "instances": [
+        {
+          "attributes": {
+            "account_id": "test-account-123",
+            "id": "test-account-123",
+            "rulesets": []
+          },
+          "schema_version": 0
+        }
+      ],
+      "mode": "data",
+      "name": "account_all",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_rulesets"
+    },
+    {
+      "instances": [
+        {
+          "attributes": {
+            "id": "test-zone-456",
+            "rulesets": [],
+            "zone_id": "test-zone-456"
+          },
+          "schema_version": 0
+        }
+      ],
+      "mode": "data",
+      "name": "zone_all",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_rulesets"
+    },
+    {
+      "instances": [
+        {
+          "attributes": {
+            "account_id": "test-account-123",
+            "id": "test-account-123",
+            "rulesets": []
+          },
+          "schema_version": 0
+        }
+      ],
+      "mode": "data",
+      "name": "filtered_by_name",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_rulesets"
+    },
+    {
+      "instances": [
+        {
+          "attributes": {
+            "account_id": "test-account-123",
+            "id": "test-account-123",
+            "rulesets": []
+          },
+          "schema_version": 0
+        }
+      ],
+      "mode": "data",
+      "name": "filtered_complex",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_rulesets"
+    },
+    {
+      "instances": [
+        {
+          "attributes": {
+            "account_id": "test-account-123",
+            "id": "test-account-123",
+            "rulesets": []
+          },
+          "schema_version": 0
+        }
+      ],
+      "mode": "data",
+      "name": "with_rules",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_rulesets"
+    },
+    {
+      "instances": [
+        {
+          "attributes": {
+            "id": "test-zone-456",
+            "rulesets": [],
+            "zone_id": "test-zone-456"
+          },
+          "schema_version": 0
+        }
+      ],
+      "mode": "data",
+      "name": "filtered_with_rules",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_rulesets"
+    },
+    {
+      "instances": [
+        {
+          "attributes": {
+            "account_id": "test-account-123",
+            "id": "test-account-123",
+            "rulesets": []
+          },
+          "schema_version": 0
+        }
+      ],
+      "mode": "data",
+      "name": "without_rules",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_rulesets"
+    },
+    {
+      "instances": [
+        {
+          "attributes": {
+            "account_id": "test-account-123",
+            "id": "test-account-123",
+            "rulesets": []
+          },
+          "schema_version": 0
+        }
+      ],
+      "mode": "data",
+      "name": "firewall_managed",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_rulesets"
+    },
+    {
+      "instances": [
+        {
+          "attributes": {
+            "account_id": "test-account-123",
+            "id": "test-account-123",
+            "rulesets": []
+          },
+          "schema_version": 0
+        }
+      ],
+      "mode": "data",
+      "name": "firewall_custom",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_rulesets"
+    },
+    {
+      "instances": [
+        {
+          "attributes": {
+            "id": "test-zone-456",
+            "rulesets": [],
+            "zone_id": "test-zone-456"
+          },
+          "schema_version": 0
+        }
+      ],
+      "mode": "data",
+      "name": "rate_limit",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_rulesets"
+    },
+    {
+      "instances": [
+        {
+          "attributes": {
+            "account_id": "test-account-123",
+            "id": "test-account-123",
+            "rulesets": []
+          },
+          "index_key": 0,
+          "schema_version": 0
+        }
+      ],
+      "mode": "data",
+      "name": "conditional",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_rulesets"
+    },
+    {
+      "instances": [
+        {
+          "attributes": {
+            "account_id": "test-account-123",
+            "id": "test-account-123",
+            "rulesets": []
+          },
+          "index_key": "http_ratelimit",
+          "schema_version": 0
+        },
+        {
+          "attributes": {
+            "account_id": "test-account-123",
+            "id": "test-account-123",
+            "rulesets": []
+          },
+          "index_key": "http_request_firewall_custom",
+          "schema_version": 0
+        },
+        {
+          "attributes": {
+            "account_id": "test-account-123",
+            "id": "test-account-123",
+            "rulesets": []
+          },
+          "index_key": "http_request_firewall_managed",
+          "schema_version": 0
+        }
+      ],
+      "mode": "data",
+      "name": "by_phase",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_rulesets"
+    },
+    {
+      "instances": [
+        {
+          "attributes": {
+            "account_id": "test-account-123",
+            "id": "test-account-123",
+            "rulesets": []
+          },
+          "index_key": "account",
+          "schema_version": 0
+        },
+        {
+          "attributes": {
+            "id": "test-zone-456",
+            "rulesets": [],
+            "zone_id": "test-zone-456"
+          },
+          "index_key": "zone",
+          "schema_version": 0
+        }
+      ],
+      "mode": "data",
+      "name": "by_scope",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_rulesets"
+    }
+  ],
+  "serial": 1,
+  "terraform_version": "1.5.0",
+  "version": 4
+}

--- a/integration/v4_to_v5/testdata/rulesets_datasource/input/rulesets.tf
+++ b/integration/v4_to_v5/testdata/rulesets_datasource/input/rulesets.tf
@@ -1,0 +1,153 @@
+# Comprehensive integration test for cloudflare_rulesets datasource migration
+# This file tests various scenarios for v4 to v5 migration
+
+# Variables (no defaults - integration tests should provide these)
+variable "cloudflare_account_id" {
+  type        = string
+  description = "Cloudflare account ID"
+}
+
+variable "cloudflare_zone_id" {
+  type        = string
+  description = "Cloudflare zone ID"
+}
+
+variable "cloudflare_domain" {
+  type        = string
+  description = "Domain for testing"
+}
+
+# Scenario 1: Basic datasource with account_id only
+data "cloudflare_rulesets" "account_all" {
+  account_id = var.cloudflare_account_id
+}
+
+# Scenario 2: Basic datasource with zone_id only
+data "cloudflare_rulesets" "zone_all" {
+  zone_id = var.cloudflare_zone_id
+}
+
+# Scenario 3: Datasource with filter block (simple filter)
+data "cloudflare_rulesets" "filtered_by_name" {
+  account_id = var.cloudflare_account_id
+  filter {
+    name = "my-custom-ruleset"
+  }
+}
+
+# Scenario 4: Datasource with filter block (complex filter - all fields)
+data "cloudflare_rulesets" "filtered_complex" {
+  account_id = var.cloudflare_account_id
+  filter {
+    id      = "abc123def456"
+    name    = "production-ruleset"
+    kind    = "custom"
+    phase   = "http_request_firewall_managed"
+    version = "5"
+  }
+}
+
+# Scenario 5: Datasource with include_rules only
+data "cloudflare_rulesets" "with_rules" {
+  account_id    = var.cloudflare_account_id
+  include_rules = true
+}
+
+# Scenario 6: Datasource with both filter and include_rules
+data "cloudflare_rulesets" "filtered_with_rules" {
+  zone_id       = var.cloudflare_zone_id
+  include_rules = true
+  filter {
+    kind  = "managed"
+    phase = "http_request_firewall_custom"
+  }
+}
+
+# Scenario 7: Datasource with include_rules = false
+data "cloudflare_rulesets" "without_rules" {
+  account_id    = var.cloudflare_account_id
+  include_rules = false
+}
+
+# Scenario 8: Multiple filters testing different phases
+data "cloudflare_rulesets" "firewall_managed" {
+  account_id = var.cloudflare_account_id
+  filter {
+    phase = "http_request_firewall_managed"
+  }
+}
+
+data "cloudflare_rulesets" "firewall_custom" {
+  account_id = var.cloudflare_account_id
+  filter {
+    phase = "http_request_firewall_custom"
+  }
+}
+
+data "cloudflare_rulesets" "rate_limit" {
+  zone_id = var.cloudflare_zone_id
+  filter {
+    phase = "http_ratelimit"
+  }
+}
+
+# Scenario 9: Cross-resource references (datasource output used elsewhere)
+output "all_account_rulesets" {
+  value       = data.cloudflare_rulesets.account_all.rulesets
+  description = "All rulesets for the account"
+}
+
+output "filtered_rulesets" {
+  value       = data.cloudflare_rulesets.filtered_by_name.rulesets
+  description = "Filtered rulesets (filter will be removed in v5)"
+}
+
+output "ruleset_count" {
+  value       = length(data.cloudflare_rulesets.account_all.rulesets)
+  description = "Number of rulesets in account"
+}
+
+# Scenario 10: Conditional datasource usage
+locals {
+  use_account_scope = true
+}
+
+data "cloudflare_rulesets" "conditional" {
+  count      = local.use_account_scope ? 1 : 0
+  account_id = var.cloudflare_account_id
+  filter {
+    kind = "custom"
+  }
+}
+
+# Scenario 11: Datasource with for_each (using a set)
+locals {
+  phases_to_check = toset([
+    "http_request_firewall_managed",
+    "http_request_firewall_custom",
+    "http_ratelimit"
+  ])
+}
+
+data "cloudflare_rulesets" "by_phase" {
+  for_each   = local.phases_to_check
+  account_id = var.cloudflare_account_id
+  filter {
+    phase = each.value
+  }
+}
+
+# Scenario 12: Datasource with for_each (using a map)
+locals {
+  scope_config = {
+    account = var.cloudflare_account_id
+    zone    = var.cloudflare_zone_id
+  }
+}
+
+data "cloudflare_rulesets" "by_scope" {
+  for_each = local.scope_config
+  # Using dynamic attribute selection
+  account_id = each.key == "account" ? each.value : null
+  zone_id    = each.key == "zone" ? each.value : null
+}

--- a/integration/v4_to_v5/testdata/rulesets_datasource/input/terraform.tfstate
+++ b/integration/v4_to_v5/testdata/rulesets_datasource/input/terraform.tfstate
@@ -1,0 +1,298 @@
+{
+  "version": 4,
+  "terraform_version": "1.5.0",
+  "serial": 1,
+  "lineage": "integration-test-rulesets",
+  "outputs": {
+    "all_account_rulesets": {
+      "value": [],
+      "type": ["list", ["object", {"id": "string", "name": "string"}]]
+    },
+    "filtered_rulesets": {
+      "value": [],
+      "type": ["list", ["object", {"id": "string", "name": "string"}]]
+    },
+    "ruleset_count": {
+      "value": 0,
+      "type": "number"
+    }
+  },
+  "resources": [
+    {
+      "mode": "data",
+      "type": "cloudflare_rulesets",
+      "name": "account_all",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "account_id": "test-account-123",
+            "id": "test-account-123",
+            "rulesets": []
+          }
+        }
+      ]
+    },
+    {
+      "mode": "data",
+      "type": "cloudflare_rulesets",
+      "name": "zone_all",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "zone_id": "test-zone-456",
+            "id": "test-zone-456",
+            "rulesets": []
+          }
+        }
+      ]
+    },
+    {
+      "mode": "data",
+      "type": "cloudflare_rulesets",
+      "name": "filtered_by_name",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "account_id": "test-account-123",
+            "filter": {
+              "name": "my-custom-ruleset"
+            },
+            "id": "test-account-123",
+            "rulesets": []
+          }
+        }
+      ]
+    },
+    {
+      "mode": "data",
+      "type": "cloudflare_rulesets",
+      "name": "filtered_complex",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "account_id": "test-account-123",
+            "filter": {
+              "id": "abc123def456",
+              "name": "production-ruleset",
+              "kind": "custom",
+              "phase": "http_request_firewall_managed",
+              "version": "5"
+            },
+            "id": "test-account-123",
+            "rulesets": []
+          }
+        }
+      ]
+    },
+    {
+      "mode": "data",
+      "type": "cloudflare_rulesets",
+      "name": "with_rules",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "account_id": "test-account-123",
+            "include_rules": true,
+            "id": "test-account-123",
+            "rulesets": []
+          }
+        }
+      ]
+    },
+    {
+      "mode": "data",
+      "type": "cloudflare_rulesets",
+      "name": "filtered_with_rules",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "zone_id": "test-zone-456",
+            "include_rules": true,
+            "filter": {
+              "kind": "managed",
+              "phase": "http_request_firewall_custom"
+            },
+            "id": "test-zone-456",
+            "rulesets": []
+          }
+        }
+      ]
+    },
+    {
+      "mode": "data",
+      "type": "cloudflare_rulesets",
+      "name": "without_rules",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "account_id": "test-account-123",
+            "include_rules": false,
+            "id": "test-account-123",
+            "rulesets": []
+          }
+        }
+      ]
+    },
+    {
+      "mode": "data",
+      "type": "cloudflare_rulesets",
+      "name": "firewall_managed",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "account_id": "test-account-123",
+            "filter": {
+              "phase": "http_request_firewall_managed"
+            },
+            "id": "test-account-123",
+            "rulesets": []
+          }
+        }
+      ]
+    },
+    {
+      "mode": "data",
+      "type": "cloudflare_rulesets",
+      "name": "firewall_custom",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "account_id": "test-account-123",
+            "filter": {
+              "phase": "http_request_firewall_custom"
+            },
+            "id": "test-account-123",
+            "rulesets": []
+          }
+        }
+      ]
+    },
+    {
+      "mode": "data",
+      "type": "cloudflare_rulesets",
+      "name": "rate_limit",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "zone_id": "test-zone-456",
+            "filter": {
+              "phase": "http_ratelimit"
+            },
+            "id": "test-zone-456",
+            "rulesets": []
+          }
+        }
+      ]
+    },
+    {
+      "mode": "data",
+      "type": "cloudflare_rulesets",
+      "name": "conditional",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "index_key": 0,
+          "schema_version": 0,
+          "attributes": {
+            "account_id": "test-account-123",
+            "filter": {
+              "kind": "custom"
+            },
+            "id": "test-account-123",
+            "rulesets": []
+          }
+        }
+      ]
+    },
+    {
+      "mode": "data",
+      "type": "cloudflare_rulesets",
+      "name": "by_phase",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "index_key": "http_ratelimit",
+          "schema_version": 0,
+          "attributes": {
+            "account_id": "test-account-123",
+            "filter": {
+              "phase": "http_ratelimit"
+            },
+            "id": "test-account-123",
+            "rulesets": []
+          }
+        },
+        {
+          "index_key": "http_request_firewall_custom",
+          "schema_version": 0,
+          "attributes": {
+            "account_id": "test-account-123",
+            "filter": {
+              "phase": "http_request_firewall_custom"
+            },
+            "id": "test-account-123",
+            "rulesets": []
+          }
+        },
+        {
+          "index_key": "http_request_firewall_managed",
+          "schema_version": 0,
+          "attributes": {
+            "account_id": "test-account-123",
+            "filter": {
+              "phase": "http_request_firewall_managed"
+            },
+            "id": "test-account-123",
+            "rulesets": []
+          }
+        }
+      ]
+    },
+    {
+      "mode": "data",
+      "type": "cloudflare_rulesets",
+      "name": "by_scope",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "index_key": "account",
+          "schema_version": 0,
+          "attributes": {
+            "account_id": "test-account-123",
+            "id": "test-account-123",
+            "rulesets": []
+          }
+        },
+        {
+          "index_key": "zone",
+          "schema_version": 0,
+          "attributes": {
+            "zone_id": "test-zone-456",
+            "id": "test-zone-456",
+            "rulesets": []
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/internal/datasources/rulesets/v4_to_v5.go
+++ b/internal/datasources/rulesets/v4_to_v5.go
@@ -1,0 +1,92 @@
+package rulesets
+
+import (
+	"github.com/hashicorp/hcl/v2/hclwrite"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+
+	"github.com/cloudflare/tf-migrate/internal"
+	"github.com/cloudflare/tf-migrate/internal/transform"
+	tfhcl "github.com/cloudflare/tf-migrate/internal/transform/hcl"
+)
+
+// V4ToV5Migrator handles the migration of cloudflare_rulesets datasource from v4 to v5.
+// Key transformations:
+// 1. Remove filter block (client-side filtering removed in v5)
+// 2. Remove include_rules field (rules not included in v5 list datasource)
+// 3. Keep account_id and zone_id unchanged
+type V4ToV5Migrator struct{}
+
+// NewV4ToV5Migrator creates a new migrator for cloudflare_rulesets datasource v4 to v5.
+func NewV4ToV5Migrator() transform.ResourceTransformer {
+	migrator := &V4ToV5Migrator{}
+	// Register with "data." prefix to distinguish from resource migration
+	internal.RegisterMigrator("data.cloudflare_rulesets", "v4", "v5", migrator)
+	return migrator
+}
+
+// GetResourceType returns the v5 datasource type this migrator handles.
+func (m *V4ToV5Migrator) GetResourceType() string {
+	return "cloudflare_rulesets"
+}
+
+// CanHandle determines if this migrator can handle the given datasource type.
+func (m *V4ToV5Migrator) CanHandle(resourceType string) bool {
+	// Only match datasource type (with "data." prefix)
+	return resourceType == "data.cloudflare_rulesets"
+}
+
+// Preprocess handles string-level transformations before HCL parsing.
+// No preprocessing needed for rulesets datasource migration.
+func (m *V4ToV5Migrator) Preprocess(content string) string {
+	return content
+}
+
+// TransformConfig handles configuration file transformations.
+// Transformations:
+// 1. Remove filter block (TypeList MaxItems:1)
+// 2. Remove include_rules attribute
+func (m *V4ToV5Migrator) TransformConfig(ctx *transform.Context, block *hclwrite.Block) (*transform.TransformResult, error) {
+	body := block.Body()
+
+	// Remove filter block (client-side filtering removed in v5)
+	tfhcl.RemoveBlocksByType(body, "filter")
+
+	// Remove include_rules field (rules not included in v5 list datasource)
+	tfhcl.RemoveAttributes(body, "include_rules")
+
+	return &transform.TransformResult{
+		Blocks:         []*hclwrite.Block{block},
+		RemoveOriginal: false,
+	}, nil
+}
+
+// TransformState handles state file transformations.
+// This function receives a single datasource instance and returns the transformed instance JSON.
+func (m *V4ToV5Migrator) TransformState(ctx *transform.Context, stateJSON gjson.Result, resourcePath, resourceName string) (string, error) {
+	result := stateJSON.String()
+
+	// Check if it's a valid datasource instance
+	if !stateJSON.Exists() || !stateJSON.Get("attributes").Exists() {
+		// Even for invalid instances, set schema_version for v5
+		result, _ = sjson.Set(result, "schema_version", 0)
+		return result, nil
+	}
+
+	attrs := stateJSON.Get("attributes")
+
+	// 1. Remove filter block from state (if present)
+	if attrs.Get("filter").Exists() {
+		result, _ = sjson.Delete(result, "attributes.filter")
+	}
+
+	// 2. Remove include_rules field from state (if present)
+	if attrs.Get("include_rules").Exists() {
+		result, _ = sjson.Delete(result, "attributes.include_rules")
+	}
+
+	// Set schema_version to 0 for v5
+	result, _ = sjson.Set(result, "schema_version", 0)
+
+	return result, nil
+}

--- a/internal/datasources/rulesets/v4_to_v5_test.go
+++ b/internal/datasources/rulesets/v4_to_v5_test.go
@@ -1,0 +1,338 @@
+package rulesets
+
+import (
+	"testing"
+
+	"github.com/cloudflare/tf-migrate/internal/testhelpers"
+)
+
+func TestV4ToV5Transformation(t *testing.T) {
+	migrator := NewV4ToV5Migrator()
+
+	// Test configuration transformations
+	t.Run("ConfigTransformation", func(t *testing.T) {
+		tests := []testhelpers.ConfigTestCase{
+			{
+				Name: "Basic datasource with account_id only",
+				Input: `
+data "cloudflare_rulesets" "test" {
+  account_id = "abc123"
+}`,
+				Expected: `data "cloudflare_rulesets" "test" {
+  account_id = "abc123"
+}`,
+			},
+			{
+				Name: "Datasource with zone_id",
+				Input: `
+data "cloudflare_rulesets" "test" {
+  zone_id = "def456"
+}`,
+				Expected: `data "cloudflare_rulesets" "test" {
+  zone_id = "def456"
+}`,
+			},
+			{
+				Name: "Remove filter block",
+				Input: `
+data "cloudflare_rulesets" "test" {
+  account_id = "abc123"
+  filter {
+    name = "my-ruleset"
+  }
+}`,
+				Expected: `data "cloudflare_rulesets" "test" {
+  account_id = "abc123"
+}`,
+			},
+			{
+				Name: "Remove include_rules field",
+				Input: `
+data "cloudflare_rulesets" "test" {
+  account_id    = "abc123"
+  include_rules = true
+}`,
+				Expected: `data "cloudflare_rulesets" "test" {
+  account_id = "abc123"
+}`,
+			},
+			{
+				Name: "Remove both filter and include_rules",
+				Input: `
+data "cloudflare_rulesets" "test" {
+  account_id    = "abc123"
+  include_rules = true
+  filter {
+    name    = "test"
+    kind    = "custom"
+    phase   = "http_request_firewall_managed"
+  }
+}`,
+				Expected: `data "cloudflare_rulesets" "test" {
+  account_id = "abc123"
+}`,
+			},
+			{
+				Name: "Variable references preserved",
+				Input: `
+data "cloudflare_rulesets" "test" {
+  account_id = var.account_id
+}`,
+				Expected: `data "cloudflare_rulesets" "test" {
+  account_id = var.account_id
+}`,
+			},
+			{
+				Name: "Multiple datasources in one file",
+				Input: `
+data "cloudflare_rulesets" "account_rulesets" {
+  account_id = var.account_id
+}
+
+data "cloudflare_rulesets" "zone_rulesets" {
+  zone_id = var.zone_id
+  filter {
+    kind = "custom"
+  }
+}`,
+				Expected: `data "cloudflare_rulesets" "account_rulesets" {
+  account_id = var.account_id
+}
+
+data "cloudflare_rulesets" "zone_rulesets" {
+  zone_id = var.zone_id
+}`,
+			},
+			{
+				Name: "Empty filter block",
+				Input: `
+data "cloudflare_rulesets" "test" {
+  account_id = "abc123"
+  filter {}
+}`,
+				Expected: `data "cloudflare_rulesets" "test" {
+  account_id = "abc123"
+}`,
+			},
+			{
+				Name: "Complex filter with all fields",
+				Input: `
+data "cloudflare_rulesets" "test" {
+  account_id = "abc123"
+  filter {
+    id      = "ruleset-123"
+    name    = "my-ruleset"
+    kind    = "custom"
+    phase   = "http_request_firewall_managed"
+    version = "1"
+  }
+}`,
+				Expected: `data "cloudflare_rulesets" "test" {
+  account_id = "abc123"
+}`,
+			},
+			{
+				Name: "Filter with partial fields",
+				Input: `
+data "cloudflare_rulesets" "test" {
+  zone_id = "zone-456"
+  filter {
+    phase = "http_request_firewall_custom"
+  }
+}`,
+				Expected: `data "cloudflare_rulesets" "test" {
+  zone_id = "zone-456"
+}`,
+			},
+			{
+				Name: "Include rules with false value",
+				Input: `
+data "cloudflare_rulesets" "test" {
+  account_id    = "abc123"
+  include_rules = false
+}`,
+				Expected: `data "cloudflare_rulesets" "test" {
+  account_id = "abc123"
+}`,
+			},
+		}
+
+		testhelpers.RunConfigTransformTests(t, tests, migrator)
+	})
+
+	// Test state transformations
+	t.Run("StateTransformation", func(t *testing.T) {
+		tests := []testhelpers.StateTestCase{
+			{
+				Name: "Minimal state with account_id",
+				Input: `{
+  "schema_version": 0,
+  "attributes": {
+    "account_id": "abc123",
+    "rulesets": []
+  }
+}`,
+				Expected: `{
+  "schema_version": 0,
+  "attributes": {
+    "account_id": "abc123",
+    "rulesets": []
+  }
+}`,
+			},
+			{
+				Name: "State with filter - filter removed",
+				Input: `{
+  "schema_version": 0,
+  "attributes": {
+    "account_id": "abc123",
+    "filter": {
+      "name": "test"
+    },
+    "rulesets": []
+  }
+}`,
+				Expected: `{
+  "schema_version": 0,
+  "attributes": {
+    "account_id": "abc123",
+    "rulesets": []
+  }
+}`,
+			},
+			{
+				Name: "State with include_rules - field removed",
+				Input: `{
+  "schema_version": 0,
+  "attributes": {
+    "account_id": "abc123",
+    "include_rules": true,
+    "rulesets": []
+  }
+}`,
+				Expected: `{
+  "schema_version": 0,
+  "attributes": {
+    "account_id": "abc123",
+    "rulesets": []
+  }
+}`,
+			},
+			{
+				Name: "State with both filter and include_rules",
+				Input: `{
+  "schema_version": 0,
+  "attributes": {
+    "account_id": "abc123",
+    "filter": {
+      "name": "test",
+      "kind": "custom"
+    },
+    "include_rules": true,
+    "rulesets": []
+  }
+}`,
+				Expected: `{
+  "schema_version": 0,
+  "attributes": {
+    "account_id": "abc123",
+    "rulesets": []
+  }
+}`,
+			},
+			{
+				Name: "State with populated rulesets (computed field untouched)",
+				Input: `{
+  "schema_version": 0,
+  "attributes": {
+    "account_id": "abc123",
+    "rulesets": [
+      {
+        "id": "ruleset-1",
+        "name": "My Ruleset",
+        "description": "Test ruleset",
+        "kind": "custom",
+        "phase": "http_request_firewall_managed",
+        "version": "1"
+      },
+      {
+        "id": "ruleset-2",
+        "name": "Another Ruleset",
+        "kind": "managed",
+        "phase": "http_request_firewall_custom",
+        "version": "2"
+      }
+    ]
+  }
+}`,
+				Expected: `{
+  "schema_version": 0,
+  "attributes": {
+    "account_id": "abc123",
+    "rulesets": [
+      {
+        "id": "ruleset-1",
+        "name": "My Ruleset",
+        "description": "Test ruleset",
+        "kind": "custom",
+        "phase": "http_request_firewall_managed",
+        "version": "1"
+      },
+      {
+        "id": "ruleset-2",
+        "name": "Another Ruleset",
+        "kind": "managed",
+        "phase": "http_request_firewall_custom",
+        "version": "2"
+      }
+    ]
+  }
+}`,
+			},
+			{
+				Name: "State with complex filter object",
+				Input: `{
+  "schema_version": 0,
+  "attributes": {
+    "zone_id": "zone-456",
+    "filter": {
+      "id": "ruleset-123",
+      "name": "test",
+      "kind": "custom",
+      "phase": "http_request_firewall_managed",
+      "version": "1"
+    },
+    "rulesets": []
+  }
+}`,
+				Expected: `{
+  "schema_version": 0,
+  "attributes": {
+    "zone_id": "zone-456",
+    "rulesets": []
+  }
+}`,
+			},
+			{
+				Name: "Empty state - sets schema_version",
+				Input: `{
+  "schema_version": 0
+}`,
+				Expected: `{
+  "schema_version": 0
+}`,
+			},
+			{
+				Name: "State without attributes - sets schema_version",
+				Input: `{
+  "schema_version": 1
+}`,
+				Expected: `{
+  "schema_version": 0
+}`,
+			},
+		}
+
+		testhelpers.RunStateTransformTests(t, tests, migrator)
+	})
+}

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -1,6 +1,7 @@
 package registry
 
 import (
+	rulesetsdata "github.com/cloudflare/tf-migrate/internal/datasources/rulesets"
 	zonedata "github.com/cloudflare/tf-migrate/internal/datasources/zone"
 	zonesdata "github.com/cloudflare/tf-migrate/internal/datasources/zones"
 	"github.com/cloudflare/tf-migrate/internal/resources/access_rule"
@@ -75,6 +76,7 @@ import (
 // Each resource package's NewV4ToV5Migrator function registers itself with the internal registry.
 func RegisterAllMigrations() {
 	// Datasources
+	rulesetsdata.NewV4ToV5Migrator()
 	zonedata.NewV4ToV5Migrator()
 	zonesdata.NewV4ToV5Migrator()
 


### PR DESCRIPTION
# Unit tests w/ coverage
```
=== RUN   TestV4ToV5Transformation
=== RUN   TestV4ToV5Transformation/ConfigTransformation
=== RUN   TestV4ToV5Transformation/ConfigTransformation/Basic_datasource_with_account_id_only
=== RUN   TestV4ToV5Transformation/ConfigTransformation/Datasource_with_zone_id
=== RUN   TestV4ToV5Transformation/ConfigTransformation/Remove_filter_block
=== RUN   TestV4ToV5Transformation/ConfigTransformation/Remove_include_rules_field
=== RUN   TestV4ToV5Transformation/ConfigTransformation/Remove_both_filter_and_include_rules
=== RUN   TestV4ToV5Transformation/ConfigTransformation/Variable_references_preserved
=== RUN   TestV4ToV5Transformation/ConfigTransformation/Multiple_datasources_in_one_file
=== RUN   TestV4ToV5Transformation/ConfigTransformation/Empty_filter_block
=== RUN   TestV4ToV5Transformation/ConfigTransformation/Complex_filter_with_all_fields
=== RUN   TestV4ToV5Transformation/ConfigTransformation/Filter_with_partial_fields
=== RUN   TestV4ToV5Transformation/ConfigTransformation/Include_rules_with_false_value
=== RUN   TestV4ToV5Transformation/StateTransformation
=== RUN   TestV4ToV5Transformation/StateTransformation/Minimal_state_with_account_id
=== RUN   TestV4ToV5Transformation/StateTransformation/State_with_filter_-_filter_removed
=== RUN   TestV4ToV5Transformation/StateTransformation/State_with_include_rules_-_field_removed
=== RUN   TestV4ToV5Transformation/StateTransformation/State_with_both_filter_and_include_rules
=== RUN   TestV4ToV5Transformation/StateTransformation/State_with_populated_rulesets_(computed_field_untouched)
=== RUN   TestV4ToV5Transformation/StateTransformation/State_with_complex_filter_object
=== RUN   TestV4ToV5Transformation/StateTransformation/Empty_state_-_sets_schema_version
=== RUN   TestV4ToV5Transformation/StateTransformation/State_without_attributes_-_sets_schema_version
--- PASS: TestV4ToV5Transformation (0.00s)
    --- PASS: TestV4ToV5Transformation/ConfigTransformation (0.00s)
        --- PASS: TestV4ToV5Transformation/ConfigTransformation/Basic_datasource_with_account_id_only (0.00s)
        --- PASS: TestV4ToV5Transformation/ConfigTransformation/Datasource_with_zone_id (0.00s)
        --- PASS: TestV4ToV5Transformation/ConfigTransformation/Remove_filter_block (0.00s)
        --- PASS: TestV4ToV5Transformation/ConfigTransformation/Remove_include_rules_field (0.00s)
        --- PASS: TestV4ToV5Transformation/ConfigTransformation/Remove_both_filter_and_include_rules (0.00s)
        --- PASS: TestV4ToV5Transformation/ConfigTransformation/Variable_references_preserved (0.00s)
        --- PASS: TestV4ToV5Transformation/ConfigTransformation/Multiple_datasources_in_one_file (0.00s)
        --- PASS: TestV4ToV5Transformation/ConfigTransformation/Empty_filter_block (0.00s)
        --- PASS: TestV4ToV5Transformation/ConfigTransformation/Complex_filter_with_all_fields (0.00s)
        --- PASS: TestV4ToV5Transformation/ConfigTransformation/Filter_with_partial_fields (0.00s)
        --- PASS: TestV4ToV5Transformation/ConfigTransformation/Include_rules_with_false_value (0.00s)
    --- PASS: TestV4ToV5Transformation/StateTransformation (0.00s)
        --- PASS: TestV4ToV5Transformation/StateTransformation/Minimal_state_with_account_id (0.00s)
        --- PASS: TestV4ToV5Transformation/StateTransformation/State_with_filter_-_filter_removed (0.00s)
        --- PASS: TestV4ToV5Transformation/StateTransformation/State_with_include_rules_-_field_removed (0.00s)
        --- PASS: TestV4ToV5Transformation/StateTransformation/State_with_both_filter_and_include_rules (0.00s)
        --- PASS: TestV4ToV5Transformation/StateTransformation/State_with_populated_rulesets_(computed_field_untouched) (0.00s)
        --- PASS: TestV4ToV5Transformation/StateTransformation/State_with_complex_filter_object (0.00s)
        --- PASS: TestV4ToV5Transformation/StateTransformation/Empty_state_-_sets_schema_version (0.00s)
        --- PASS: TestV4ToV5Transformation/StateTransformation/State_without_attributes_-_sets_schema_version (0.00s)
PASS
coverage: 95.2% of statements
ok  	github.com/cloudflare/tf-migrate/internal/datasources/rulesets	1.019s	coverage: 95.2% of statements
```

# Integration tests
```
=== RUN   TestSingleResource
=== RUN   TestSingleResource/rulesets_datasource
--- PASS: TestSingleResource (0.77s)
    --- PASS: TestSingleResource/rulesets_datasource (0.77s)
PASS
ok  	github.com/cloudflare/tf-migrate/integration/v4_to_v5	50.397s
```

# E2E tests
```
========================================
✓ Migration Complete!
========================================

Results:
  Input (v4):  /Users/musa/cf-repos/sdks/migrations/ruleset/tf-migrate/e2e/tf/v4
  Output (v5): /Users/musa/cf-repos/sdks/migrations/ruleset/tf-migrate/e2e/migrated-v4_to_v5

Next steps:
  cd /Users/musa/cf-repos/sdks/migrations/ruleset/tf-migrate/e2e/migrated-v4_to_v5
  terraform init
  terraform plan

✓ Migration successful

Step 3: Testing v5 configurations
Running terraform init in migrated-v4_to_v5/...
✓ Terraform init successful
Running terraform plan in v5/...
✓ Terraform plan shows no changes (expected)
Running terraform apply in v5/...
✓ Terraform apply successful
Capturing v5 state...
✓ Saved v5 state to tmp/v5-state.json

Step 4: Verifying stable state (v5 plan after apply)
Running terraform plan again to check for ongoing drift...
✓ No ongoing drift detected - migration achieved stable state!



========================================
✓ E2E Test Complete!
========================================

Summary:

  Step 1: v4 terraform apply
    Status: ✓ SUCCESS

  Step 2: Migration (v4 → v5)
    Status: ✓ SUCCESS

  Step 3: v5 plan (before apply)
    Status: ✓ No changes needed

  Step 4: v5 terraform apply
    Status: ✓ SUCCESS

  Step 5: v5 plan (after apply)
    Status: ✓ SUCCESS - Stable state achieved
    Result: No changes detected

Logs saved to:
  - /Users/musa/cf-repos/sdks/migrations/ruleset/tf-migrate/e2e/tmp
```