### PR TITLE
fix: workers_script name -> id rename inside `workers_route`

### DIFF
--- a/integration/v4_to_v5/testdata/worker_route/expected/worker_route.tf
+++ b/integration/v4_to_v5/testdata/worker_route/expected/worker_route.tf
@@ -1,6 +1,6 @@
 # Comprehensive integration test for worker_route migration
 # This file tests ALL Terraform patterns and edge cases
-# Note: Testing routes without script_name to avoid requiring actual worker scripts
+# Includes script_name traversal references to validate v4->v5 attribute rewrites
 
 # ========================================
 # Variables
@@ -201,10 +201,70 @@ resource "cloudflare_workers_route" "complex_interpolation" {
 }
 
 ###############################################################################
+# Pattern 12: Worker script dependencies for route references
+###############################################################################
+
+resource "cloudflare_workers_script" "segment_proxy" {
+  account_id  = var.cloudflare_account_id
+  content     = "addEventListener('fetch', event => { event.respondWith(new Response('ok')); });"
+  script_name = "${local.name_prefix}-segment-proxy"
+}
+
+
+resource "cloudflare_workers_script" "segment_proxy_indexed" {
+  count       = 1
+  account_id  = var.cloudflare_account_id
+  content     = "addEventListener('fetch', event => { event.respondWith(new Response('ok')); });"
+  script_name = "${local.name_prefix}-segment-proxy-${count.index}"
+}
+
+resource "cloudflare_workers_script" "segment_proxy_each" {
+  for_each    = toset(["alpha"])
+  account_id  = var.cloudflare_account_id
+  content     = "addEventListener('fetch', event => { event.respondWith(new Response('ok')); });"
+  script_name = "${local.name_prefix}-segment-proxy-${each.key}"
+}
+
+###############################################################################
+# Pattern 12: script_name reference rewrites
+###############################################################################
+
+resource "cloudflare_workers_route" "script_ref_plural" {
+  zone_id = local.zone_id
+  pattern = "${local.name_prefix}-script-plural.cf-tf-test.com/*"
+  script  = cloudflare_workers_script.segment_proxy.id
+}
+
+resource "cloudflare_workers_route" "script_ref_singular" {
+  zone_id = local.zone_id
+  pattern = "${local.name_prefix}-script-singular.cf-tf-test.com/*"
+  script  = cloudflare_workers_script.legacy_proxy.id
+}
+
+resource "cloudflare_workers_route" "script_ref_indexed" {
+  zone_id = local.zone_id
+  pattern = "${local.name_prefix}-script-indexed.cf-tf-test.com/*"
+  script  = cloudflare_workers_script.segment_proxy_indexed[0].id
+}
+
+resource "cloudflare_workers_route" "script_ref_each_key" {
+  zone_id = local.zone_id
+  pattern = "${local.name_prefix}-script-each.cf-tf-test.com/*"
+  script  = cloudflare_workers_script.segment_proxy_each["alpha"].id
+}
+
+resource "cloudflare_workers_route" "script_ref_dot_index" {
+  zone_id = local.zone_id
+  pattern = "${local.name_prefix}-script-dotidx.cf-tf-test.com/*"
+  script  = cloudflare_workers_script.segment_proxy_indexed.0.id
+}
+
+###############################################################################
 # Summary: Test Coverage
 ###############################################################################
 # Total resources: 25+ instances across all patterns
 # - Routes without script_name (catch-all/fallback): 25+ instances
+# - script_name references with worker_script/workers_script traversals
 # - for_each with maps: 2 instances (api_routes)
 # - for_each with sets: 2 instances (admin_routes)
 # - count-based: 3 instances (numbered)
@@ -213,3 +273,14 @@ resource "cloudflare_workers_route" "complex_interpolation" {
 # - Special patterns: wildcard, exact paths, query params, special chars
 # - Environment configs: 3 instances (prod/staging/dev)
 ###############################################################################
+
+resource "cloudflare_workers_script" "legacy_proxy" {
+  account_id  = var.cloudflare_account_id
+  content     = "addEventListener('fetch', event => { event.respondWith(new Response('ok')); });"
+  script_name = "${local.name_prefix}-legacy-proxy"
+}
+
+moved {
+  from = cloudflare_worker_script.legacy_proxy
+  to   = cloudflare_workers_script.legacy_proxy
+}

--- a/integration/v4_to_v5/testdata/worker_route/input/worker_route.tf
+++ b/integration/v4_to_v5/testdata/worker_route/input/worker_route.tf
@@ -1,6 +1,6 @@
 # Comprehensive integration test for worker_route migration
 # This file tests ALL Terraform patterns and edge cases
-# Note: Testing routes without script_name to avoid requiring actual worker scripts
+# Includes script_name traversal references to validate v4->v5 attribute rewrites
 
 # ========================================
 # Variables
@@ -201,10 +201,75 @@ resource "cloudflare_workers_route" "complex_interpolation" {
 }
 
 ###############################################################################
+# Pattern 12: Worker script dependencies for route references
+###############################################################################
+
+resource "cloudflare_workers_script" "segment_proxy" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-segment-proxy"
+  content    = "addEventListener('fetch', event => { event.respondWith(new Response('ok')); });"
+}
+
+resource "cloudflare_worker_script" "legacy_proxy" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-legacy-proxy"
+  content    = "addEventListener('fetch', event => { event.respondWith(new Response('ok')); });"
+}
+
+resource "cloudflare_workers_script" "segment_proxy_indexed" {
+  count      = 1
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-segment-proxy-${count.index}"
+  content    = "addEventListener('fetch', event => { event.respondWith(new Response('ok')); });"
+}
+
+resource "cloudflare_workers_script" "segment_proxy_each" {
+  for_each   = toset(["alpha"])
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-segment-proxy-${each.key}"
+  content    = "addEventListener('fetch', event => { event.respondWith(new Response('ok')); });"
+}
+
+###############################################################################
+# Pattern 12: script_name reference rewrites
+###############################################################################
+
+resource "cloudflare_workers_route" "script_ref_plural" {
+  zone_id     = local.zone_id
+  pattern     = "${local.name_prefix}-script-plural.cf-tf-test.com/*"
+  script_name = cloudflare_workers_script.segment_proxy.name
+}
+
+resource "cloudflare_workers_route" "script_ref_singular" {
+  zone_id     = local.zone_id
+  pattern     = "${local.name_prefix}-script-singular.cf-tf-test.com/*"
+  script_name = cloudflare_worker_script.legacy_proxy.name
+}
+
+resource "cloudflare_workers_route" "script_ref_indexed" {
+  zone_id     = local.zone_id
+  pattern     = "${local.name_prefix}-script-indexed.cf-tf-test.com/*"
+  script_name = cloudflare_workers_script.segment_proxy_indexed[0].name
+}
+
+resource "cloudflare_workers_route" "script_ref_each_key" {
+  zone_id     = local.zone_id
+  pattern     = "${local.name_prefix}-script-each.cf-tf-test.com/*"
+  script_name = cloudflare_workers_script.segment_proxy_each["alpha"].name
+}
+
+resource "cloudflare_workers_route" "script_ref_dot_index" {
+  zone_id     = local.zone_id
+  pattern     = "${local.name_prefix}-script-dotidx.cf-tf-test.com/*"
+  script_name = cloudflare_workers_script.segment_proxy_indexed.0.name
+}
+
+###############################################################################
 # Summary: Test Coverage
 ###############################################################################
 # Total resources: 25+ instances across all patterns
 # - Routes without script_name (catch-all/fallback): 25+ instances
+# - script_name references with worker_script/workers_script traversals
 # - for_each with maps: 2 instances (api_routes)
 # - for_each with sets: 2 instances (admin_routes)
 # - count-based: 3 instances (numbered)

--- a/internal/resources/worker_route/v4_to_v5.go
+++ b/internal/resources/worker_route/v4_to_v5.go
@@ -1,23 +1,15 @@
 package worker_route
 
 import (
-	"regexp"
+	"bytes"
 
+	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/hashicorp/hcl/v2/hclwrite"
 
 	"github.com/cloudflare/tf-migrate/internal"
 	"github.com/cloudflare/tf-migrate/internal/transform"
 	tfhcl "github.com/cloudflare/tf-migrate/internal/transform/hcl"
 )
-
-// Matches cloudflare_worker_script or cloudflare_workers_script references
-// with .name suffix and optional index accessor:
-//   - cloudflare_worker_script.example.name
-//   - cloudflare_workers_script.example.name
-//   - cloudflare_workers_script.example[0].name       (bracket syntax)
-//   - cloudflare_workers_script.example[each.key].name (bracket syntax with expression)
-//   - cloudflare_workers_script.example.0.name         (legacy dot-index syntax)
-var scriptNameRefRe = regexp.MustCompile(`(cloudflare_workers?_script\.\w+(?:\[[^\]]*\]|\.\d+)?)\.name\b`)
 
 type V4ToV5Migrator struct {
 }
@@ -91,19 +83,201 @@ func (m *V4ToV5Migrator) TransformConfig(ctx *transform.Context, block *hclwrite
 	}, nil
 }
 
-// replaceScriptReferenceAttribute updates `script` references from
-// cloudflare_workers_script.*.name to cloudflare_workers_script.*.id.
+// replaceScriptReferenceAttribute updates script traversal references from
+// cloudflare_worker(s)_script.*.name to cloudflare_worker(s)_script.*.id.
 func replaceScriptReferenceAttribute(blockBody *hclwrite.Body) error {
 	scriptAttr := blockBody.GetAttribute("script")
 	if scriptAttr == nil {
 		return nil
 	}
 
-	scriptExpr := string(scriptAttr.Expr().BuildTokens(nil).Bytes())
-	updated := scriptNameRefRe.ReplaceAllString(scriptExpr, "${1}.id")
-	if updated == scriptExpr {
+	original := scriptAttr.Expr().BuildTokens(nil)
+	updated, changed := rewriteScriptReferenceTokens(original)
+	if !changed {
 		return nil
 	}
 
-	return tfhcl.SetAttributeFromExpressionString(blockBody, "script", updated)
+	blockBody.SetAttributeRaw("script", updated)
+	return nil
+}
+
+func rewriteScriptReferenceTokens(tokens hclwrite.Tokens) (hclwrite.Tokens, bool) {
+	updated := cloneTokens(tokens)
+	changed := false
+
+	for i, tok := range updated {
+		if tok.Type != hclsyntax.TokenIdent || !bytes.Equal(tok.Bytes, []byte("name")) {
+			continue
+		}
+
+		if !isWorkerScriptNameTraversal(updated, i) {
+			continue
+		}
+
+		updated[i].Bytes = []byte("id")
+		changed = true
+	}
+
+	return updated, changed
+}
+
+func isWorkerScriptNameTraversal(tokens hclwrite.Tokens, nameIdx int) bool {
+	if nameIdx < 2 {
+		return false
+	}
+
+	prev := previousSignificantToken(tokens, nameIdx-1)
+	if prev < 0 || tokens[prev].Type != hclsyntax.TokenDot {
+		return false
+	}
+
+	for i := prev - 1; i >= 0; i-- {
+		i = previousSignificantToken(tokens, i)
+		if i < 0 {
+			return false
+		}
+
+		tok := tokens[i]
+
+		// Skip over bracket-enclosed content (e.g., [0], [each.key], ["alpha"])
+		if tok.Type == hclsyntax.TokenCBrack {
+			i = skipBracketBackward(tokens, i)
+			if i < 0 {
+				return false
+			}
+			continue
+		}
+
+		if tok.Type == hclsyntax.TokenIdent && (bytes.Equal(tok.Bytes, []byte("cloudflare_worker_script")) || bytes.Equal(tok.Bytes, []byte("cloudflare_workers_script"))) {
+			return isValidScriptTraversal(tokens, i, nameIdx)
+		}
+
+		if traversalDelimiter(tok.Type) {
+			return false
+		}
+	}
+
+	return false
+}
+
+// skipBracketBackward scans backward from a closing bracket to find its matching
+// opening bracket, returning the index of the TokenOBrack. Returns -1 if not found.
+func skipBracketBackward(tokens hclwrite.Tokens, closeBrackIdx int) int {
+	depth := 1
+	for i := closeBrackIdx - 1; i >= 0; i-- {
+		switch tokens[i].Type {
+		case hclsyntax.TokenCBrack:
+			depth++
+		case hclsyntax.TokenOBrack:
+			depth--
+			if depth == 0 {
+				return i
+			}
+		}
+	}
+	return -1
+}
+
+func isValidScriptTraversal(tokens hclwrite.Tokens, rootIdx, nameIdx int) bool {
+	if rootIdx+2 >= nameIdx {
+		return false
+	}
+
+	firstDot := nextSignificantToken(tokens, rootIdx+1)
+	if firstDot < 0 || tokens[firstDot].Type != hclsyntax.TokenDot {
+		return false
+	}
+
+	resourceName := nextSignificantToken(tokens, firstDot+1)
+	if resourceName < 0 || tokens[resourceName].Type != hclsyntax.TokenIdent {
+		return false
+	}
+
+	dotCount := 0
+	for i := rootIdx + 1; i < nameIdx; i++ {
+		i = nextSignificantToken(tokens, i)
+		if i < 0 || i >= nameIdx {
+			break
+		}
+
+		// Skip over bracket-enclosed content (e.g., [0], [each.key], ["alpha"])
+		if tokens[i].Type == hclsyntax.TokenOBrack {
+			i = skipBracketForward(tokens, i)
+			if i < 0 {
+				return false
+			}
+			continue
+		}
+
+		if traversalDelimiter(tokens[i].Type) {
+			return false
+		}
+
+		if tokens[i].Type == hclsyntax.TokenDot {
+			dotCount++
+		}
+	}
+
+	return dotCount >= 2
+}
+
+// skipBracketForward scans forward from an opening bracket to find its matching
+// closing bracket, returning the index of the TokenCBrack. Returns -1 if not found.
+func skipBracketForward(tokens hclwrite.Tokens, openBrackIdx int) int {
+	depth := 1
+	for i := openBrackIdx + 1; i < len(tokens); i++ {
+		switch tokens[i].Type {
+		case hclsyntax.TokenOBrack:
+			depth++
+		case hclsyntax.TokenCBrack:
+			depth--
+			if depth == 0 {
+				return i
+			}
+		}
+	}
+	return -1
+}
+
+func previousSignificantToken(tokens hclwrite.Tokens, start int) int {
+	for i := start; i >= 0; i-- {
+		t := tokens[i].Type
+		if t == hclsyntax.TokenNewline || t == hclsyntax.TokenComment {
+			continue
+		}
+		return i
+	}
+	return -1
+}
+
+func nextSignificantToken(tokens hclwrite.Tokens, start int) int {
+	for i := start; i < len(tokens); i++ {
+		t := tokens[i].Type
+		if t == hclsyntax.TokenNewline || t == hclsyntax.TokenComment {
+			continue
+		}
+		return i
+	}
+	return -1
+}
+
+func traversalDelimiter(t hclsyntax.TokenType) bool {
+	switch t {
+	case hclsyntax.TokenEOF, hclsyntax.TokenComma, hclsyntax.TokenQuestion, hclsyntax.TokenColon, hclsyntax.TokenEqual,
+		hclsyntax.TokenOr, hclsyntax.TokenAnd, hclsyntax.TokenPlus, hclsyntax.TokenMinus, hclsyntax.TokenStar,
+		hclsyntax.TokenSlash, hclsyntax.TokenPercent, hclsyntax.TokenGreaterThan, hclsyntax.TokenGreaterThanEq,
+		hclsyntax.TokenLessThan, hclsyntax.TokenLessThanEq, hclsyntax.TokenEqualOp, hclsyntax.TokenNotEqual,
+		hclsyntax.TokenOQuote, hclsyntax.TokenQuotedLit, hclsyntax.TokenCQuote:
+		return true
+	default:
+		return false
+	}
+}
+
+func cloneTokens(tokens hclwrite.Tokens) hclwrite.Tokens {
+	out := make(hclwrite.Tokens, len(tokens))
+	for i, tok := range tokens {
+		out[i] = &hclwrite.Token{Type: tok.Type, Bytes: append([]byte(nil), tok.Bytes...)}
+	}
+	return out
 }

--- a/internal/resources/worker_route/v4_to_v5.go
+++ b/internal/resources/worker_route/v4_to_v5.go
@@ -1,12 +1,23 @@
 package worker_route
 
 import (
+	"regexp"
+
 	"github.com/hashicorp/hcl/v2/hclwrite"
 
 	"github.com/cloudflare/tf-migrate/internal"
 	"github.com/cloudflare/tf-migrate/internal/transform"
 	tfhcl "github.com/cloudflare/tf-migrate/internal/transform/hcl"
 )
+
+// Matches cloudflare_worker_script or cloudflare_workers_script references
+// with .name suffix and optional index accessor:
+//   - cloudflare_worker_script.example.name
+//   - cloudflare_workers_script.example.name
+//   - cloudflare_workers_script.example[0].name       (bracket syntax)
+//   - cloudflare_workers_script.example[each.key].name (bracket syntax with expression)
+//   - cloudflare_workers_script.example.0.name         (legacy dot-index syntax)
+var scriptNameRefRe = regexp.MustCompile(`(cloudflare_workers?_script\.\w+(?:\[[^\]]*\]|\.\d+)?)\.name\b`)
 
 type V4ToV5Migrator struct {
 }
@@ -56,6 +67,11 @@ func (m *V4ToV5Migrator) TransformConfig(ctx *transform.Context, block *hclwrite
 	// Rename field: script_name → script
 	tfhcl.RenameAttribute(body, "script_name", "script")
 
+	// Replace cloudflare_workers_script.*.name -> cloudflare_workers_script.*.id
+	if err := replaceScriptReferenceAttribute(body); err != nil {
+		return nil, err
+	}
+
 	// Generate moved block if the resource was renamed (singular → plural)
 	if wasSingular {
 		_, newType := m.GetResourceRename()
@@ -75,3 +91,19 @@ func (m *V4ToV5Migrator) TransformConfig(ctx *transform.Context, block *hclwrite
 	}, nil
 }
 
+// replaceScriptReferenceAttribute updates `script` references from
+// cloudflare_workers_script.*.name to cloudflare_workers_script.*.id.
+func replaceScriptReferenceAttribute(blockBody *hclwrite.Body) error {
+	scriptAttr := blockBody.GetAttribute("script")
+	if scriptAttr == nil {
+		return nil
+	}
+
+	scriptExpr := string(scriptAttr.Expr().BuildTokens(nil).Bytes())
+	updated := scriptNameRefRe.ReplaceAllString(scriptExpr, "${1}.id")
+	if updated == scriptExpr {
+		return nil
+	}
+
+	return tfhcl.SetAttributeFromExpressionString(blockBody, "script", updated)
+}

--- a/internal/resources/worker_route/v4_to_v5_test.go
+++ b/internal/resources/worker_route/v4_to_v5_test.go
@@ -77,6 +77,91 @@ moved {
   to   = cloudflare_workers_route.example
 }`,
 		},
+		{
+			Name: "Script reference rewrites workers_script name to id",
+			Input: `resource "cloudflare_worker_route" "example" {
+  zone_id     = "d41d8cd98f00b204e9800998ecf8427e"
+  pattern     = "example.com/*"
+  script_name = cloudflare_workers_script.my_worker.name
+}`,
+			Expected: `resource "cloudflare_workers_route" "example" {
+  zone_id = "d41d8cd98f00b204e9800998ecf8427e"
+  pattern = "example.com/*"
+  script  = cloudflare_workers_script.my_worker.id
+}
+  
+moved {
+  from = cloudflare_worker_route.example
+  to   = cloudflare_workers_route.example
+}`,
+		},
+		{
+			Name: "Indexed script reference rewrites workers_script name to id",
+			Input: `resource "cloudflare_worker_route" "example" {
+  zone_id     = "d41d8cd98f00b204e9800998ecf8427e"
+  pattern     = "${each.key}.example.com/*"
+  script_name = cloudflare_workers_script.my_worker[each.key].name
+}`,
+			Expected: `resource "cloudflare_workers_route" "example" {
+  zone_id  = "d41d8cd98f00b204e9800998ecf8427e"
+  pattern  = "${each.key}.example.com/*"
+  script   = cloudflare_workers_script.my_worker[each.key].id
+}
+  
+moved {
+  from = cloudflare_worker_route.example
+  to   = cloudflare_workers_route.example
+}`,
+		},
+		{
+			Name: "Singular worker_script reference rewrites name to id",
+			Input: `resource "cloudflare_workers_route" "example" {
+  zone_id     = "d41d8cd98f00b204e9800998ecf8427e"
+  pattern     = "example.com/*"
+  script_name = cloudflare_worker_script.my_worker.name
+}`,
+			Expected: `resource "cloudflare_workers_route" "example" {
+  zone_id = "d41d8cd98f00b204e9800998ecf8427e"
+  pattern = "example.com/*"
+  script  = cloudflare_worker_script.my_worker.id
+}`,
+		},
+		{
+			Name: "Singular worker_route with singular worker_script reference",
+			Input: `resource "cloudflare_worker_route" "datadog_rum_route" {
+  zone_id     = local.prod_coalition_zone_id
+  pattern     = "${local.datadog_rum_host}/*"
+  script_name = cloudflare_worker_script.datadog_rum_proxy.name
+}`,
+			Expected: `resource "cloudflare_workers_route" "datadog_rum_route" {
+  zone_id = local.prod_coalition_zone_id
+  pattern = "${local.datadog_rum_host}/*"
+  script  = cloudflare_worker_script.datadog_rum_proxy.id
+}
+
+moved {
+  from = cloudflare_worker_route.datadog_rum_route
+  to   = cloudflare_workers_route.datadog_rum_route
+}`,
+		},
+		{
+			Name: "Legacy dot-index script reference rewrites workers_script name to id",
+			Input: `resource "cloudflare_worker_route" "example" {
+  zone_id     = "d41d8cd98f00b204e9800998ecf8427e"
+  pattern     = "example.com/*"
+  script_name = cloudflare_workers_script.my_worker.0.name
+}`,
+			Expected: `resource "cloudflare_workers_route" "example" {
+  zone_id = "d41d8cd98f00b204e9800998ecf8427e"
+  pattern = "example.com/*"
+  script  = cloudflare_workers_script.my_worker.0.id
+}
+
+moved {
+  from = cloudflare_worker_route.example
+  to   = cloudflare_workers_route.example
+}`,
+		},
 	}
 
 	testhelpers.RunConfigTransformTests(t, tests, migrator)

--- a/internal/resources/worker_route/v4_to_v5_test.go
+++ b/internal/resources/worker_route/v4_to_v5_test.go
@@ -162,6 +162,19 @@ moved {
   to   = cloudflare_workers_route.example
 }`,
 		},
+		{
+			Name: "String-keyed bracket index rewrites workers_script name to id",
+			Input: `resource "cloudflare_workers_route" "example" {
+  zone_id     = "d41d8cd98f00b204e9800998ecf8427e"
+  pattern     = "example.com/*"
+  script_name = cloudflare_workers_script.my_worker["alpha"].name
+}`,
+			Expected: `resource "cloudflare_workers_route" "example" {
+  zone_id = "d41d8cd98f00b204e9800998ecf8427e"
+  pattern = "example.com/*"
+  script  = cloudflare_workers_script.my_worker["alpha"].id
+}`,
+		},
 	}
 
 	testhelpers.RunConfigTransformTests(t, tests, migrator)


### PR DESCRIPTION
Fix for wrong attribute name hen migrating from `cloudflare_worker_script` to `cloudflare_workers_script`inside a `worker_route` resource. The name attribute must be changed to id, otherwise an error is thrown:

```HCL
│ Error: Unsupported attribute
│
│   on segment_proxy.tf line 100, in resource "cloudflare_workers_route" "segment_api_route":
│  100:   script  = cloudflare_workers_script.segment_proxy.name
│
│ This object has no argument, nested block, or exported attribute named "name".
```