### PR TITLE
Zero trust gateway certificate fix

### DIFF
--- a/integration/v4_to_v5/testdata/zero_trust_gateway_certificate/input/zero_trust_gateway_certificate_e2e.tf
+++ b/integration/v4_to_v5/testdata/zero_trust_gateway_certificate/input/zero_trust_gateway_certificate_e2e.tf
@@ -25,7 +25,15 @@ resource "cloudflare_zero_trust_gateway_certificate" "with_lifecycle" {
   activate             = true
 
   lifecycle {
-    create_before_destroy = true
-    ignore_changes        = [activate]
+    # create_before_destroy is intentionally omitted: the gateway certificate API
+    # returns 500 when attempting to delete an active certificate, so recreation
+    # would leave a deposed object that can never be cleaned up.
+    #
+    # validity_period_days and gateway_managed are both RequiresReplace attributes.
+    # We ignore them in E2E tests to prevent Terraform from planning a replacement
+    # when the existing certificate was created with different values (e.g. from a
+    # prior test run). The migration logic for these attributes is covered by
+    # integration tests which use fixture data.
+    ignore_changes = [activate, validity_period_days, gateway_managed]
   }
 }

--- a/integration/v4_to_v5/testdata/zero_trust_gateway_certificate/input/zero_trust_gateway_certificate_e2e.tf
+++ b/integration/v4_to_v5/testdata/zero_trust_gateway_certificate/input/zero_trust_gateway_certificate_e2e.tf
@@ -29,11 +29,11 @@ resource "cloudflare_zero_trust_gateway_certificate" "with_lifecycle" {
     # returns 500 when attempting to delete an active certificate, so recreation
     # would leave a deposed object that can never be cleaned up.
     #
-    # validity_period_days and gateway_managed are both RequiresReplace attributes.
-    # We ignore them in E2E tests to prevent Terraform from planning a replacement
-    # when the existing certificate was created with different values (e.g. from a
-    # prior test run). The migration logic for these attributes is covered by
-    # integration tests which use fixture data.
-    ignore_changes = [activate, validity_period_days, gateway_managed]
+    # validity_period_days is a RequiresReplace attribute. We ignore it in E2E
+    # tests to prevent Terraform from planning a replacement when the existing
+    # certificate was created with a different value (e.g. from a prior test run).
+    # The migration logic for this attribute is covered by integration tests
+    # which use fixture data.
+    ignore_changes = [activate, validity_period_days]
   }
 }

--- a/integration/v4_to_v5/testdata/zero_trust_gateway_settings/input/zero_trust_gateway_settings_e2e.tf
+++ b/integration/v4_to_v5/testdata/zero_trust_gateway_settings/input/zero_trust_gateway_settings_e2e.tf
@@ -30,6 +30,11 @@ variable "cloudflare_domain" {
 # - antivirus (requires entitlement)
 # - extended_email_matching (may require entitlement)
 # - certificate/custom_certificate (requires real cert IDs)
+#
+# Note: tls_decrypt_enabled is set to false because the Cloudflare API now
+# requires a certificate to be configured when TLS decryption is enabled
+# (API error 2211). fips.tls is also set to false since FIPS TLS mode
+# depends on TLS decryption being active.
 # ============================================================================
 
 resource "cloudflare_teams_account" "e2e_comprehensive" {
@@ -37,7 +42,7 @@ resource "cloudflare_teams_account" "e2e_comprehensive" {
 
   # Flat boolean fields -> nested structures in v5
   activity_log_enabled       = true
-  tls_decrypt_enabled        = true
+  tls_decrypt_enabled        = false
   protocol_detection_enabled = true
 
   # Browser isolation fields set to false (no entitlement needed for false values)
@@ -60,7 +65,7 @@ resource "cloudflare_teams_account" "e2e_comprehensive" {
   }
 
   fips {
-    tls = true
+    tls = false
   }
 
   # Deprecated blocks - these will create separate resources in v5


### PR DESCRIPTION
## PR Summary

**Fix E2E test failures caused by API enforcement changes**

Two E2E test fixtures needed updates to handle recent Cloudflare API enforcement changes and lifecycle constraints that prevent clean test runs.

### `zero_trust_gateway_settings`

The Cloudflare API now rejects `tls_decrypt_enabled = true` with error 2211 unless a certificate is also configured. The E2E fixture had `tls_decrypt_enabled = true` with no certificate block, causing the **v4 `terraform apply`** step to fail before migration even begins. `fips.tls = true` was also disabled since FIPS TLS mode depends on TLS decryption being active. Migration logic for both fields is covered by integration tests using fixture data.

### `zero_trust_gateway_certificate`

Two related issues:

1. **500 on DELETE**: The API returns 500 when attempting to delete an active gateway certificate. The fixture had `create_before_destroy = true`, which caused Terraform to create a new cert then fail trying to destroy the old deposed object — leaving dangling state.

2. **Unintended replacement**: `validity_period_days` is a `RequiresReplace` attribute. If the existing certificate in the test account was created with a different value, Terraform plans a full replacement on every run, hitting the 3-certs-per-24h rate limit. `gateway_managed` was also removed from `ignore_changes` as it does not exist as a user-settable attribute in the v5 schema (it was v4-only; v5 uses a computed `type` attribute instead).

**Fix**: Remove `create_before_destroy`, add `validity_period_days` to `ignore_changes` to prevent replacement of the existing certificate across test runs.

---

