### PR TITLE
feat: add v4->v5 migration support for 'load_balancer_pools' data source

### DIFF
--- a/integration/v4_to_v5/testdata/load_balancer_pools_datasource/expected/load_balancer_pools.tf
+++ b/integration/v4_to_v5/testdata/load_balancer_pools_datasource/expected/load_balancer_pools.tf
@@ -1,0 +1,260 @@
+# Load Balancer Pools datasource v4 test fixtures
+# Comprehensive integration test with 20+ datasource instances
+
+# ========================================
+# Pattern 1-2: Variables & Locals
+# ========================================
+
+variable "cloudflare_account_id" {
+  description = "Cloudflare account ID"
+  type        = string
+}
+
+variable "cloudflare_zone_id" {
+  description = "Cloudflare zone ID"
+  type        = string
+}
+
+variable "cloudflare_domain" {
+  description = "Cloudflare domain"
+  type        = string
+}
+
+# Resource-specific variables with defaults
+variable "pool_name_filter" {
+  type    = string
+  default = "prod-.*"
+}
+
+variable "enable_monitoring" {
+  type    = bool
+  default = true
+}
+
+variable "pool_count" {
+  type    = number
+  default = 3
+}
+
+locals {
+  name_prefix       = "cftftest"
+  common_account_id = var.cloudflare_account_id
+
+  # Complex expression
+  pool_name_pattern = "${local.name_prefix}-pool-.*"
+  backup_pattern    = "backup-.*"
+}
+
+# ========================================
+# Basic Scenarios (from minimal test)
+# ========================================
+
+# Scenario 1: Basic datasource - no filter
+data "cloudflare_load_balancer_pools" "all" {
+  account_id = var.cloudflare_account_id
+}
+
+# Scenario 2: With filter block (to be removed in v5)
+data "cloudflare_load_balancer_pools" "filtered" {
+  account_id = var.cloudflare_account_id
+
+}
+
+# Scenario 3: With variable reference in filter
+data "cloudflare_load_balancer_pools" "with_var" {
+  account_id = var.cloudflare_account_id
+
+}
+
+# Scenario 4: With local reference in filter
+data "cloudflare_load_balancer_pools" "with_local" {
+  account_id = local.common_account_id
+
+}
+
+# Scenario 5: Empty filter block
+data "cloudflare_load_balancer_pools" "empty_filter" {
+  account_id = var.cloudflare_account_id
+
+}
+
+# Scenario 6: Filter with complex expression
+data "cloudflare_load_balancer_pools" "backup_pools" {
+  account_id = var.cloudflare_account_id
+
+}
+
+# ========================================
+# Pattern 3: for_each with maps
+# ========================================
+
+variable "pool_filters" {
+  type = map(object({
+    name_pattern = string
+  }))
+  default = {
+    "production" = {
+      name_pattern = "prod-.*"
+    }
+    "staging" = {
+      name_pattern = "stg-.*"
+    }
+    "development" = {
+      name_pattern = "dev-.*"
+    }
+    "testing" = {
+      name_pattern = "test-.*"
+    }
+  }
+}
+
+data "cloudflare_load_balancer_pools" "by_environment" {
+  for_each = var.pool_filters
+
+  account_id = local.common_account_id
+
+}
+
+# ========================================
+# Pattern 4: for_each with list converted to set
+# ========================================
+
+variable "regions" {
+  type = list(object({
+    key     = string
+    pattern = string
+  }))
+  default = [
+    {
+      key     = "us-east"
+      pattern = ".*-us-east-.*"
+    },
+    {
+      key     = "us-west"
+      pattern = ".*-us-west-.*"
+    },
+    {
+      key     = "eu-central"
+      pattern = ".*-eu-central-.*"
+    }
+  ]
+}
+
+data "cloudflare_load_balancer_pools" "by_region" {
+  for_each = { for idx, region in var.regions : region.key => region }
+
+  account_id = var.cloudflare_account_id
+
+}
+
+# ========================================
+# Pattern 5: Count-based datasources
+# ========================================
+
+data "cloudflare_load_balancer_pools" "pool_batch" {
+  count = var.pool_count
+
+  account_id = var.cloudflare_account_id
+
+}
+
+# ========================================
+# Pattern 6: Conditional datasource creation
+# ========================================
+
+data "cloudflare_load_balancer_pools" "monitoring_pools" {
+  count = var.enable_monitoring ? 1 : 0
+
+  account_id = var.cloudflare_account_id
+
+}
+
+data "cloudflare_load_balancer_pools" "conditional_by_env" {
+  count = var.enable_monitoring ? 2 : 0
+
+  account_id = var.cloudflare_account_id
+
+}
+
+# ========================================
+# Pattern 7: Cross-datasource references
+# ========================================
+
+# Reference all pools first
+data "cloudflare_load_balancer_pools" "primary" {
+  account_id = var.cloudflare_account_id
+}
+
+# Use output from primary datasource in another context
+locals {
+  has_pools = length(data.cloudflare_load_balancer_pools.primary.result) > 0
+}
+
+# ========================================
+# Pattern 9: Terraform functions
+# ========================================
+
+# Using coalesce
+data "cloudflare_load_balancer_pools" "with_coalesce" {
+  account_id = coalesce(local.common_account_id, var.cloudflare_account_id)
+
+}
+
+# Using conditional expression
+data "cloudflare_load_balancer_pools" "conditional_filter" {
+  account_id = var.cloudflare_account_id
+
+}
+
+# Using join/format
+locals {
+  filter_patterns  = ["api-.*", "web-.*"]
+  combined_pattern = join("|", local.filter_patterns)
+}
+
+data "cloudflare_load_balancer_pools" "combined_pattern" {
+  account_id = var.cloudflare_account_id
+
+}
+
+# ========================================
+# Outputs to test pools → result rename
+# ========================================
+
+# Basic output - array access
+output "all_pool_ids" {
+  value       = data.cloudflare_load_balancer_pools.all.result[*].id
+  description = "All pool IDs"
+}
+
+output "all_pool_names" {
+  value       = data.cloudflare_load_balancer_pools.all.result[*].name
+  description = "All pool names"
+}
+
+# Filtered output
+output "filtered_pool_names" {
+  value       = data.cloudflare_load_balancer_pools.filtered.result[*].name
+  description = "Filtered pool names"
+}
+
+# Complex output with nested data access
+output "primary_pool_origins" {
+  value = {
+    for pool in data.cloudflare_load_balancer_pools.primary.result :
+    pool.id => length(lookup(pool, "origins", []))
+  }
+  description = "Origin count per pool"
+}
+
+# Output testing attribute access patterns
+output "pool_details" {
+  value = [
+    for pool in data.cloudflare_load_balancer_pools.all.result : {
+      id      = pool.id
+      name    = pool.name
+      enabled = lookup(pool, "enabled", true)
+    }
+  ]
+  description = "Pool details"
+}

--- a/integration/v4_to_v5/testdata/load_balancer_pools_datasource/expected/terraform.tfstate
+++ b/integration/v4_to_v5/testdata/load_balancer_pools_datasource/expected/terraform.tfstate
@@ -1,0 +1,373 @@
+{
+  "lineage": "test-lineage",
+  "outputs": {},
+  "resources": [
+    {
+      "instances": [
+        {
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "id": "checksum-all",
+            "result": [
+              {
+                "enabled": true,
+                "id": "pool1",
+                "name": "example-pool-1"
+              },
+              {
+                "enabled": false,
+                "id": "pool2",
+                "name": "example-pool-2"
+              }
+            ]
+          },
+          "schema_version": 0
+        }
+      ],
+      "mode": "data",
+      "name": "all",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_load_balancer_pools"
+    },
+    {
+      "instances": [
+        {
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "id": "checksum-filtered",
+            "result": [
+              {
+                "enabled": true,
+                "id": "pool1",
+                "name": "example-pool-1"
+              }
+            ]
+          },
+          "schema_version": 0
+        }
+      ],
+      "mode": "data",
+      "name": "filtered",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_load_balancer_pools"
+    },
+    {
+      "instances": [
+        {
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "id": "checksum-with-var",
+            "result": [
+              {
+                "enabled": true,
+                "id": "pool-prod-1",
+                "name": "prod-api-pool"
+              }
+            ]
+          },
+          "schema_version": 0
+        }
+      ],
+      "mode": "data",
+      "name": "with_var",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_load_balancer_pools"
+    },
+    {
+      "instances": [
+        {
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "id": "checksum-with-local",
+            "result": []
+          },
+          "schema_version": 0
+        }
+      ],
+      "mode": "data",
+      "name": "with_local",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_load_balancer_pools"
+    },
+    {
+      "instances": [
+        {
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "id": "checksum-empty-filter",
+            "result": [
+              {
+                "enabled": true,
+                "id": "pool1",
+                "name": "example-pool-1"
+              }
+            ]
+          },
+          "schema_version": 0
+        }
+      ],
+      "mode": "data",
+      "name": "empty_filter",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_load_balancer_pools"
+    },
+    {
+      "instances": [
+        {
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "id": "checksum-backup",
+            "result": []
+          },
+          "schema_version": 0
+        }
+      ],
+      "mode": "data",
+      "name": "backup_pools",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_load_balancer_pools"
+    },
+    {
+      "instances": [
+        {
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "id": "checksum-env-dev",
+            "result": []
+          },
+          "index_key": "development",
+          "schema_version": 0
+        },
+        {
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "id": "checksum-env-prod",
+            "result": [
+              {
+                "enabled": true,
+                "id": "pool-prod-1",
+                "name": "prod-api-pool"
+              }
+            ]
+          },
+          "index_key": "production",
+          "schema_version": 0
+        },
+        {
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "id": "checksum-env-stg",
+            "result": []
+          },
+          "index_key": "staging",
+          "schema_version": 0
+        },
+        {
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "id": "checksum-env-test",
+            "result": []
+          },
+          "index_key": "testing",
+          "schema_version": 0
+        }
+      ],
+      "mode": "data",
+      "name": "by_environment",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_load_balancer_pools"
+    },
+    {
+      "instances": [
+        {
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "id": "checksum-region-eu",
+            "result": []
+          },
+          "index_key": "eu-central",
+          "schema_version": 0
+        },
+        {
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "id": "checksum-region-us-east",
+            "result": []
+          },
+          "index_key": "us-east",
+          "schema_version": 0
+        },
+        {
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "id": "checksum-region-us-west",
+            "result": []
+          },
+          "index_key": "us-west",
+          "schema_version": 0
+        }
+      ],
+      "mode": "data",
+      "name": "by_region",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_load_balancer_pools"
+    },
+    {
+      "instances": [
+        {
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "id": "checksum-batch-0",
+            "result": []
+          },
+          "index_key": 0,
+          "schema_version": 0
+        },
+        {
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "id": "checksum-batch-1",
+            "result": []
+          },
+          "index_key": 1,
+          "schema_version": 0
+        },
+        {
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "id": "checksum-batch-2",
+            "result": []
+          },
+          "index_key": 2,
+          "schema_version": 0
+        }
+      ],
+      "mode": "data",
+      "name": "pool_batch",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_load_balancer_pools"
+    },
+    {
+      "instances": [
+        {
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "id": "checksum-monitoring",
+            "result": []
+          },
+          "index_key": 0,
+          "schema_version": 0
+        }
+      ],
+      "mode": "data",
+      "name": "monitoring_pools",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_load_balancer_pools"
+    },
+    {
+      "instances": [
+        {
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "id": "checksum-conditional-primary",
+            "result": []
+          },
+          "index_key": 0,
+          "schema_version": 0
+        },
+        {
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "id": "checksum-conditional-secondary",
+            "result": []
+          },
+          "index_key": 1,
+          "schema_version": 0
+        }
+      ],
+      "mode": "data",
+      "name": "conditional_by_env",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_load_balancer_pools"
+    },
+    {
+      "instances": [
+        {
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "id": "checksum-primary",
+            "result": [
+              {
+                "enabled": true,
+                "id": "pool1",
+                "name": "example-pool-1",
+                "origins": [
+                  {
+                    "address": "192.168.1.1",
+                    "name": "origin1"
+                  }
+                ]
+              }
+            ]
+          },
+          "schema_version": 0
+        }
+      ],
+      "mode": "data",
+      "name": "primary",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_load_balancer_pools"
+    },
+    {
+      "instances": [
+        {
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "id": "checksum-coalesce",
+            "result": []
+          },
+          "schema_version": 0
+        }
+      ],
+      "mode": "data",
+      "name": "with_coalesce",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_load_balancer_pools"
+    },
+    {
+      "instances": [
+        {
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "id": "checksum-conditional-filter",
+            "result": []
+          },
+          "schema_version": 0
+        }
+      ],
+      "mode": "data",
+      "name": "conditional_filter",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_load_balancer_pools"
+    },
+    {
+      "instances": [
+        {
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "id": "checksum-combined",
+            "result": []
+          },
+          "schema_version": 0
+        }
+      ],
+      "mode": "data",
+      "name": "combined_pattern",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_load_balancer_pools"
+    }
+  ],
+  "serial": 1,
+  "terraform_version": "1.5.0",
+  "version": 4
+}

--- a/integration/v4_to_v5/testdata/load_balancer_pools_datasource/input/load_balancer_pools.tf
+++ b/integration/v4_to_v5/testdata/load_balancer_pools_datasource/input/load_balancer_pools.tf
@@ -1,0 +1,298 @@
+# Load Balancer Pools datasource v4 test fixtures
+# Comprehensive integration test with 20+ datasource instances
+
+# ========================================
+# Pattern 1-2: Variables & Locals
+# ========================================
+
+variable "cloudflare_account_id" {
+  description = "Cloudflare account ID"
+  type        = string
+}
+
+variable "cloudflare_zone_id" {
+  description = "Cloudflare zone ID"
+  type        = string
+}
+
+variable "cloudflare_domain" {
+  description = "Cloudflare domain"
+  type        = string
+}
+
+# Resource-specific variables with defaults
+variable "pool_name_filter" {
+  type    = string
+  default = "prod-.*"
+}
+
+variable "enable_monitoring" {
+  type    = bool
+  default = true
+}
+
+variable "pool_count" {
+  type    = number
+  default = 3
+}
+
+locals {
+  name_prefix = "cftftest"
+  common_account_id = var.cloudflare_account_id
+
+  # Complex expression
+  pool_name_pattern = "${local.name_prefix}-pool-.*"
+  backup_pattern    = "backup-.*"
+}
+
+# ========================================
+# Basic Scenarios (from minimal test)
+# ========================================
+
+# Scenario 1: Basic datasource - no filter
+data "cloudflare_load_balancer_pools" "all" {
+  account_id = var.cloudflare_account_id
+}
+
+# Scenario 2: With filter block (to be removed in v5)
+data "cloudflare_load_balancer_pools" "filtered" {
+  account_id = var.cloudflare_account_id
+
+  filter {
+    name = "example-.*"
+  }
+}
+
+# Scenario 3: With variable reference in filter
+data "cloudflare_load_balancer_pools" "with_var" {
+  account_id = var.cloudflare_account_id
+
+  filter {
+    name = var.pool_name_filter
+  }
+}
+
+# Scenario 4: With local reference in filter
+data "cloudflare_load_balancer_pools" "with_local" {
+  account_id = local.common_account_id
+
+  filter {
+    name = local.pool_name_pattern
+  }
+}
+
+# Scenario 5: Empty filter block
+data "cloudflare_load_balancer_pools" "empty_filter" {
+  account_id = var.cloudflare_account_id
+
+  filter {
+  }
+}
+
+# Scenario 6: Filter with complex expression
+data "cloudflare_load_balancer_pools" "backup_pools" {
+  account_id = var.cloudflare_account_id
+
+  filter {
+    name = local.backup_pattern
+  }
+}
+
+# ========================================
+# Pattern 3: for_each with maps
+# ========================================
+
+variable "pool_filters" {
+  type = map(object({
+    name_pattern = string
+  }))
+  default = {
+    "production" = {
+      name_pattern = "prod-.*"
+    }
+    "staging" = {
+      name_pattern = "stg-.*"
+    }
+    "development" = {
+      name_pattern = "dev-.*"
+    }
+    "testing" = {
+      name_pattern = "test-.*"
+    }
+  }
+}
+
+data "cloudflare_load_balancer_pools" "by_environment" {
+  for_each = var.pool_filters
+
+  account_id = local.common_account_id
+
+  filter {
+    name = each.value.name_pattern
+  }
+}
+
+# ========================================
+# Pattern 4: for_each with list converted to set
+# ========================================
+
+variable "regions" {
+  type = list(object({
+    key     = string
+    pattern = string
+  }))
+  default = [
+    {
+      key     = "us-east"
+      pattern = ".*-us-east-.*"
+    },
+    {
+      key     = "us-west"
+      pattern = ".*-us-west-.*"
+    },
+    {
+      key     = "eu-central"
+      pattern = ".*-eu-central-.*"
+    }
+  ]
+}
+
+data "cloudflare_load_balancer_pools" "by_region" {
+  for_each = { for idx, region in var.regions : region.key => region }
+
+  account_id = var.cloudflare_account_id
+
+  filter {
+    name = each.value.pattern
+  }
+}
+
+# ========================================
+# Pattern 5: Count-based datasources
+# ========================================
+
+data "cloudflare_load_balancer_pools" "pool_batch" {
+  count = var.pool_count
+
+  account_id = var.cloudflare_account_id
+
+  filter {
+    name = "batch-${count.index}-.*"
+  }
+}
+
+# ========================================
+# Pattern 6: Conditional datasource creation
+# ========================================
+
+data "cloudflare_load_balancer_pools" "monitoring_pools" {
+  count = var.enable_monitoring ? 1 : 0
+
+  account_id = var.cloudflare_account_id
+
+  filter {
+    name = "monitor-.*"
+  }
+}
+
+data "cloudflare_load_balancer_pools" "conditional_by_env" {
+  count = var.enable_monitoring ? 2 : 0
+
+  account_id = var.cloudflare_account_id
+
+  filter {
+    name = count.index == 0 ? "primary-.*" : "secondary-.*"
+  }
+}
+
+# ========================================
+# Pattern 7: Cross-datasource references
+# ========================================
+
+# Reference all pools first
+data "cloudflare_load_balancer_pools" "primary" {
+  account_id = var.cloudflare_account_id
+}
+
+# Use output from primary datasource in another context
+locals {
+  has_pools = length(data.cloudflare_load_balancer_pools.primary.pools) > 0
+}
+
+# ========================================
+# Pattern 9: Terraform functions
+# ========================================
+
+# Using coalesce
+data "cloudflare_load_balancer_pools" "with_coalesce" {
+  account_id = coalesce(local.common_account_id, var.cloudflare_account_id)
+
+  filter {
+    name = coalesce(var.pool_name_filter, "default-.*")
+  }
+}
+
+# Using conditional expression
+data "cloudflare_load_balancer_pools" "conditional_filter" {
+  account_id = var.cloudflare_account_id
+
+  filter {
+    name = var.enable_monitoring ? "monitored-.*" : "unmonitored-.*"
+  }
+}
+
+# Using join/format
+locals {
+  filter_patterns = ["api-.*", "web-.*"]
+  combined_pattern = join("|", local.filter_patterns)
+}
+
+data "cloudflare_load_balancer_pools" "combined_pattern" {
+  account_id = var.cloudflare_account_id
+
+  filter {
+    name = format("%s-pool-.*", local.name_prefix)
+  }
+}
+
+# ========================================
+# Outputs to test pools → result rename
+# ========================================
+
+# Basic output - array access
+output "all_pool_ids" {
+  value       = data.cloudflare_load_balancer_pools.all.pools[*].id
+  description = "All pool IDs"
+}
+
+output "all_pool_names" {
+  value       = data.cloudflare_load_balancer_pools.all.pools[*].name
+  description = "All pool names"
+}
+
+# Filtered output
+output "filtered_pool_names" {
+  value       = data.cloudflare_load_balancer_pools.filtered.pools[*].name
+  description = "Filtered pool names"
+}
+
+# Complex output with nested data access
+output "primary_pool_origins" {
+  value = {
+    for pool in data.cloudflare_load_balancer_pools.primary.pools :
+    pool.id => length(lookup(pool, "origins", []))
+  }
+  description = "Origin count per pool"
+}
+
+# Output testing attribute access patterns
+output "pool_details" {
+  value = [
+    for pool in data.cloudflare_load_balancer_pools.all.pools : {
+      id      = pool.id
+      name    = pool.name
+      enabled = lookup(pool, "enabled", true)
+    }
+  ]
+  description = "Pool details"
+}

--- a/integration/v4_to_v5/testdata/load_balancer_pools_datasource/input/terraform.tfstate
+++ b/integration/v4_to_v5/testdata/load_balancer_pools_datasource/input/terraform.tfstate
@@ -1,0 +1,373 @@
+{
+  "lineage": "test-lineage",
+  "outputs": {},
+  "resources": [
+    {
+      "instances": [
+        {
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "id": "checksum-all",
+            "result": [
+              {
+                "enabled": true,
+                "id": "pool1",
+                "name": "example-pool-1"
+              },
+              {
+                "enabled": false,
+                "id": "pool2",
+                "name": "example-pool-2"
+              }
+            ]
+          },
+          "schema_version": 0
+        }
+      ],
+      "mode": "data",
+      "name": "all",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_load_balancer_pools"
+    },
+    {
+      "instances": [
+        {
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "id": "checksum-filtered",
+            "result": [
+              {
+                "enabled": true,
+                "id": "pool1",
+                "name": "example-pool-1"
+              }
+            ]
+          },
+          "schema_version": 0
+        }
+      ],
+      "mode": "data",
+      "name": "filtered",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_load_balancer_pools"
+    },
+    {
+      "instances": [
+        {
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "id": "checksum-with-var",
+            "result": [
+              {
+                "enabled": true,
+                "id": "pool-prod-1",
+                "name": "prod-api-pool"
+              }
+            ]
+          },
+          "schema_version": 0
+        }
+      ],
+      "mode": "data",
+      "name": "with_var",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_load_balancer_pools"
+    },
+    {
+      "instances": [
+        {
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "id": "checksum-with-local",
+            "result": []
+          },
+          "schema_version": 0
+        }
+      ],
+      "mode": "data",
+      "name": "with_local",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_load_balancer_pools"
+    },
+    {
+      "instances": [
+        {
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "id": "checksum-empty-filter",
+            "result": [
+              {
+                "enabled": true,
+                "id": "pool1",
+                "name": "example-pool-1"
+              }
+            ]
+          },
+          "schema_version": 0
+        }
+      ],
+      "mode": "data",
+      "name": "empty_filter",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_load_balancer_pools"
+    },
+    {
+      "instances": [
+        {
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "id": "checksum-backup",
+            "result": []
+          },
+          "schema_version": 0
+        }
+      ],
+      "mode": "data",
+      "name": "backup_pools",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_load_balancer_pools"
+    },
+    {
+      "instances": [
+        {
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "id": "checksum-env-dev",
+            "result": []
+          },
+          "index_key": "development",
+          "schema_version": 0
+        },
+        {
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "id": "checksum-env-prod",
+            "result": [
+              {
+                "enabled": true,
+                "id": "pool-prod-1",
+                "name": "prod-api-pool"
+              }
+            ]
+          },
+          "index_key": "production",
+          "schema_version": 0
+        },
+        {
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "id": "checksum-env-stg",
+            "result": []
+          },
+          "index_key": "staging",
+          "schema_version": 0
+        },
+        {
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "id": "checksum-env-test",
+            "result": []
+          },
+          "index_key": "testing",
+          "schema_version": 0
+        }
+      ],
+      "mode": "data",
+      "name": "by_environment",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_load_balancer_pools"
+    },
+    {
+      "instances": [
+        {
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "id": "checksum-region-eu",
+            "result": []
+          },
+          "index_key": "eu-central",
+          "schema_version": 0
+        },
+        {
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "id": "checksum-region-us-east",
+            "result": []
+          },
+          "index_key": "us-east",
+          "schema_version": 0
+        },
+        {
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "id": "checksum-region-us-west",
+            "result": []
+          },
+          "index_key": "us-west",
+          "schema_version": 0
+        }
+      ],
+      "mode": "data",
+      "name": "by_region",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_load_balancer_pools"
+    },
+    {
+      "instances": [
+        {
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "id": "checksum-batch-0",
+            "result": []
+          },
+          "index_key": 0,
+          "schema_version": 0
+        },
+        {
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "id": "checksum-batch-1",
+            "result": []
+          },
+          "index_key": 1,
+          "schema_version": 0
+        },
+        {
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "id": "checksum-batch-2",
+            "result": []
+          },
+          "index_key": 2,
+          "schema_version": 0
+        }
+      ],
+      "mode": "data",
+      "name": "pool_batch",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_load_balancer_pools"
+    },
+    {
+      "instances": [
+        {
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "id": "checksum-monitoring",
+            "result": []
+          },
+          "index_key": 0,
+          "schema_version": 0
+        }
+      ],
+      "mode": "data",
+      "name": "monitoring_pools",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_load_balancer_pools"
+    },
+    {
+      "instances": [
+        {
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "id": "checksum-conditional-primary",
+            "result": []
+          },
+          "index_key": 0,
+          "schema_version": 0
+        },
+        {
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "id": "checksum-conditional-secondary",
+            "result": []
+          },
+          "index_key": 1,
+          "schema_version": 0
+        }
+      ],
+      "mode": "data",
+      "name": "conditional_by_env",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_load_balancer_pools"
+    },
+    {
+      "instances": [
+        {
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "id": "checksum-primary",
+            "result": [
+              {
+                "enabled": true,
+                "id": "pool1",
+                "name": "example-pool-1",
+                "origins": [
+                  {
+                    "address": "192.168.1.1",
+                    "name": "origin1"
+                  }
+                ]
+              }
+            ]
+          },
+          "schema_version": 0
+        }
+      ],
+      "mode": "data",
+      "name": "primary",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_load_balancer_pools"
+    },
+    {
+      "instances": [
+        {
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "id": "checksum-coalesce",
+            "result": []
+          },
+          "schema_version": 0
+        }
+      ],
+      "mode": "data",
+      "name": "with_coalesce",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_load_balancer_pools"
+    },
+    {
+      "instances": [
+        {
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "id": "checksum-conditional-filter",
+            "result": []
+          },
+          "schema_version": 0
+        }
+      ],
+      "mode": "data",
+      "name": "conditional_filter",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_load_balancer_pools"
+    },
+    {
+      "instances": [
+        {
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "id": "checksum-combined",
+            "result": []
+          },
+          "schema_version": 0
+        }
+      ],
+      "mode": "data",
+      "name": "combined_pattern",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "type": "cloudflare_load_balancer_pools"
+    }
+  ],
+  "serial": 1,
+  "terraform_version": "1.5.0",
+  "version": 4
+}

--- a/integration/v4_to_v5/testdata/load_balancer_pools_datasource/input/terraform.tfstate.backup
+++ b/integration/v4_to_v5/testdata/load_balancer_pools_datasource/input/terraform.tfstate.backup
@@ -1,0 +1,476 @@
+{
+  "version": 4,
+  "terraform_version": "1.5.0",
+  "serial": 1,
+  "lineage": "test-lineage",
+  "outputs": {},
+  "resources": [
+    {
+      "mode": "data",
+      "type": "cloudflare_load_balancer_pools",
+      "name": "all",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "id": "checksum-all",
+            "pools": [
+              {
+                "id": "pool1",
+                "name": "example-pool-1",
+                "enabled": true
+              },
+              {
+                "id": "pool2",
+                "name": "example-pool-2",
+                "enabled": false
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "mode": "data",
+      "type": "cloudflare_load_balancer_pools",
+      "name": "filtered",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "filter": [
+              {
+                "name": "example-.*"
+              }
+            ],
+            "id": "checksum-filtered",
+            "pools": [
+              {
+                "id": "pool1",
+                "name": "example-pool-1",
+                "enabled": true
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "mode": "data",
+      "type": "cloudflare_load_balancer_pools",
+      "name": "with_var",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "filter": [
+              {
+                "name": "prod-.*"
+              }
+            ],
+            "id": "checksum-with-var",
+            "pools": [
+              {
+                "id": "pool-prod-1",
+                "name": "prod-api-pool",
+                "enabled": true
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "mode": "data",
+      "type": "cloudflare_load_balancer_pools",
+      "name": "with_local",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "filter": [
+              {
+                "name": "cftftest-pool-.*"
+              }
+            ],
+            "id": "checksum-with-local",
+            "pools": []
+          }
+        }
+      ]
+    },
+    {
+      "mode": "data",
+      "type": "cloudflare_load_balancer_pools",
+      "name": "empty_filter",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "filter": [
+              {}
+            ],
+            "id": "checksum-empty-filter",
+            "pools": [
+              {
+                "id": "pool1",
+                "name": "example-pool-1",
+                "enabled": true
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "mode": "data",
+      "type": "cloudflare_load_balancer_pools",
+      "name": "backup_pools",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "filter": [
+              {
+                "name": "backup-.*"
+              }
+            ],
+            "id": "checksum-backup",
+            "pools": []
+          }
+        }
+      ]
+    },
+    {
+      "mode": "data",
+      "type": "cloudflare_load_balancer_pools",
+      "name": "by_environment",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "index_key": "development",
+          "schema_version": 0,
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "filter": [
+              {
+                "name": "dev-.*"
+              }
+            ],
+            "id": "checksum-env-dev",
+            "pools": []
+          }
+        },
+        {
+          "index_key": "production",
+          "schema_version": 0,
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "filter": [
+              {
+                "name": "prod-.*"
+              }
+            ],
+            "id": "checksum-env-prod",
+            "pools": [
+              {
+                "id": "pool-prod-1",
+                "name": "prod-api-pool",
+                "enabled": true
+              }
+            ]
+          }
+        },
+        {
+          "index_key": "staging",
+          "schema_version": 0,
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "filter": [
+              {
+                "name": "stg-.*"
+              }
+            ],
+            "id": "checksum-env-stg",
+            "pools": []
+          }
+        },
+        {
+          "index_key": "testing",
+          "schema_version": 0,
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "filter": [
+              {
+                "name": "test-.*"
+              }
+            ],
+            "id": "checksum-env-test",
+            "pools": []
+          }
+        }
+      ]
+    },
+    {
+      "mode": "data",
+      "type": "cloudflare_load_balancer_pools",
+      "name": "by_region",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "index_key": "eu-central",
+          "schema_version": 0,
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "filter": [
+              {
+                "name": ".*-eu-central-.*"
+              }
+            ],
+            "id": "checksum-region-eu",
+            "pools": []
+          }
+        },
+        {
+          "index_key": "us-east",
+          "schema_version": 0,
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "filter": [
+              {
+                "name": ".*-us-east-.*"
+              }
+            ],
+            "id": "checksum-region-us-east",
+            "pools": []
+          }
+        },
+        {
+          "index_key": "us-west",
+          "schema_version": 0,
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "filter": [
+              {
+                "name": ".*-us-west-.*"
+              }
+            ],
+            "id": "checksum-region-us-west",
+            "pools": []
+          }
+        }
+      ]
+    },
+    {
+      "mode": "data",
+      "type": "cloudflare_load_balancer_pools",
+      "name": "pool_batch",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "index_key": 0,
+          "schema_version": 0,
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "filter": [
+              {
+                "name": "batch-0-.*"
+              }
+            ],
+            "id": "checksum-batch-0",
+            "pools": []
+          }
+        },
+        {
+          "index_key": 1,
+          "schema_version": 0,
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "filter": [
+              {
+                "name": "batch-1-.*"
+              }
+            ],
+            "id": "checksum-batch-1",
+            "pools": []
+          }
+        },
+        {
+          "index_key": 2,
+          "schema_version": 0,
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "filter": [
+              {
+                "name": "batch-2-.*"
+              }
+            ],
+            "id": "checksum-batch-2",
+            "pools": []
+          }
+        }
+      ]
+    },
+    {
+      "mode": "data",
+      "type": "cloudflare_load_balancer_pools",
+      "name": "monitoring_pools",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "index_key": 0,
+          "schema_version": 0,
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "filter": [
+              {
+                "name": "monitor-.*"
+              }
+            ],
+            "id": "checksum-monitoring",
+            "pools": []
+          }
+        }
+      ]
+    },
+    {
+      "mode": "data",
+      "type": "cloudflare_load_balancer_pools",
+      "name": "conditional_by_env",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "index_key": 0,
+          "schema_version": 0,
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "filter": [
+              {
+                "name": "primary-.*"
+              }
+            ],
+            "id": "checksum-conditional-primary",
+            "pools": []
+          }
+        },
+        {
+          "index_key": 1,
+          "schema_version": 0,
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "filter": [
+              {
+                "name": "secondary-.*"
+              }
+            ],
+            "id": "checksum-conditional-secondary",
+            "pools": []
+          }
+        }
+      ]
+    },
+    {
+      "mode": "data",
+      "type": "cloudflare_load_balancer_pools",
+      "name": "primary",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "id": "checksum-primary",
+            "pools": [
+              {
+                "id": "pool1",
+                "name": "example-pool-1",
+                "enabled": true,
+                "origins": [
+                  {
+                    "name": "origin1",
+                    "address": "192.168.1.1"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "mode": "data",
+      "type": "cloudflare_load_balancer_pools",
+      "name": "with_coalesce",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "filter": [
+              {
+                "name": "prod-.*"
+              }
+            ],
+            "id": "checksum-coalesce",
+            "pools": []
+          }
+        }
+      ]
+    },
+    {
+      "mode": "data",
+      "type": "cloudflare_load_balancer_pools",
+      "name": "conditional_filter",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "filter": [
+              {
+                "name": "monitored-.*"
+              }
+            ],
+            "id": "checksum-conditional-filter",
+            "pools": []
+          }
+        }
+      ]
+    },
+    {
+      "mode": "data",
+      "type": "cloudflare_load_balancer_pools",
+      "name": "combined_pattern",
+      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "account_id": "f037e56e89293a057740de681ac9abbe",
+            "filter": [
+              {
+                "name": "cftftest-pool-.*"
+              }
+            ],
+            "id": "checksum-combined",
+            "pools": []
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/internal/datasources/load_balancer_pools/v4_to_v5.go
+++ b/internal/datasources/load_balancer_pools/v4_to_v5.go
@@ -1,0 +1,118 @@
+package load_balancer_pools
+
+import (
+	"github.com/hashicorp/hcl/v2/hclwrite"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+
+	"github.com/cloudflare/tf-migrate/internal"
+	"github.com/cloudflare/tf-migrate/internal/transform"
+	tfhcl "github.com/cloudflare/tf-migrate/internal/transform/hcl"
+)
+
+// V4ToV5Migrator handles the migration of cloudflare_load_balancer_pools datasource from v4 to v5.
+// Key transformations:
+// 1. Remove filter block (no v5 equivalent - v4's regex name filtering not available in v5)
+// 2. Minimal state transformation (datasources are mostly computed)
+// 3. Output field renamed: pools → result (handled by provider, not migration)
+type V4ToV5Migrator struct{}
+
+// NewV4ToV5Migrator creates a new migrator for cloudflare_load_balancer_pools datasource v4 to v5.
+func NewV4ToV5Migrator() transform.ResourceTransformer {
+	migrator := &V4ToV5Migrator{}
+	// Register with "data." prefix to distinguish from resource migration
+	internal.RegisterMigrator("data.cloudflare_load_balancer_pools", "v4", "v5", migrator)
+	return migrator
+}
+
+// GetResourceType returns the v5 datasource type this migrator handles.
+func (m *V4ToV5Migrator) GetResourceType() string {
+	return "cloudflare_load_balancer_pools"
+}
+
+// GetAttributeRenames returns attribute renames for cross-file reference updates.
+// The load_balancer_pools datasource changed its output attribute from "pools" to "result".
+func (m *V4ToV5Migrator) GetAttributeRenames() []transform.AttributeRename {
+	return []transform.AttributeRename{
+		{
+			ResourceType: "data.cloudflare_load_balancer_pools",
+			OldAttribute: "pools",
+			NewAttribute: "result",
+		},
+	}
+}
+
+// CanHandle determines if this migrator can handle the given datasource type.
+func (m *V4ToV5Migrator) CanHandle(resourceType string) bool {
+	// Only match datasource type (with "data." prefix)
+	return resourceType == "data.cloudflare_load_balancer_pools"
+}
+
+// Preprocess handles string-level transformations before HCL parsing.
+// No preprocessing needed for load_balancer_pools datasource migration.
+func (m *V4ToV5Migrator) Preprocess(content string) string {
+	return content
+}
+
+// TransformConfig handles configuration file transformations.
+// Main transformation:
+// - Remove filter block (v4's regex name filtering has no v5 equivalent)
+// - account_id remains unchanged
+// - New v5 fields (monitor, max_items) are not added during migration
+func (m *V4ToV5Migrator) TransformConfig(ctx *transform.Context, block *hclwrite.Block) (*transform.TransformResult, error) {
+	body := block.Body()
+
+	// Remove filter block (no v5 equivalent for regex name filtering)
+	tfhcl.RemoveBlocksByType(body, "filter")
+
+	// account_id stays as-is (required in both v4 and v5)
+	// monitor and max_items are new in v5 - not added during migration
+
+	return &transform.TransformResult{
+		Blocks:         []*hclwrite.Block{block},
+		RemoveOriginal: false,
+	}, nil
+}
+
+// TransformState handles state file transformations.
+// Main transformations:
+// 1. Set schema_version = 0
+// 2. Remove filter field (if present)
+// 3. Rename pools → result (preserving data)
+func (m *V4ToV5Migrator) TransformState(ctx *transform.Context, instance gjson.Result, resourcePath, resourceName string) (string, error) {
+	result := instance.String()
+	attrs := instance.Get("attributes")
+
+	if !attrs.Exists() {
+		// No attributes to transform, but still set schema_version
+		result, _ = sjson.Set(result, "schema_version", 0)
+		return result, nil
+	}
+
+	// Set schema_version to 0 for v5
+	result, _ = sjson.Set(result, "schema_version", 0)
+
+	// Remove filter field (if present in state)
+	result, _ = sjson.Delete(result, "attributes.filter")
+
+	// Rename pools → result (preserving data)
+	poolsField := attrs.Get("pools")
+	if poolsField.Exists() {
+		if poolsField.IsArray() {
+			// Copy pools to result
+			result, _ = sjson.Set(result, "attributes.result", poolsField.Value())
+			// Delete old pools field
+			result, _ = sjson.Delete(result, "attributes.pools")
+		} else {
+			// pools is null or missing - just delete it
+			result, _ = sjson.Delete(result, "attributes.pools")
+		}
+	}
+
+	return result, nil
+}
+
+func init() {
+	// Register the migrator on package initialization
+	NewV4ToV5Migrator()
+}

--- a/internal/datasources/load_balancer_pools/v4_to_v5_test.go
+++ b/internal/datasources/load_balancer_pools/v4_to_v5_test.go
@@ -1,0 +1,327 @@
+package load_balancer_pools
+
+import (
+	"testing"
+
+	"github.com/cloudflare/tf-migrate/internal/testhelpers"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConfigTransformation(t *testing.T) {
+	migrator := NewV4ToV5Migrator()
+
+	tests := []testhelpers.ConfigTestCase{
+		{
+			Name: "basic datasource - no filter",
+			Input: `
+data "cloudflare_load_balancer_pools" "example" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+}`,
+			Expected: `
+data "cloudflare_load_balancer_pools" "example" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+}`,
+		},
+		{
+			Name: "with filter block - removed in v5",
+			Input: `
+data "cloudflare_load_balancer_pools" "example" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+
+  filter {
+    name = "example-.*"
+  }
+}`,
+			Expected: `
+data "cloudflare_load_balancer_pools" "example" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+
+}`,
+		},
+		{
+			Name: "with empty filter block",
+			Input: `
+data "cloudflare_load_balancer_pools" "example" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+
+  filter {
+  }
+}`,
+			Expected: `
+data "cloudflare_load_balancer_pools" "example" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+
+}`,
+		},
+		{
+			Name: "with variable references",
+			Input: `
+data "cloudflare_load_balancer_pools" "example" {
+  account_id = var.cloudflare_account_id
+
+  filter {
+    name = "prod-.*"
+  }
+}`,
+			Expected: `
+data "cloudflare_load_balancer_pools" "example" {
+  account_id = var.cloudflare_account_id
+
+}`,
+		},
+		{
+			Name: "multiple datasources in one file",
+			Input: `
+data "cloudflare_load_balancer_pools" "all" {
+  account_id = "abc123"
+}
+
+data "cloudflare_load_balancer_pools" "filtered" {
+  account_id = "abc123"
+
+  filter {
+    name = "example-.*"
+  }
+}`,
+			Expected: `
+data "cloudflare_load_balancer_pools" "all" {
+  account_id = "abc123"
+}
+
+data "cloudflare_load_balancer_pools" "filtered" {
+  account_id = "abc123"
+
+}`,
+		},
+		{
+			Name: "with local reference",
+			Input: `
+data "cloudflare_load_balancer_pools" "example" {
+  account_id = local.account_id
+
+  filter {
+    name = local.pool_name_pattern
+  }
+}`,
+			Expected: `
+data "cloudflare_load_balancer_pools" "example" {
+  account_id = local.account_id
+
+}`,
+		},
+	}
+
+	testhelpers.RunConfigTransformTests(t, tests, migrator)
+}
+
+func TestStateTransformation(t *testing.T) {
+	migrator := NewV4ToV5Migrator()
+
+	tests := []testhelpers.StateTestCase{
+		{
+			Name: "minimal state - no filter or pools",
+			Input: `{
+  "schema_version": 0,
+  "attributes": {
+    "account_id": "f037e56e89293a057740de681ac9abbe",
+    "id": "checksum123"
+  }
+}`,
+			Expected: `{
+  "schema_version": 0,
+  "attributes": {
+    "account_id": "f037e56e89293a057740de681ac9abbe",
+    "id": "checksum123"
+  }
+}`,
+		},
+		{
+			Name: "state with filter - removed",
+			Input: `{
+  "schema_version": 0,
+  "attributes": {
+    "account_id": "f037e56e89293a057740de681ac9abbe",
+    "filter": [
+      {
+        "name": "example-.*"
+      }
+    ],
+    "id": "checksum123"
+  }
+}`,
+			Expected: `{
+  "schema_version": 0,
+  "attributes": {
+    "account_id": "f037e56e89293a057740de681ac9abbe",
+    "id": "checksum123"
+  }
+}`,
+		},
+		{
+			Name: "pools array renamed to result",
+			Input: `{
+  "schema_version": 0,
+  "attributes": {
+    "account_id": "f037e56e89293a057740de681ac9abbe",
+    "pools": [
+      {
+        "id": "pool1",
+        "name": "example-pool",
+        "enabled": true,
+        "minimum_origins": 1
+      },
+      {
+        "id": "pool2",
+        "name": "another-pool",
+        "enabled": false
+      }
+    ],
+    "id": "checksum123"
+  }
+}`,
+			Expected: `{
+  "schema_version": 0,
+  "attributes": {
+    "account_id": "f037e56e89293a057740de681ac9abbe",
+    "result": [
+      {
+        "id": "pool1",
+        "name": "example-pool",
+        "enabled": true,
+        "minimum_origins": 1
+      },
+      {
+        "id": "pool2",
+        "name": "another-pool",
+        "enabled": false
+      }
+    ],
+    "id": "checksum123"
+  }
+}`,
+		},
+		{
+			Name: "empty pools array",
+			Input: `{
+  "schema_version": 0,
+  "attributes": {
+    "account_id": "f037e56e89293a057740de681ac9abbe",
+    "pools": [],
+    "id": "checksum123"
+  }
+}`,
+			Expected: `{
+  "schema_version": 0,
+  "attributes": {
+    "account_id": "f037e56e89293a057740de681ac9abbe",
+    "result": [],
+    "id": "checksum123"
+  }
+}`,
+		},
+		{
+			Name: "null pools field",
+			Input: `{
+  "schema_version": 0,
+  "attributes": {
+    "account_id": "f037e56e89293a057740de681ac9abbe",
+    "pools": null,
+    "id": "checksum123"
+  }
+}`,
+			Expected: `{
+  "schema_version": 0,
+  "attributes": {
+    "account_id": "f037e56e89293a057740de681ac9abbe",
+    "id": "checksum123"
+  }
+}`,
+		},
+	}
+
+	testhelpers.RunStateTransformTests(t, tests, migrator)
+}
+
+func TestMigratorMethods(t *testing.T) {
+	migrator := NewV4ToV5Migrator()
+
+	t.Run("GetResourceType returns correct type", func(t *testing.T) {
+		resourceType := migrator.GetResourceType()
+		assert.Equal(t, "cloudflare_load_balancer_pools", resourceType)
+	})
+
+	t.Run("CanHandle matches correct datasource type", func(t *testing.T) {
+		assert.True(t, migrator.CanHandle("data.cloudflare_load_balancer_pools"))
+		assert.False(t, migrator.CanHandle("cloudflare_load_balancer_pools"))
+		assert.False(t, migrator.CanHandle("data.cloudflare_zone"))
+		assert.False(t, migrator.CanHandle("cloudflare_load_balancer_pool"))
+	})
+
+	t.Run("GetAttributeRenames returns correct mapping", func(t *testing.T) {
+		// Cast to concrete type to access GetAttributeRenames
+		concreteMigrator := migrator.(*V4ToV5Migrator)
+		renames := concreteMigrator.GetAttributeRenames()
+		assert.Len(t, renames, 1)
+		assert.Equal(t, "data.cloudflare_load_balancer_pools", renames[0].ResourceType)
+		assert.Equal(t, "pools", renames[0].OldAttribute)
+		assert.Equal(t, "result", renames[0].NewAttribute)
+	})
+
+	t.Run("Preprocess returns content unchanged", func(t *testing.T) {
+		input := "some terraform config content"
+		output := migrator.Preprocess(input)
+		assert.Equal(t, input, output)
+	})
+}
+
+func TestStateTransformationEdgeCases(t *testing.T) {
+	migrator := NewV4ToV5Migrator()
+
+	tests := []testhelpers.StateTestCase{
+		{
+			Name: "state with no attributes field",
+			Input: `{
+  "schema_version": 0
+}`,
+			Expected: `{
+  "schema_version": 0
+}`,
+		},
+		{
+			Name: "state with both filter and pools",
+			Input: `{
+  "schema_version": 0,
+  "attributes": {
+    "account_id": "f037e56e89293a057740de681ac9abbe",
+    "filter": [
+      {
+        "name": "example-.*"
+      }
+    ],
+    "pools": [
+      {
+        "id": "pool1",
+        "name": "example-pool"
+      }
+    ],
+    "id": "checksum123"
+  }
+}`,
+			Expected: `{
+  "schema_version": 0,
+  "attributes": {
+    "account_id": "f037e56e89293a057740de681ac9abbe",
+    "result": [
+      {
+        "id": "pool1",
+        "name": "example-pool"
+      }
+    ],
+    "id": "checksum123"
+  }
+}`,
+		},
+	}
+
+	testhelpers.RunStateTransformTests(t, tests, migrator)
+}

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -1,6 +1,7 @@
 package registry
 
 import (
+	lbpoolsdata "github.com/cloudflare/tf-migrate/internal/datasources/load_balancer_pools"
 	zonedata "github.com/cloudflare/tf-migrate/internal/datasources/zone"
 	zonesdata "github.com/cloudflare/tf-migrate/internal/datasources/zones"
 	"github.com/cloudflare/tf-migrate/internal/resources/access_rule"
@@ -75,6 +76,7 @@ import (
 // Each resource package's NewV4ToV5Migrator function registers itself with the internal registry.
 func RegisterAllMigrations() {
 	// Datasources
+	lbpoolsdata.NewV4ToV5Migrator()
 	zonedata.NewV4ToV5Migrator()
 	zonesdata.NewV4ToV5Migrator()
 


### PR DESCRIPTION
# Unit tests w/ coverage
```
=== RUN   TestConfigTransformation
=== RUN   TestConfigTransformation/basic_datasource_-_no_filter
=== RUN   TestConfigTransformation/with_filter_block_-_removed_in_v5
=== RUN   TestConfigTransformation/with_empty_filter_block
=== RUN   TestConfigTransformation/with_variable_references
=== RUN   TestConfigTransformation/multiple_datasources_in_one_file
=== RUN   TestConfigTransformation/with_local_reference
--- PASS: TestConfigTransformation (0.00s)
    --- PASS: TestConfigTransformation/basic_datasource_-_no_filter (0.00s)
    --- PASS: TestConfigTransformation/with_filter_block_-_removed_in_v5 (0.00s)
    --- PASS: TestConfigTransformation/with_empty_filter_block (0.00s)
    --- PASS: TestConfigTransformation/with_variable_references (0.00s)
    --- PASS: TestConfigTransformation/multiple_datasources_in_one_file (0.00s)
    --- PASS: TestConfigTransformation/with_local_reference (0.00s)
=== RUN   TestStateTransformation
=== RUN   TestStateTransformation/minimal_state_-_no_filter_or_pools
=== RUN   TestStateTransformation/state_with_filter_-_removed
=== RUN   TestStateTransformation/pools_array_renamed_to_result
=== RUN   TestStateTransformation/empty_pools_array
=== RUN   TestStateTransformation/null_pools_field
--- PASS: TestStateTransformation (0.00s)
    --- PASS: TestStateTransformation/minimal_state_-_no_filter_or_pools (0.00s)
    --- PASS: TestStateTransformation/state_with_filter_-_removed (0.00s)
    --- PASS: TestStateTransformation/pools_array_renamed_to_result (0.00s)
    --- PASS: TestStateTransformation/empty_pools_array (0.00s)
    --- PASS: TestStateTransformation/null_pools_field (0.00s)
=== RUN   TestMigratorMethods
=== RUN   TestMigratorMethods/GetResourceType_returns_correct_type
=== RUN   TestMigratorMethods/CanHandle_matches_correct_datasource_type
=== RUN   TestMigratorMethods/GetAttributeRenames_returns_correct_mapping
=== RUN   TestMigratorMethods/Preprocess_returns_content_unchanged
--- PASS: TestMigratorMethods (0.00s)
    --- PASS: TestMigratorMethods/GetResourceType_returns_correct_type (0.00s)
    --- PASS: TestMigratorMethods/CanHandle_matches_correct_datasource_type (0.00s)
    --- PASS: TestMigratorMethods/GetAttributeRenames_returns_correct_mapping (0.00s)
    --- PASS: TestMigratorMethods/Preprocess_returns_content_unchanged (0.00s)
=== RUN   TestStateTransformationEdgeCases
=== RUN   TestStateTransformationEdgeCases/state_with_no_attributes_field
=== RUN   TestStateTransformationEdgeCases/state_with_both_filter_and_pools
--- PASS: TestStateTransformationEdgeCases (0.00s)
    --- PASS: TestStateTransformationEdgeCases/state_with_no_attributes_field (0.00s)
    --- PASS: TestStateTransformationEdgeCases/state_with_both_filter_and_pools (0.00s)
PASS
coverage: 100.0% of statements
ok  	github.com/cloudflare/tf-migrate/internal/datasources/load_balancer_pools	0.488s	coverage: 100.0% of statements
```

# Integration tests
```
=== RUN   TestSingleResource
=== RUN   TestSingleResource/load_balancer_pools_datasource
--- PASS: TestSingleResource (0.72s)
    --- PASS: TestSingleResource/load_balancer_pools_datasource (0.72s)
PASS
ok  	github.com/cloudflare/tf-migrate/integration/v4_to_v5	1.070s
```

# E2E tests
```
========================================
✓ Migration Complete!
========================================

Results:
  Input (v4):  /Users/musa/cf-repos/sdks/migrations/load_balancer_pools/tf-migrate/e2e/tf/v4
  Output (v5): /Users/musa/cf-repos/sdks/migrations/load_balancer_pools/tf-migrate/e2e/migrated-v4_to_v5

Next steps:
  cd /Users/musa/cf-repos/sdks/migrations/load_balancer_pools/tf-migrate/e2e/migrated-v4_to_v5
  terraform init
  terraform plan

✓ Migration successful

Step 3: Testing v5 configurations
Running terraform init in migrated-v4_to_v5/...
Cleaning v5 .terraform directory for fresh init...
✓ Terraform init successful
Running terraform plan in v5/...
✓ Terraform plan shows no changes (expected)
Running terraform apply in v5/...
✓ Terraform apply successful
Capturing v5 state...
✓ Saved v5 state to tmp/v5-state.json

Step 4: Verifying stable state (v5 plan after apply)
Running terraform plan again to check for ongoing drift...
✓ No ongoing drift detected - migration achieved stable state!



========================================
✓ E2E Test Complete!
========================================

Summary:

  Step 1: v4 terraform apply
    Status: ✓ SUCCESS

  Step 2: Migration (v4 → v5)
    Status: ✓ SUCCESS

  Step 3: v5 plan (before apply)
    Status: ✓ No changes needed

  Step 4: v5 terraform apply
    Status: ✓ SUCCESS

  Step 5: v5 plan (after apply)
    Status: ✓ SUCCESS - Stable state achieved
    Result: No changes detected

Logs saved to:
  - /Users/musa/cf-repos/sdks/migrations/load_balancer_pools/tf-migrate/e2e/tmp
```