### PR TITLE
fix(drift-exemptions): exempt zero trust access identity drifts

### DIFF
--- a/e2e/drift-exemptions/zero_trust_access_identity_provider.yaml
+++ b/e2e/drift-exemptions/zero_trust_access_identity_provider.yaml
@@ -7,6 +7,12 @@
 version: 1
 
 exemptions:
+  - name: "azure_conditional_access_enabled"
+    description: "After migration, the v5 provider's state upgrader does not carry forward the 'conditional_access_enabled' field for Azure AD identity providers when it was set to false in v4. The plan will show this field being added with value false. Your Conditional Access policy enforcement is not affected. This drift resolves after the next terraform apply."
+    patterns:
+      - 'conditional_access_enabled.*false'
+    enabled: true
+
   - name: "azure_support_groups"
     description: "After migration, the v5 provider's state upgrader does not carry forward the 'support_groups' field for Azure identity providers. The plan will show this field being set to false. Your Azure group sync configuration is not affected. This drift resolves after the next terraform apply."
     patterns:

--- a/internal/verifydrift/exemptions/drift-exemptions/zero_trust_access_identity_provider.yaml
+++ b/internal/verifydrift/exemptions/drift-exemptions/zero_trust_access_identity_provider.yaml
@@ -7,6 +7,12 @@
 version: 1
 
 exemptions:
+  - name: "azure_conditional_access_enabled"
+    description: "After migration, the v5 provider's state upgrader does not carry forward the 'conditional_access_enabled' field for Azure AD identity providers when it was set to false in v4. The plan will show this field being added with value false. Your Conditional Access policy enforcement is not affected. This drift resolves after the next terraform apply."
+    patterns:
+      - 'conditional_access_enabled.*false'
+    enabled: true
+
   - name: "azure_support_groups"
     description: "After migration, the v5 provider's state upgrader does not carry forward the 'support_groups' field for Azure identity providers. The plan will show this field being set to false. Your Azure group sync configuration is not affected. This drift resolves after the next terraform apply."
     patterns:


### PR DESCRIPTION
exempt conditional_access_enabled false->null for identity providers

The v5 provider state upgrader uses FalseyBoolToNull for ConditionalAccessEnabled, which drops 'false' values to null. For Azure AD identity providers that explicitly set 'conditional_access_enabled = false' in their v4 config, tf-migrate correctly preserves that value in the migrated v5 config — but the state upgrader discards it.

This causes a one-time plan diff of '+ conditional_access_enabled = false' after migration. The provider's normalizeReadZeroTrustIDPConfigData already handles this stably after the first apply (it copies null back from state when both are false), so the drift does not recur.

Add an exemption matching the existing 'azure_support_groups' pattern.

Note: support_groups was already exempted; this adds the parallel exemption for conditional_access_enabled.


```
========================================
✓ E2E Test Complete!
========================================

Summary:

  Step 1: v4 terraform apply
    Status: ✓ SUCCESS

  Step 2: Migration (v4 → v5)
    Status: ✓ SUCCESS

  Step 3: v5 plan (before apply)
    Status: ✓ SUCCESS - Drift matched exemptions
    Result: 4 material changes (4 matched exemptions, 0 unmatched)
    Terraform: Plan: 0 to add, 3 to change, 0 to destroy.

  Step 4: v5 terraform apply
    Status: ✓ SUCCESS

  Step 5: v5 plan (after apply)
    Status: ✓ SUCCESS - Stable state achieved
    Result: No changes detected

```