### PR TITLE
chore(zero_trust_device_posture_rule): remove state upgrade

### DIFF
--- a/integration/v4_to_v5/testdata/zero_trust_device_posture_rule/expected/zero_trust_device_posture_rule.tf
+++ b/integration/v4_to_v5/testdata/zero_trust_device_posture_rule/expected/zero_trust_device_posture_rule.tf
@@ -74,6 +74,7 @@ locals {
 
 
 
+
 resource "cloudflare_zero_trust_device_posture_rule" "map_example" {
   for_each = {
     "prod" = {
@@ -87,7 +88,7 @@ resource "cloudflare_zero_trust_device_posture_rule" "map_example" {
     "staging" = {
       account_id = var.cloudflare_account_id
       name       = "${local.name_prefix}-staging-posture-rule"
-      type       = "firewall"
+      type       = "os_version"
       schedule   = "12h"
       platform   = "windows"
       version    = "10.0.0"
@@ -103,7 +104,7 @@ resource "cloudflare_zero_trust_device_posture_rule" "map_example" {
     "qa" = {
       account_id = var.cloudflare_account_id
       name       = "${local.name_prefix}-qa-posture-rule"
-      type       = "firewall"
+      type       = "os_version"
       schedule   = "12h"
       platform   = "linux"
       version    = "1.0.0"
@@ -363,7 +364,7 @@ resource "cloudflare_zero_trust_device_posture_rule" "maximal" {
   type        = "os_version"
   description = "All fields populated"
   schedule    = "24h"
-  expiration  = "24h"
+  expiration  = "25h"
 
 
   input = {
@@ -413,7 +414,7 @@ resource "cloudflare_zero_trust_device_posture_rule" "basic" {
   type        = "os_version"
   description = "Device posture rule for corporate devices."
   schedule    = "24h"
-  expiration  = "24h"
+  expiration  = "25h"
 
 
   input = {
@@ -523,4 +524,25 @@ resource "cloudflare_zero_trust_device_posture_rule" "application" {
 moved {
   from = cloudflare_device_posture_rule.application
   to   = cloudflare_zero_trust_device_posture_rule.application
+}
+
+# Test case 6: Domain joined rule
+resource "cloudflare_zero_trust_device_posture_rule" "domain_joined" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-tf-test-domain-joined"
+  type       = "domain_joined"
+  schedule   = "5m"
+
+
+  input = {
+    domain = "example.com"
+  }
+  match = [{
+    platform = "windows"
+  }]
+}
+
+moved {
+  from = cloudflare_device_posture_rule.domain_joined
+  to   = cloudflare_zero_trust_device_posture_rule.domain_joined
 }

--- a/integration/v4_to_v5/testdata/zero_trust_device_posture_rule/input/zero_trust_device_posture_rule.tf
+++ b/integration/v4_to_v5/testdata/zero_trust_device_posture_rule/input/zero_trust_device_posture_rule.tf
@@ -42,7 +42,7 @@ resource "cloudflare_device_posture_rule" "map_example" {
     "staging" = {
       account_id  = var.cloudflare_account_id
       name = "${local.name_prefix}-staging-posture-rule"
-      type        = "firewall"
+      type        = "os_version"
       schedule    = "12h"
       platform    = "windows"
       version     = "10.0.0"
@@ -58,7 +58,7 @@ resource "cloudflare_device_posture_rule" "map_example" {
     "qa" = {
       account_id  = var.cloudflare_account_id
       name = "${local.name_prefix}-qa-posture-rule"
-      type        = "firewall"
+      type        = "os_version"
       schedule    = "12h"
       platform    = "linux"
       version     = "1.0.0"
@@ -290,7 +290,7 @@ resource "cloudflare_device_posture_rule" "maximal" {
   type        = "os_version"
   description = "All fields populated"
   schedule    = "24h"
-  expiration  = "24h"
+  expiration  = "25h"
 
   match {
     platform = "linux"
@@ -334,7 +334,7 @@ resource "cloudflare_device_posture_rule" "basic" {
   type        = "os_version"
   description = "Device posture rule for corporate devices."
   schedule    = "24h"
-  expiration  = "24h"
+  expiration  = "25h"
 
   match {
     platform = "linux"
@@ -421,5 +421,21 @@ resource "cloudflare_device_posture_rule" "application" {
     path    = "/usr/bin/security-app"
     sha256  = "abc123def456"
     running = true
+  }
+}
+
+# Test case 6: Domain joined rule
+resource "cloudflare_device_posture_rule" "domain_joined" {
+  account_id = var.cloudflare_account_id
+  name = "${local.name_prefix}-tf-test-domain-joined"
+  type       = "domain_joined"
+  schedule   = "5m"
+
+  match {
+    platform = "windows"
+  }
+
+  input {
+    domain = "example.com"
   }
 }


### PR DESCRIPTION
```
Building binaries...
go build -v -o bin/tf-migrate ./cmd/tf-migrate
go build -v -o bin/e2e-runner ./cmd/e2e-runner


========================================
State Migration Methods for Specified Resources
========================================

Resources using provider's UpgradeState/MoveState:
  zero_trust_device_posture_rule

Targeting specific resources: zero_trust_device_posture_rule
Target arguments: -target=module.zero_trust_device_posture_rule


========================================
E2E Migration Test
========================================

Step 0: Initializing test resources
Running tests with:
  User:       terraform-test-user-a@cfapi.net
  Account ID: a09697b020084f87a205896b35575a37
  Zone ID:    cd581854c1f59f8c686ee796d0eddce2
  Domain:     vaishak.terraform.cfapi.net
  Provider:   Local (/Users/vaishak/cf-repos/github/terraform-provider-cloudflare)

Running init script...

========================================
Syncing Test Resources
========================================

Filtering to specific resources: zero_trust_device_posture_rule
Syncing resource files from testdata...
  ✓ zero_trust_device_posture_rule/zero_trust_device_posture_rule.tf
  ✓ zero_trust_device_posture_rule/versions.tf

  Total: 2 files synced

Configuring terraform variables...


✓ Saved configuration
    Account ID: a09697b020084f87a205896b35575a37
    Zone ID: cd581854c1f59f8c686ee796d0eddce2
    Domain: vaishak.terraform.cfapi.net
    File: v4/terraform.tfvars

Scanning for import annotations...

Updating main.tf with module references...
  ↻ Updated main.tf with 1 module references


========================================
✓ Sync Complete!
========================================

Summary:
  - Terraform v4 configs: /Users/vaishak/cf-repos/github/tf-migrate/e2e/tf/v4
  - Modules: 1
  - Files synced: 2

Configuring remote backend...
✓ Backend configured

  ✓ Provider installation preserved
  ✓ Backend already configured

Next steps:
  cd tf/v4 && terraform apply

Note: Configuration is automatically loaded from terraform.tfvars
      State is managed remotely in R2

✓ Test resources initialized


========================================
Setting up local provider
========================================

Using provider from: /Users/vaishak/cf-repos/github/terraform-provider-cloudflare
Building provider...
  Building in: /Users/vaishak/cf-repos/github/terraform-provider-cloudflare
  Output: /Users/vaishak/cf-repos/github/terraform-provider-cloudflare/terraform-provider-cloudflare
✓ Provider built successfully: /Users/vaishak/cf-repos/github/terraform-provider-cloudflare/terraform-provider-cloudflare
✓ Created dev overrides config: /Users/vaishak/cf-repos/github/tf-migrate/.terraformrc-tf-migrate
✓ Local provider will be used for v5 testing

Note: v4 tests will use the registry provider (v4.x)
      v5 tests will use the local provider with dev overrides

Step 1: Testing v4 configurations
Running terraform init in v4/...
Found local state file, backing up and using remote state...
✓ Terraform init successful (remote state loaded from R2)
Running terraform plan in v4/...
✓ Terraform plan successful
  Plan: 26 to add, 0 to change, 0 to destroy.

Detailed changes:

  # module.zero_trust_device_posture_rule.cloudflare_device_posture_rule.application will be created
  + resource "cloudflare_device_posture_rule" "application" {
      + account_id = "a09697b020084f87a205896b35575a37"
      + id         = (known after apply)
      + name       = "cftftest-tf-test-application"
      + schedule   = "30m"
      + type       = "application"

  # module.zero_trust_device_posture_rule.cloudflare_device_posture_rule.basic will be created
  + resource "cloudflare_device_posture_rule" "basic" {
      + account_id  = "a09697b020084f87a205896b35575a37"
      + description = "Device posture rule for corporate devices."
      + expiration  = "25h"
      + id          = (known after apply)
      + name        = "cftftest-tf-test-posture-basic"
      + schedule    = "24h"
      + type        = "os_version"

  # module.zero_trust_device_posture_rule.cloudflare_device_posture_rule.conditional_enabled[0] will be created
  + resource "cloudflare_device_posture_rule" "conditional_enabled" {
      + account_id  = "a09697b020084f87a205896b35575a37"
      + description = "Conditionally enabled firewall rule"
      + id          = (known after apply)
      + name        = "cftftest-conditional-firewall-enabled"
      + schedule    = "12h"
      + type        = "firewall"

  # module.zero_trust_device_posture_rule.cloudflare_device_posture_rule.counted[0] will be created
  + resource "cloudflare_device_posture_rule" "counted" {
      + account_id  = "a09697b020084f87a205896b35575a37"
      + description = "This is posture rule number 0"
      + id          = (known after apply)
      + name        = "cftftest-counted-rule-0"
      + schedule    = "24h"
      + type        = "os_version"

  # module.zero_trust_device_posture_rule.cloudflare_device_posture_rule.counted[1] will be created
  + resource "cloudflare_device_posture_rule" "counted" {
      + account_id  = "a09697b020084f87a205896b35575a37"
      + description = "This is posture rule number 1"
      + id          = (known after apply)
      + name        = "cftftest-counted-rule-1"
      + schedule    = "24h"
      + type        = "os_version"

  # module.zero_trust_device_posture_rule.cloudflare_device_posture_rule.counted[2] will be created
  + resource "cloudflare_device_posture_rule" "counted" {
      + account_id  = "a09697b020084f87a205896b35575a37"
      + description = "This is posture rule number 2"
      + id          = (known after apply)
      + name        = "cftftest-counted-rule-2"
      + schedule    = "24h"
      + type        = "os_version"

  # module.zero_trust_device_posture_rule.cloudflare_device_posture_rule.disk_encryption will be created
  + resource "cloudflare_device_posture_rule" "disk_encryption" {
      + account_id = "a09697b020084f87a205896b35575a37"
      + id         = (known after apply)
      + name       = "cftftest-tf-test-disk"
      + schedule   = "5m"
      + type       = "disk_encryption"

  # module.zero_trust_device_posture_rule.cloudflare_device_posture_rule.domain_joined will be created
  + resource "cloudflare_device_posture_rule" "domain_joined" {
      + account_id = "a09697b020084f87a205896b35575a37"
      + id         = (known after apply)
      + name       = "cftftest-tf-test-domain-joined"
      + schedule   = "5m"
      + type       = "domain_joined"

  # module.zero_trust_device_posture_rule.cloudflare_device_posture_rule.firewall will be created
  + resource "cloudflare_device_posture_rule" "firewall" {
      + account_id = "a09697b020084f87a205896b35575a37"
      + id         = (known after apply)
      + name       = "cftftest-tf-test-firewall"
      + schedule   = "5m"
      + type       = "firewall"

  # module.zero_trust_device_posture_rule.cloudflare_device_posture_rule.map_example["dev"] will be created
  + resource "cloudflare_device_posture_rule" "map_example" {
      + account_id = "a09697b020084f87a205896b35575a37"
      + id         = (known after apply)
      + name       = "cftftest-dev-posture-rule"
      + schedule   = "6h"
      + type       = "os_version"

  # module.zero_trust_device_posture_rule.cloudflare_device_posture_rule.map_example["perf"] will be created
  + resource "cloudflare_device_posture_rule" "map_example" {
      + account_id = "a09697b020084f87a205896b35575a37"
      + id         = (known after apply)
      + name       = "cftftest-perf-posture-rule"
      + schedule   = "24h"
      + type       = "os_version"

  # module.zero_trust_device_posture_rule.cloudflare_device_posture_rule.map_example["prod"] will be created
  + resource "cloudflare_device_posture_rule" "map_example" {
      + account_id = "a09697b020084f87a205896b35575a37"
      + id         = (known after apply)
      + name       = "cftftest-prod-posture-rule"
      + schedule   = "24h"
      + type       = "os_version"

  # module.zero_trust_device_posture_rule.cloudflare_device_posture_rule.map_example["qa"] will be created
  + resource "cloudflare_device_posture_rule" "map_example" {
      + account_id = "a09697b020084f87a205896b35575a37"
      + id         = (known after apply)
      + name       = "cftftest-qa-posture-rule"
      + schedule   = "12h"
      + type       = "os_version"

  # module.zero_trust_device_posture_rule.cloudflare_device_posture_rule.map_example["staging"] will be created
  + resource "cloudflare_device_posture_rule" "map_example" {
      + account_id = "a09697b020084f87a205896b35575a37"
      + id         = (known after apply)
      + name       = "cftftest-staging-posture-rule"
      + schedule   = "12h"
      + type       = "os_version"

  # module.zero_trust_device_posture_rule.cloudflare_device_posture_rule.maximal will be created
  + resource "cloudflare_device_posture_rule" "maximal" {
      + account_id  = "a09697b020084f87a205896b35575a37"
      + description = "All fields populated"
      + expiration  = "25h"
      + id          = (known after apply)
      + name        = "cftftest-maximal-rule"
      + schedule    = "24h"
      + type        = "os_version"

  # module.zero_trust_device_posture_rule.cloudflare_device_posture_rule.minimal will be created
  + resource "cloudflare_device_posture_rule" "minimal" {
      + account_id = "a09697b020084f87a205896b35575a37"
      + id         = (known after apply)
      + name       = "cftftest-minimal-rule"
      + schedule   = "5m"
      + type       = "firewall"

  # module.zero_trust_device_posture_rule.cloudflare_device_posture_rule.multi_platform will be created
  + resource "cloudflare_device_posture_rule" "multi_platform" {
      + account_id = "a09697b020084f87a205896b35575a37"
      + id         = (known after apply)
      + name       = "cftftest-tf-test-multi"
      + schedule   = "5m"
      + type       = "firewall"

  # module.zero_trust_device_posture_rule.cloudflare_device_posture_rule.set_example["alpha"] will be created
  + resource "cloudflare_device_posture_rule" "set_example" {
      + account_id = "a09697b020084f87a205896b35575a37"
      + id         = (known after apply)
      + name       = "cftftest-set-alpha-rule"
      + schedule   = "5m"
      + type       = "firewall"

  # module.zero_trust_device_posture_rule.cloudflare_device_posture_rule.set_example["beta"] will be created
  + resource "cloudflare_device_posture_rule" "set_example" {
      + account_id = "a09697b020084f87a205896b35575a37"
      + id         = (known after apply)
      + name       = "cftftest-set-beta-rule"
      + schedule   = "5m"
      + type       = "firewall"

  # module.zero_trust_device_posture_rule.cloudflare_device_posture_rule.set_example["delta"] will be created
  + resource "cloudflare_device_posture_rule" "set_example" {
      + account_id = "a09697b020084f87a205896b35575a37"
      + id         = (known after apply)
      + name       = "cftftest-set-delta-rule"
      + schedule   = "5m"
      + type       = "firewall"

  # module.zero_trust_device_posture_rule.cloudflare_device_posture_rule.set_example["gamma"] will be created
  + resource "cloudflare_device_posture_rule" "set_example" {
      + account_id = "a09697b020084f87a205896b35575a37"
      + id         = (known after apply)
      + name       = "cftftest-set-gamma-rule"
      + schedule   = "5m"
      + type       = "firewall"

  # module.zero_trust_device_posture_rule.cloudflare_device_posture_rule.with_functions will be created
  + resource "cloudflare_device_posture_rule" "with_functions" {
      + account_id  = "a09697b020084f87a205896b35575a37"
      + description = "Rule for account a09697b020084f87a205896b35575a37"
      + id          = (known after apply)
      + name        = "cftftest-function-example"
      + schedule    = "24h"
      + type        = "os_version"

  # module.zero_trust_device_posture_rule.cloudflare_device_posture_rule.with_interpolation will be created
  + resource "cloudflare_device_posture_rule" "with_interpolation" {
      + account_id  = "a09697b020084f87a205896b35575a37"
      + description = "Interpolated rule name"
      + id          = (known after apply)
      + name        = "cftftest-rule-for-account-a09697b020084f87a205896b35575a37"
      + schedule    = "5m"
      + type        = "firewall"

  # module.zero_trust_device_posture_rule.cloudflare_device_posture_rule.with_lifecycle will be created
  + resource "cloudflare_device_posture_rule" "with_lifecycle" {
      + account_id  = "a09697b020084f87a205896b35575a37"
      + description = "Rule with lifecycle arguments"
      + id          = (known after apply)
      + name        = "cftftest-lifecycle-test-rule"
      + schedule    = "24h"
      + type        = "os_version"

  # module.zero_trust_device_posture_rule.cloudflare_device_posture_rule.with_nulls will be created
  + resource "cloudflare_device_posture_rule" "with_nulls" {
      + account_id = "a09697b020084f87a205896b35575a37"
      + id         = (known after apply)
      + name       = "cftftest-with-nulls"
      + schedule   = "5m"
      + type       = "firewall"

  # module.zero_trust_device_posture_rule.cloudflare_device_posture_rule.with_prevent_destroy will be created
  + resource "cloudflare_device_posture_rule" "with_prevent_destroy" {
      + account_id = "a09697b020084f87a205896b35575a37"
      + id         = (known after apply)
      + name       = "cftftest-prevent-destroy-rule"
      + schedule   = "12h"
      + type       = "firewall"


Running terraform apply in v4/...
✓ Terraform apply successful
  Apply complete! Resources: 26 added, 0 changed, 0 destroyed.
Syncing state from remote...
✓ Local state file synced from R2
Capturing v4 state...
✓ Saved v4 state to tmp/v4-state.json


Step 2: Running migration
Running ./scripts/migrate...
Building tf-migrate binary...
✓ Binary built successfully

========================================
Running v4 to v5 Migration
========================================

Preparing output directory...
  ✓ Preserved v5 provider installation (.terraform/)
  ✓ Preserved v5 dependency lock file (.terraform.lock.hcl)
Copying only targeted resources: zero_trust_device_posture_rule
    ✓ Copied root file: provider.tf
    ✓ Copied root file: terraform.tfvars
    ✓ Copied root file: terraform.tfstate

    ✓ Copied module: zero_trust_device_posture_rule
Creating filtered main.tf...
✓ Copied targeted resources to migrated-v4_to_v5/
✓ Updated provider.tf to use ~> 5.0 and removed backend config
Filtering state file to only include targeted resources...
✓ Filtered state to 26 resources from targeted modules

Migrating configuration files...
Skipping state transformation - using provider's state upgrader
Cloudflare Terraform Provider Migration Tool
============================================

Configuration directory: /Users/vaishak/cf-repos/github/tf-migrate/e2e/migrated-v4_to_v5
Output directory: in-place
✓ Using Cloudflare API credentials (API key + email)

Found 4 configuration files to migrate
[1/4] Processing main.tf... ✓
[2/4] Processing provider.tf... ✓
[3/4] Processing versions.tf... ✓
[4/4] Processing zero_trust_device_posture_rule.tf... ✓
2026-02-13T09:11:35.943-0800 [WARN]  tf-migrate: Migrator does not implement ResourceRenamer interface - cross-file references may not be updated: migrator="*zero_trust_split_tunnel.V4ToV5Migrator"
2026-02-13T09:11:35.943-0800 [WARN]  tf-migrate: Migrator does not implement ResourceRenamer interface - cross-file references may not be updated: migrator="*rulesets.V4ToV5Migrator"
2026-02-13T09:11:35.943-0800 [WARN]  tf-migrate: Migrator does not implement ResourceRenamer interface - cross-file references may not be updated: migrator="*queue.V4ToV5Migrator"
2026-02-13T09:11:35.943-0800 [WARN]  tf-migrate: Migrator does not implement ResourceRenamer interface - cross-file references may not be updated: migrator="*zero_trust_gateway_certificate.V4ToV5Migrator"
2026-02-13T09:11:35.943-0800 [WARN]  tf-migrate: Migrator does not implement ResourceRenamer interface - cross-file references may not be updated: migrator="*load_balancer_pools.V4ToV5Migrator"
2026-02-13T09:11:35.943-0800 [WARN]  tf-migrate: Migrator does not implement ResourceRenamer interface - cross-file references may not be updated: migrator="*zone_setting.V4ToV5Migrator"

Applying cross-file reference updates (29 updates across 4 files)...
✓ Updated cross-file references (29 updates applied)
✓ Migration complete (config transformed, state will be upgraded by provider)


========================================
✓ Migration Complete!
========================================

Results:
  Input (v4):  /Users/vaishak/cf-repos/github/tf-migrate/e2e/tf/v4
  Output (v5): /Users/vaishak/cf-repos/github/tf-migrate/e2e/migrated-v4_to_v5

Next steps:
  cd /Users/vaishak/cf-repos/github/tf-migrate/e2e/migrated-v4_to_v5
  terraform init
  terraform plan

✓ Migration successful

Step 3: Testing v5 configurations
Running terraform init in migrated-v4_to_v5/...
Cleaning v5 .terraform directory for fresh init...
Removing .terraform.lock.hcl to allow dev_overrides...
✓ Terraform init successful
Running terraform plan in v5/...
✓ Terraform plan shows only computed value refreshes (ignored with --apply-exemptions)
Running terraform apply in v5/...
✓ Terraform apply successful
Capturing v5 state...
✓ Saved v5 state to tmp/v5-state.json

Step 4: Verifying stable state (v5 plan after apply)
Running terraform plan again to check for ongoing drift...
✓ No ongoing drift detected - migration achieved stable state!



========================================
✓ E2E Test Complete!
========================================

Summary:

  Step 1: v4 terraform apply
    Status: ✓ SUCCESS

  Step 2: Migration (v4 → v5)
    Status: ✓ SUCCESS

  Step 3: v5 plan (before apply)
    Status: ⚠ Changes detected but all exempted
    Result: 0 real changes (0 exempted)
    Terraform: Plan: 0 to add, 0 to change, 0 to destroy.

  Step 4: v5 terraform apply
    Status: ✓ SUCCESS

  Step 5: v5 plan (after apply)
    Status: ✓ SUCCESS - Stable state achieved
    Result: No changes detected

Logs saved to:
  - /Users/vaishak/cf-repos/github/tf-migrate/e2e/tmp
  ```