### PR TITLE
feat(workers_custom_domain): config migration and e2e tests

### DIFF
--- a/integration/v4_to_v5/testdata/workers_custom_domain/expected/workers_custom_domain.tf
+++ b/integration/v4_to_v5/testdata/workers_custom_domain/expected/workers_custom_domain.tf
@@ -1,0 +1,33 @@
+variable "cloudflare_account_id" {
+  description = "Cloudflare account ID"
+  type        = string
+}
+
+variable "cloudflare_zone_id" {
+  description = "Cloudflare zone ID"
+  type        = string
+}
+
+variable "cloudflare_domain" {
+  description = "Cloudflare domain for testing"
+  type        = string
+}
+
+locals {
+  workers_service_name = "edge-worker"
+  workers_hostname     = "api.${var.cloudflare_domain}"
+}
+
+
+resource "cloudflare_workers_custom_domain" "example" {
+  account_id  = var.cloudflare_account_id
+  hostname    = local.workers_hostname
+  service     = local.workers_service_name
+  zone_id     = var.cloudflare_zone_id
+  environment = "production"
+}
+
+moved {
+  from = cloudflare_worker_domain.example
+  to   = cloudflare_workers_custom_domain.example
+}

--- a/integration/v4_to_v5/testdata/workers_custom_domain/input/workers_custom_domain.tf
+++ b/integration/v4_to_v5/testdata/workers_custom_domain/input/workers_custom_domain.tf
@@ -1,0 +1,27 @@
+variable "cloudflare_account_id" {
+  description = "Cloudflare account ID"
+  type        = string
+}
+
+variable "cloudflare_zone_id" {
+  description = "Cloudflare zone ID"
+  type        = string
+}
+
+variable "cloudflare_domain" {
+  description = "Cloudflare domain for testing"
+  type        = string
+}
+
+locals {
+  workers_service_name = "edge-worker"
+  workers_hostname     = "api.${var.cloudflare_domain}"
+}
+
+resource "cloudflare_worker_domain" "example" {
+  account_id  = var.cloudflare_account_id
+  hostname    = local.workers_hostname
+  service     = local.workers_service_name
+  zone_id     = var.cloudflare_zone_id
+  environment = "production"
+}

--- a/integration/v4_to_v5/testdata/workers_custom_domain/input/workers_custom_domain_e2e.tf
+++ b/integration/v4_to_v5/testdata/workers_custom_domain/input/workers_custom_domain_e2e.tf
@@ -1,0 +1,37 @@
+variable "cloudflare_account_id" {
+  description = "Cloudflare account ID"
+  type        = string
+}
+
+variable "cloudflare_zone_id" {
+  description = "Cloudflare zone ID"
+  type        = string
+}
+
+variable "cloudflare_domain" {
+  description = "Cloudflare domain for testing"
+  type        = string
+}
+
+locals {
+  workers_service_name = "cftftest-workers-custom-domain-${substr(var.cloudflare_account_id, 0, 8)}"
+  workers_hostname     = "workers-custom-domain-${substr(var.cloudflare_account_id, 0, 8)}.${var.cloudflare_domain}"
+  workers_content      = "addEventListener('fetch', event => { event.respondWith(new Response('ok')); });"
+}
+
+# Prerequisite Worker service for domain attachment.
+resource "cloudflare_workers_script" "service" {
+  account_id = var.cloudflare_account_id
+  name       = local.workers_service_name
+  content    = local.workers_content
+}
+
+resource "cloudflare_worker_domain" "example" {
+  account_id  = var.cloudflare_account_id
+  hostname    = local.workers_hostname
+  service     = local.workers_service_name
+  zone_id     = var.cloudflare_zone_id
+  environment = "production"
+
+  depends_on = [cloudflare_workers_script.service]
+}

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -48,6 +48,7 @@ import (
 	"github.com/cloudflare/tf-migrate/internal/resources/turnstile_widget"
 	"github.com/cloudflare/tf-migrate/internal/resources/url_normalization_settings"
 	"github.com/cloudflare/tf-migrate/internal/resources/worker_route"
+	"github.com/cloudflare/tf-migrate/internal/resources/workers_custom_domain"
 	"github.com/cloudflare/tf-migrate/internal/resources/workers_for_platforms_dispatch_namespace"
 	"github.com/cloudflare/tf-migrate/internal/resources/workers_kv"
 	"github.com/cloudflare/tf-migrate/internal/resources/workers_kv_namespace"
@@ -138,6 +139,7 @@ func RegisterAllMigrations() {
 	turnstile_widget.NewV4ToV5Migrator()
 	url_normalization_settings.NewV4ToV5Migrator()
 	worker_route.NewV4ToV5Migrator()
+	workers_custom_domain.NewV4ToV5Migrator()
 	workers_kv.NewV4ToV5Migrator()
 	workers_kv_namespace.NewV4ToV5Migrator()
 	workers_script.NewV4ToV5Migrator()

--- a/internal/resources/workers_custom_domain/v4_to_v5.go
+++ b/internal/resources/workers_custom_domain/v4_to_v5.go
@@ -1,0 +1,58 @@
+package workers_custom_domain
+
+import (
+	"github.com/cloudflare/tf-migrate/internal"
+	"github.com/cloudflare/tf-migrate/internal/transform"
+	tfhcl "github.com/cloudflare/tf-migrate/internal/transform/hcl"
+	"github.com/hashicorp/hcl/v2/hclwrite"
+	"github.com/tidwall/gjson"
+)
+
+type V4ToV5Migrator struct{}
+
+func NewV4ToV5Migrator() transform.ResourceTransformer {
+	migrator := &V4ToV5Migrator{}
+	internal.RegisterMigrator("cloudflare_worker_domain", "v4", "v5", migrator)
+	return migrator
+}
+
+func (m *V4ToV5Migrator) GetResourceType() string {
+	return "cloudflare_workers_custom_domain"
+}
+
+func (m *V4ToV5Migrator) CanHandle(resourceType string) bool {
+	return resourceType == "cloudflare_worker_domain"
+}
+
+func (m *V4ToV5Migrator) Preprocess(content string) string {
+	return content
+}
+
+func (m *V4ToV5Migrator) GetResourceRename() (string, string) {
+	return "cloudflare_worker_domain", "cloudflare_workers_custom_domain"
+}
+
+func (m *V4ToV5Migrator) TransformConfig(ctx *transform.Context, block *hclwrite.Block) (*transform.TransformResult, error) {
+	resourceName := tfhcl.GetResourceName(block)
+	tfhcl.RenameResourceType(block, "cloudflare_worker_domain", "cloudflare_workers_custom_domain")
+
+	oldType, newType := m.GetResourceRename()
+	from := oldType + "." + resourceName
+	to := newType + "." + resourceName
+	movedBlock := tfhcl.CreateMovedBlock(from, to)
+
+	return &transform.TransformResult{
+		Blocks:         []*hclwrite.Block{block, movedBlock},
+		RemoveOriginal: true,
+	}, nil
+}
+
+// TransformState is a no-op because provider StateUpgrader/MoveState handles migration.
+func (m *V4ToV5Migrator) TransformState(ctx *transform.Context, stateJSON gjson.Result, resourcePath, resourceName string) (string, error) {
+	return stateJSON.String(), nil
+}
+
+// UsesProviderStateUpgrader indicates this resource relies on provider state migration.
+func (m *V4ToV5Migrator) UsesProviderStateUpgrader() bool {
+	return true
+}

--- a/internal/resources/workers_custom_domain/v4_to_v5_test.go
+++ b/internal/resources/workers_custom_domain/v4_to_v5_test.go
@@ -1,0 +1,68 @@
+package workers_custom_domain
+
+import (
+	"testing"
+
+	"github.com/cloudflare/tf-migrate/internal/testhelpers"
+)
+
+func TestV4ToV5ConfigTransformation(t *testing.T) {
+	migrator := NewV4ToV5Migrator()
+
+	tests := []testhelpers.ConfigTestCase{
+		{
+			Name: "rename resource type with attributes passthrough",
+			Input: `resource "cloudflare_worker_domain" "example" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+  zone_id    = "023e105f4ecef8ad9ca31a8372d0c353"
+  hostname   = "api.example.com"
+  service    = "my-worker"
+  environment = "production"
+}`,
+			Expected: `resource "cloudflare_workers_custom_domain" "example" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+  zone_id    = "023e105f4ecef8ad9ca31a8372d0c353"
+  hostname   = "api.example.com"
+  service    = "my-worker"
+  environment = "production"
+}
+
+moved {
+  from = cloudflare_worker_domain.example
+  to   = cloudflare_workers_custom_domain.example
+}`,
+		},
+		{
+			Name: "preserve meta arguments",
+			Input: `resource "cloudflare_worker_domain" "domains" {
+  for_each = toset(["api.example.com", "admin.example.com"])
+
+  account_id = "f037e56e89293a057740de681ac9abbe"
+  hostname   = each.value
+  service    = "my-worker"
+}`,
+			Expected: `resource "cloudflare_workers_custom_domain" "domains" {
+  for_each = toset(["api.example.com", "admin.example.com"])
+
+  account_id = "f037e56e89293a057740de681ac9abbe"
+  hostname   = each.value
+  service    = "my-worker"
+}
+
+moved {
+  from = cloudflare_worker_domain.domains
+  to   = cloudflare_workers_custom_domain.domains
+}`,
+		},
+	}
+
+	testhelpers.RunConfigTransformTests(t, tests, migrator)
+}
+
+func TestUsesProviderStateUpgrader(t *testing.T) {
+	migrator := NewV4ToV5Migrator()
+
+	if got := migrator.(*V4ToV5Migrator).UsesProviderStateUpgrader(); !got {
+		t.Fatalf("UsesProviderStateUpgrader() = %v, want true", got)
+	}
+}


### PR DESCRIPTION
```
~/cf-repos/github/tf-migrate main *1 !1 ?2 ❯ ./scripts/run-e2e-tests.sh --apply-exemptions --provider /Users/vaishak/cf-repos/github/terraform-provider-cloudflare --resources workers_custom_domain
Building binaries...
go build -v -o bin/tf-migrate ./cmd/tf-migrate
go build -v -o bin/e2e-runner ./cmd/e2e-runner


========================================
State Migration Methods for Specified Resources
========================================

Resources using provider's UpgradeState/MoveState:
  workers_custom_domain

Targeting specific resources: workers_custom_domain
Target arguments: -target=module.workers_custom_domain


========================================
E2E Migration Test
========================================

Step 0: Initializing test resources
Running tests with:
  User:       vaishak@cloudflare.com
  Account ID: 8511639f53e8d7871003f714afd1dba4
  Zone ID:    b9c9ae341a26b5b692441bb6573015b9
  Domain:     vaishak.terraform.cfapi.net
  Provider:   Local (/Users/vaishak/cf-repos/github/terraform-provider-cloudflare)

Running init script...

========================================
Syncing Test Resources
========================================

Filtering to specific resources: workers_custom_domain
Syncing resource files from testdata...
  ✓ workers_custom_domain/workers_custom_domain.tf (from workers_custom_domain_e2e.tf)
  ✓ workers_custom_domain/versions.tf

  Total: 2 files synced

Configuring terraform variables...


✓ Saved configuration
    Account ID: 8511639f53e8d7871003f714afd1dba4
    Zone ID: b9c9ae341a26b5b692441bb6573015b9
    Domain: vaishak.terraform.cfapi.net
    File: v4/terraform.tfvars

Scanning for import annotations...

Updating main.tf with module references...
  ↻ Updated main.tf with 1 module references


========================================
✓ Sync Complete!
========================================

Summary:
  - Terraform v4 configs: /Users/vaishak/cf-repos/github/tf-migrate/e2e/tf/v4
  - Modules: 1
  - Files synced: 2

Configuring remote backend...
✓ Backend configured

  ✓ Provider installation preserved
  ✓ Backend already configured

Next steps:
  cd tf/v4 && terraform apply

Note: Configuration is automatically loaded from terraform.tfvars
      State is managed remotely in R2

✓ Test resources initialized


========================================
Setting up local provider
========================================

Using provider from: /Users/vaishak/cf-repos/github/terraform-provider-cloudflare
Building provider...
  Building in: /Users/vaishak/cf-repos/github/terraform-provider-cloudflare
  Output: /Users/vaishak/cf-repos/github/terraform-provider-cloudflare/terraform-provider-cloudflare
✓ Provider built successfully: /Users/vaishak/cf-repos/github/terraform-provider-cloudflare/terraform-provider-cloudflare
✓ Created dev overrides config: /Users/vaishak/cf-repos/github/tf-migrate/.terraformrc-tf-migrate
✓ Local provider will be used for v5 testing

Note: v4 tests will use the registry provider (v4.x)
      v5 tests will use the local provider with dev overrides

Step 1: Testing v4 configurations
Running terraform init in v4/...
Found local state file, backing up and using remote state...
✓ Terraform init successful (remote state loaded from R2)
Running terraform plan in v4/...
✓ Terraform plan shows no changes

Running terraform apply in v4/...
✓ Terraform apply successful
  Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
Syncing state from remote...
✓ Local state file synced from R2
Capturing v4 state...
✓ Saved v4 state to tmp/v4-state.json


Step 2: Running migration
Running ./scripts/migrate...
Building tf-migrate binary...
✓ Binary built successfully

========================================
Running v4 to v5 Migration
========================================

Preparing output directory...
  ✓ Preserved v5 provider installation (.terraform/)
  ✓ Preserved v5 dependency lock file (.terraform.lock.hcl)
Copying only targeted resources: workers_custom_domain
    ✓ Copied root file: provider.tf
    ✓ Copied root file: terraform.tfvars
    ✓ Copied root file: terraform.tfstate

    ✓ Copied module: workers_custom_domain
Creating filtered main.tf...
✓ Copied targeted resources to migrated-v4_to_v5/
✓ Updated provider.tf to use ~> 5.0 and removed backend config
Filtering state file to only include targeted resources...
✓ Filtered state to 2 resources from targeted modules

Migrating configuration files...
Skipping state transformation - using provider's state upgrader
Cloudflare Terraform Provider Migration Tool
============================================

Configuration directory: /Users/vaishak/cf-repos/github/tf-migrate/e2e/migrated-v4_to_v5
Output directory: in-place

Found 4 configuration files to migrate
[1/4] Processing main.tf... ✓
[2/4] Processing provider.tf... ✓
[3/4] Processing versions.tf... ✓
[4/4] Processing workers_custom_domain.tf... ✓
2026-03-05T16:32:00.416-0800 [WARN]  tf-migrate: Migrator does not implement ResourceRenamer interface - cross-file references may not be updated: migrator="*zero_trust_gateway_certificate.V4ToV5Migrator"
2026-03-05T16:32:00.416-0800 [WARN]  tf-migrate: Migrator does not implement ResourceRenamer interface - cross-file references may not be updated: migrator="*rulesets.V4ToV5Migrator"
2026-03-05T16:32:00.416-0800 [WARN]  tf-migrate: Migrator does not implement ResourceRenamer interface - cross-file references may not be updated: migrator="*queue.V4ToV5Migrator"
2026-03-05T16:32:00.416-0800 [WARN]  tf-migrate: Migrator does not implement ResourceRenamer interface - cross-file references may not be updated: migrator="*load_balancer_pools.V4ToV5Migrator"
2026-03-05T16:32:00.416-0800 [WARN]  tf-migrate: Migrator does not implement ResourceRenamer interface - cross-file references may not be updated: migrator="*zone_setting.V4ToV5Migrator"
2026-03-05T16:32:00.416-0800 [WARN]  tf-migrate: Migrator does not implement ResourceRenamer interface - cross-file references may not be updated: migrator="*zero_trust_split_tunnel.V4ToV5Migrator"

Applying cross-file reference updates (30 updates across 4 files)...
✓ Updated cross-file references (30 updates applied)
✓ Migration complete (config transformed, state will be upgraded by provider)


========================================
✓ Migration Complete!
========================================

Results:
  Input (v4):  /Users/vaishak/cf-repos/github/tf-migrate/e2e/tf/v4
  Output (v5): /Users/vaishak/cf-repos/github/tf-migrate/e2e/migrated-v4_to_v5

Next steps:
  cd /Users/vaishak/cf-repos/github/tf-migrate/e2e/migrated-v4_to_v5
  terraform init
  terraform plan

✓ Migration successful

Step 3: Testing v5 configurations
Running terraform init in migrated-v4_to_v5/...
Cleaning v5 .terraform directory for fresh init...
Removing .terraform.lock.hcl to allow dev_overrides...
✓ Terraform init successful
Running terraform plan in v5/...
✓ Terraform plan shows only computed value refreshes (ignored with --apply-exemptions)
Running terraform apply in v5/...
✓ Terraform apply successful
Capturing v5 state...
✓ Saved v5 state to tmp/v5-state.json

Step 4: Verifying stable state (v5 plan after apply)
Running terraform plan again to check for ongoing drift...
✓ No ongoing drift detected - migration achieved stable state!



========================================
✓ E2E Test Complete!
========================================

Summary:

  Step 1: v4 terraform apply
    Status: ✓ SUCCESS

  Step 2: Migration (v4 → v5)
    Status: ✓ SUCCESS

  Step 3: v5 plan (before apply)
    Status: ⚠ Changes detected but all exempted
    Result: 0 real changes (0 exempted)
    Terraform: Plan: 0 to add, 0 to change, 0 to destroy.

  Step 4: v5 terraform apply
    Status: ✓ SUCCESS

  Step 5: v5 plan (after apply)
    Status: ✓ SUCCESS - Stable state achieved
    Result: No changes detected

Logs saved to:
  - /Users/vaishak/cf-repos/github/tf-migrate/e2e/tmp
 ```