### PR TITLE
**fix: extract `profile_id` from import-address annotation for predefined DLP profiles + Atlantis migration guide**

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,6 +299,134 @@ tf-migrate verify-drift --file plan.txt || exit 1
 
 ---
 
+## Migrating an Atlantis-Managed Workspace
+
+This section covers migrating a Terraform workspace that uses [Atlantis](https://www.runatlantis.io/) for CI/CD. The key constraints are:
+
+- **You cannot run `terraform init -upgrade` in Atlantis** — Atlantis runs its own `terraform init` as part of its workflow and does not support remote flags.
+- **The remote state backend is typically unreachable from your local machine** — running `terraform init` locally will fail if the backend requires network access inside a private environment.
+- **The `.terraform.lock.hcl` must be committed with v5 hashes** — Atlantis uses the lock file as-is and will not upgrade providers on its own.
+
+### Prerequisites
+
+- `tf-migrate` binary (see [Installation](#installation))
+- Terraform CLI installed locally (same version as used in Atlantis — check `terraform_version` in `atlantis.yaml`)
+- Access to the Git repository
+
+### Step-by-step
+
+#### 1. Run tf-migrate against your config directory
+
+```bash
+tf-migrate migrate \
+  --config-dir ./tf/your-workspace \
+  --source-version v4 \
+  --target-version v5
+```
+
+tf-migrate transforms all `.tf` files in-place (with `.backup` files alongside each original) and prints a summary of:
+- Resources renamed
+- Cross-file references updated
+- Warnings for anything requiring manual follow-up
+
+Review the warnings carefully before proceeding.
+
+#### 2. Clean up backup files
+
+tf-migrate creates `.backup` files alongside every modified file. Delete them before committing:
+
+```bash
+find ./tf/your-workspace -name "*.backup" -delete
+```
+
+#### 3. Update the provider version in `main.tf`
+
+tf-migrate does not modify `required_providers`. Update the Cloudflare provider version constraint manually:
+
+```hcl
+# Before
+cloudflare = {
+  source  = "cloudflare/cloudflare"
+  version = "4.x.x"
+}
+
+# After
+cloudflare = {
+  source  = "cloudflare/cloudflare"
+  version = "5.x.x"   # target v5 version
+}
+```
+
+#### 4. Regenerate `.terraform.lock.hcl` locally with `-backend=false`
+
+Because the remote backend is not reachable locally, use `-backend=false` to skip it. This still downloads the v5 provider and regenerates the lock file with v5 hashes:
+
+```bash
+terraform -chdir=./tf/your-workspace init -upgrade -backend=false
+```
+
+> **Why `-backend=false`?** Without it, Terraform tries to initialise the remote backend, which fails if the backend endpoint (e.g. an internal HTTP state server) is only reachable from within your CI environment.
+
+#### 5. Handle `zone_settings_override` state removal (if applicable)
+
+If your workspace uses `cloudflare_zone_settings_override`, tf-migrate splits each instance into multiple `cloudflare_zone_setting` resources and emits `removed {}` blocks and `import {}` blocks in the migrated file.
+
+The v5 provider has no schema for `cloudflare_zone_settings_override`, so the old state entries must be removed **before the first `terraform plan/apply`** against the v5 provider. tf-migrate prints the exact `terraform state rm` commands needed — run them before Atlantis processes the plan:
+
+```bash
+terraform state rm 'cloudflare_zone_settings_override.your_resource_name'
+# repeat for each instance listed in the tf-migrate warnings
+```
+
+After removal, the `import {}` blocks in the migrated file will import each setting's current value from the Cloudflare API on the first `terraform apply`.
+
+#### 6. Commit everything together
+
+```bash
+git add tf/your-workspace/
+git commit -m "migrate your-workspace from cloudflare provider v4 to v5"
+```
+
+The commit should include:
+- All modified `.tf` files
+- Updated `main.tf` with the new provider version
+- Updated `.terraform.lock.hcl` with v5 hashes
+
+> **Do not commit `.backup` files** — delete them in step 2.
+
+#### 7. Push and let Atlantis plan
+
+Atlantis will pick up the committed lock file, download the v5 provider, and run `terraform plan`. The plan output will reflect the migrated v5 config.
+
+---
+
+### Why the lock file matters
+
+Atlantis uses the committed `.terraform.lock.hcl` to pin provider versions. If the lock file still references the old v4 provider (e.g. `constraints = "4.52.5"`), Atlantis will download and use the v4 provider even if `main.tf` specifies a v5 version — causing the entire plan to fail with schema errors like:
+
+```
+Error: Invalid resource type
+  The provider cloudflare/cloudflare does not support resource type "cloudflare_dns_record".
+```
+
+This is the most common mistake when migrating an Atlantis workspace. Always regenerate and commit the lock file as part of the migration.
+
+---
+
+### Summary
+
+| Step | Where | What |
+|------|-------|------|
+| 1. Run tf-migrate | Local | Transform `.tf` files |
+| 2. Delete `.backup` files | Local | Clean up before commit |
+| 3. Update `main.tf` | Local | Set v5 provider version |
+| 4. `terraform init -upgrade -backend=false` | Local | Regenerate lock file with v5 hashes |
+| 5. `terraform state rm` (if needed) | Local / CI pre-plan | Remove old `zone_settings_override` state entries |
+| 6. Commit all changes | Local | `.tf` files + `main.tf` + `.terraform.lock.hcl` |
+| 7. Push | Git | Atlantis picks up the v5 lock file and plans |
+
+---
+
 ## Command Reference
 
 ### Global Flags

--- a/e2e/drift-exemptions/zero_trust_dlp_custom_profile.yaml
+++ b/e2e/drift-exemptions/zero_trust_dlp_custom_profile.yaml
@@ -1,0 +1,30 @@
+# Drift Exemptions for zero_trust_dlp_custom_profile resource
+#
+# This module contains cloudflare_zero_trust_gateway_policy resources that
+# reference DLP profiles, and those policies exhibit the same drift patterns
+# as the standalone zero_trust_gateway_policy module.
+
+version: 1
+
+exemptions:
+  - name: "precedence_normalization"
+    description: "The v5 provider respects the config-specified precedence value and plans to send it to the API, replacing the server-assigned collision-avoidance value stored in v4 state (e.g. 3000433 -> 3000). This is one-time drift that resolves after the first terraform apply — the API accepts the config value and the plan stabilises."
+    resource_types:
+      - "cloudflare_zero_trust_gateway_policy"
+    patterns:
+      - '~ precedence\s*='
+      - 'precedence\s*=\s*\d{4,}\s*->\s*\d{1,4}'
+    enabled: true
+
+  - name: "filters_computed_to_null"
+    description: "The 'filters' field was written to state by the v4 provider based on the API response but was not explicitly set in the config. The v5 provider schema marks 'filters' as Computed+Optional, so the value is now preserved from state. This exemption covers any residual drift during the transition period."
+    resource_types:
+      - "cloudflare_zero_trust_gateway_policy"
+    patterns:
+      - '-\s*filters\s*=\s*\['
+      - 'filters.*->.*null'
+    enabled: true
+
+settings:
+  apply_exemptions: true
+  verbose_exemptions: false

--- a/integration/v4_to_v5/testdata/zero_trust_dlp_predefined_profile/expected/zero_trust_dlp_predefined_profile.tf
+++ b/integration/v4_to_v5/testdata/zero_trust_dlp_predefined_profile/expected/zero_trust_dlp_predefined_profile.tf
@@ -18,6 +18,7 @@ variable "cloudflare_domain" {
 
 
 
+
 # Pattern 1: Basic predefined profile with entries
 resource "cloudflare_zero_trust_dlp_predefined_profile" "aws_keys" {
   account_id          = var.cloudflare_account_id
@@ -73,4 +74,20 @@ resource "cloudflare_zero_trust_dlp_predefined_profile" "all_disabled" {
 moved {
   from = cloudflare_dlp_profile.all_disabled
   to   = cloudflare_zero_trust_dlp_predefined_profile.all_disabled
+}
+
+# Pattern 5: Predefined profile with profile_id from import-address annotation
+# tf-migrate:import-address=${var.cloudflare_account_id}/c8932cc4-3312-4152-8041-f3f257122dc4
+resource "cloudflare_zero_trust_dlp_predefined_profile" "with_import_annotation" {
+  account_id          = var.cloudflare_account_id
+  allowed_match_count = 0
+
+
+  enabled_entries = []
+  profile_id      = "c8932cc4-3312-4152-8041-f3f257122dc4"
+}
+
+moved {
+  from = cloudflare_dlp_profile.with_import_annotation
+  to   = cloudflare_zero_trust_dlp_predefined_profile.with_import_annotation
 }

--- a/integration/v4_to_v5/testdata/zero_trust_dlp_predefined_profile/input/zero_trust_dlp_predefined_profile.tf
+++ b/integration/v4_to_v5/testdata/zero_trust_dlp_predefined_profile/input/zero_trust_dlp_predefined_profile.tf
@@ -94,3 +94,24 @@ resource "cloudflare_dlp_profile" "all_disabled" {
     enabled = false
   }
 }
+
+# Pattern 5: Predefined profile with profile_id from import-address annotation
+# tf-migrate:import-address=${var.cloudflare_account_id}/c8932cc4-3312-4152-8041-f3f257122dc4
+resource "cloudflare_dlp_profile" "with_import_annotation" {
+  account_id          = var.cloudflare_account_id
+  name                = "Credentials and Secrets"
+  type                = "predefined"
+  allowed_match_count = 0
+
+  entry {
+    id      = "d8fcfc9c-773c-405e-8426-21ecbb67ba93"
+    name    = "Amazon AWS Access Key ID"
+    enabled = false
+  }
+
+  entry {
+    id      = "2c0e33e1-71da-40c8-aad3-32e674ad3d96"
+    name    = "Amazon AWS Secret Access Key"
+    enabled = false
+  }
+}

--- a/internal/resources/zero_trust_dlp_custom_profile/v4_to_v5.go
+++ b/internal/resources/zero_trust_dlp_custom_profile/v4_to_v5.go
@@ -2,6 +2,8 @@ package zero_trust_dlp_custom_profile
 
 import (
 	"fmt"
+	"regexp"
+	"strings"
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
@@ -82,7 +84,7 @@ func (m *V4ToV5Migrator) TransformConfig(ctx *transform.Context, block *hclwrite
 		tfhcl.RenameResourceType(block, currentType, newType)
 		tfhcl.RemoveAttributes(body, "type")
 		tfhcl.RemoveAttributes(body, "name") // name is read-only (Computed) in v5 predefined profiles
-		m.transformPredefinedEntryBlocks(body)
+		m.transformPredefinedEntryBlocks(body, ctx.Content, resourceName)
 
 	default:
 		return &transform.TransformResult{
@@ -211,7 +213,42 @@ func (m *V4ToV5Migrator) transformPatternBlock(entryBody *hclwrite.Body) {
 	entryBody.RemoveBlock(patternBlock)
 }
 
-func (m *V4ToV5Migrator) transformPredefinedEntryBlocks(body *hclwrite.Body) {
+// importAddressProfileIDRe matches a tf-migrate:import-address annotation of the form
+// # tf-migrate:import-address=<account_id>/<profile_id>
+// and captures the profile UUID (the second path segment).
+var importAddressProfileIDRe = regexp.MustCompile(`#\s*tf-migrate:import-address=[^/\s]+/([0-9a-f-]{36})`)
+
+// extractProfileIDFromImportAddress scans the raw file content for a
+// tf-migrate:import-address annotation that appears immediately before the given
+// resource declaration and returns the profile UUID (second path segment), or "".
+func extractProfileIDFromImportAddress(content []byte, resourceName string) string {
+	resourceDecl := regexp.MustCompile(
+		`resource\s+"cloudflare_(?:dlp_profile|zero_trust_dlp_profile|zero_trust_dlp_predefined_profile)"\s+"` +
+			regexp.QuoteMeta(resourceName) + `"`)
+
+	lines := strings.Split(string(content), "\n")
+	for i, line := range lines {
+		if resourceDecl.MatchString(line) {
+			// Search backwards through the preceding comment block for the annotation.
+			for j := i - 1; j >= 0; j-- {
+				trimmed := strings.TrimSpace(lines[j])
+				if trimmed == "" {
+					continue
+				}
+				if !strings.HasPrefix(trimmed, "#") {
+					break
+				}
+				if m := importAddressProfileIDRe.FindStringSubmatch(trimmed); m != nil {
+					return m[1]
+				}
+			}
+			break
+		}
+	}
+	return ""
+}
+
+func (m *V4ToV5Migrator) transformPredefinedEntryBlocks(body *hclwrite.Body, fileContent []byte, resourceName string) {
 	var enabledEntryIDs []string
 	hasEntryBlocks := false
 	for _, block := range body.Blocks() {
@@ -258,8 +295,11 @@ func (m *V4ToV5Migrator) transformPredefinedEntryBlocks(body *hclwrite.Body) {
 		}
 	}
 
+	// Resolve profile_id: prefer the resource-level id attribute (v4 state import
+	// pattern), then fall back to the tf-migrate:import-address annotation comment.
 	if idAttr := body.GetAttribute("id"); idAttr != nil {
 		tfhcl.RenameAttribute(body, "id", "profile_id")
+	} else if profileID := extractProfileIDFromImportAddress(fileContent, resourceName); profileID != "" {
+		body.SetAttributeValue("profile_id", cty.StringVal(profileID))
 	}
 }
-

--- a/internal/resources/zero_trust_dlp_custom_profile/v4_to_v5_test.go
+++ b/internal/resources/zero_trust_dlp_custom_profile/v4_to_v5_test.go
@@ -212,7 +212,7 @@ moved {
 }`,
 			},
 			{
-				Name: "Predefined profile migration",
+				Name: "Predefined profile migration - profile_id from resource id attribute",
 				Input: `resource "cloudflare_dlp_profile" "predefined" {
   id                  = "aws-keys-uuid"
   account_id          = "123456789"
@@ -249,6 +249,41 @@ moved {
 moved {
   from = cloudflare_dlp_profile.predefined
   to   = cloudflare_zero_trust_dlp_predefined_profile.predefined
+}`,
+			},
+			{
+				Name: "Predefined profile migration - profile_id from import-address annotation",
+				Input: `# tf-migrate:import-address=123456789/c8932cc4-3312-4152-8041-f3f257122dc4
+resource "cloudflare_dlp_profile" "creds" {
+  account_id          = "123456789"
+  name                = "Credentials and Secrets"
+  type                = "predefined"
+  allowed_match_count = 0
+
+  entry {
+    id      = "d8fcfc9c-773c-405e-8426-21ecbb67ba93"
+    name    = "Amazon AWS Access Key ID"
+    enabled = false
+  }
+
+  entry {
+    id      = "2c0e33e1-71da-40c8-aad3-32e674ad3d96"
+    name    = "Amazon AWS Secret Access Key"
+    enabled = false
+  }
+}`,
+				Expected: `# tf-migrate:import-address=123456789/c8932cc4-3312-4152-8041-f3f257122dc4
+resource "cloudflare_zero_trust_dlp_predefined_profile" "creds" {
+  account_id          = "123456789"
+  profile_id          = "c8932cc4-3312-4152-8041-f3f257122dc4"
+  allowed_match_count = 0
+
+  enabled_entries = []
+}
+
+moved {
+  from = cloudflare_dlp_profile.creds
+  to   = cloudflare_zero_trust_dlp_predefined_profile.creds
 }`,
 			},
 		}

--- a/internal/verifydrift/exemptions/drift-exemptions/zero_trust_dlp_custom_profile.yaml
+++ b/internal/verifydrift/exemptions/drift-exemptions/zero_trust_dlp_custom_profile.yaml
@@ -1,0 +1,30 @@
+# Drift Exemptions for zero_trust_dlp_custom_profile resource
+#
+# This module contains cloudflare_zero_trust_gateway_policy resources that
+# reference DLP profiles, and those policies exhibit the same drift patterns
+# as the standalone zero_trust_gateway_policy module.
+
+version: 1
+
+exemptions:
+  - name: "precedence_normalization"
+    description: "The v5 provider respects the config-specified precedence value and plans to send it to the API, replacing the server-assigned collision-avoidance value stored in v4 state (e.g. 3000433 -> 3000). This is one-time drift that resolves after the first terraform apply — the API accepts the config value and the plan stabilises."
+    resource_types:
+      - "cloudflare_zero_trust_gateway_policy"
+    patterns:
+      - '~ precedence\s*='
+      - 'precedence\s*=\s*\d{4,}\s*->\s*\d{1,4}'
+    enabled: true
+
+  - name: "filters_computed_to_null"
+    description: "The 'filters' field was written to state by the v4 provider based on the API response but was not explicitly set in the config. The v5 provider schema marks 'filters' as Computed+Optional, so the value is now preserved from state. This exemption covers any residual drift during the transition period."
+    resource_types:
+      - "cloudflare_zero_trust_gateway_policy"
+    patterns:
+      - '-\s*filters\s*=\s*\['
+      - 'filters.*->.*null'
+    enabled: true
+
+settings:
+  apply_exemptions: true
+  verbose_exemptions: false


### PR DESCRIPTION
### Problem

When migrating `cloudflare_dlp_profile` resources with `type = "predefined"` to `cloudflare_zero_trust_dlp_predefined_profile`, the v5 resource requires a `profile_id` field that has no equivalent in the v4 config. The profile UUID only appears in the `tf-migrate:import-address` annotation comment above the resource (e.g. `# tf-migrate:import-address=${var.account_id}/c8932cc4-3312-4152-8041-f3f257122dc4`), but the transformer was not reading it — leaving `profile_id` unset and causing `terraform plan` to fail with:

```
Error: Missing required argument
  The argument "profile_id" is required, but no definition was found.
```

### Changes

**`internal/resources/zero_trust_dlp_custom_profile/v4_to_v5.go`**

- Added `extractProfileIDFromImportAddress(content, resourceName)` — scans the raw file bytes backwards from the resource declaration through its preceding comment block, matches `# tf-migrate:import-address=<account_id>/<uuid>`, and returns the UUID
- `transformPredefinedEntryBlocks` now accepts `fileContent` and `resourceName` and falls back to annotation extraction when no resource-level `id` attribute is present (existing path retained for backwards compatibility)

**`internal/resources/zero_trust_dlp_custom_profile/v4_to_v5_test.go`**

- Renamed existing predefined profile test case to make the two paths explicit
- Added new test case: `"Predefined profile migration - profile_id from import-address annotation"` covering the real-world pattern

**`integration/v4_to_v5/testdata/zero_trust_dlp_predefined_profile/`**

- Added Pattern 5 to both `input/` and `expected/` fixtures: a predefined profile with a `tf-migrate:import-address` annotation, validating end-to-end that `profile_id` is correctly extracted and written to the migrated config

**`e2e/drift-exemptions/zero_trust_dlp_custom_profile.yaml`** *(new)*

- Adds `precedence_normalization` and `filters_computed_to_null` exemptions scoped explicitly to `cloudflare_zero_trust_gateway_policy`, covering the gateway policy resources that appear inside the `zero_trust_dlp_custom_profile` e2e test module. Explicit `resource_types` scoping is required to prevent the implicit file-name scoping from blocking these patterns from matching the correct resource type.

**`README.md`**

- New section: **Migrating an Atlantis-Managed Workspace** — covers the full end-to-end workflow for users whose Terraform state backend is unreachable locally (the common Atlantis setup). Key points: use `terraform init -upgrade -backend=false` to regenerate the lock file without connecting to the remote backend; always commit the updated lock file alongside the migrated `.tf` files; run `terraform state rm` for `zone_settings_override` entries before the first plan. Includes a summary table and a callout explaining the lock file trap (the most common failure mode).

### Testing

- All existing unit tests pass
- New unit test covers the annotation extraction path
- Integration test for `zero_trust_dlp_predefined_profile` passes with the new Pattern 5 fixture
- Full integration suite (`86` resources) passes: `go test ./internal/... ./integration/...`

---



```
========================================
✓ E2E Test Complete!
========================================

Summary:

  Step 1: v4 terraform apply
    Status: ✓ SUCCESS

  Step 2: Migration (v4 → v5)
    Status: ✓ SUCCESS

  Step 3: v5 plan (before apply)
    Status: ✓ SUCCESS - Drift matched exemptions
    Result: 2 material changes (2 matched exemptions, 0 unmatched)
    Terraform: Plan: 0 to add, 2 to change, 0 to destroy.

  Step 4: v5 terraform apply
    Status: ✓ SUCCESS

  Step 5: v5 plan (after apply)
    Status: ✓ SUCCESS - Stable state achieved
    Result: No changes detected
```