### PR TITLE
feat: v5 e2e test runner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ dist/
 
 # Local provider dev overrides
 .terraformrc-tf-migrate
+.terraformrc-su-test
 
 # E2E test files
 # Ignore v4 directory except provider.tf and backend.hcl
@@ -15,11 +16,13 @@ e2e/tf/v4/*
 !e2e/tf/v4/provider.tf
 !e2e/tf/v4/backend.hcl
 
+e2e-v5/tf
 # Migrated output
 e2e/migrated-v4_to_v5/
 
 # E2E test outputs
 e2e/tmp/
+e2e-v5/tmp/
 
 # E2E test state files (stored in remote backend)
 e2e/tf/v4/terraform.tfstate*

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ GO := go
 MAIN_PACKAGE := ./cmd/tf-migrate
 E2E_PACKAGE := ./cmd/e2e-runner
 
-.PHONY: all build build-e2e build-all test test-unit test-integration lint-testdata clean release-snapshot sync-exemptions
+.PHONY: all build build-e2e build-all test test-unit test-integration lint-testdata clean release-snapshot sync-exemptions test-state-upgrader
 
 # Default target: build all binaries
 all: build-all

--- a/cmd/e2e-runner/main.go
+++ b/cmd/e2e-runner/main.go
@@ -113,6 +113,80 @@ var cleanCmd = &cobra.Command{
 	},
 }
 
+// ============================================================================
+// V5 Upgrade Commands - Tests provider v5 upgrades for v5→v5 migrations
+// ============================================================================
+
+var v5UpgradeCleanCmd = &cobra.Command{
+	Use:          "v5-upgrade-clean",
+	Short:        "Clean up v5 upgrade test resources",
+	Long:         `Destroys resources and removes them from the v5 upgrade test state. Use --modules to target specific modules.`,
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cfg := &e2e.V5UpgradeConfig{
+			FromVersion: cmd.Flag("from-version").Value.String(),
+			ToVersion:   cmd.Flag("to-version").Value.String(),
+		}
+
+		var modules []string
+		modulesStr, _ := cmd.Flags().GetString("modules")
+		if modulesStr != "" {
+			for _, m := range strings.Split(modulesStr, ",") {
+				m = strings.TrimSpace(m)
+				if m != "" {
+					modules = append(modules, m)
+				}
+			}
+		}
+
+		return e2e.RunV5UpgradeClean(cfg, modules)
+	},
+}
+
+var v5UpgradeCmd = &cobra.Command{
+	Use:          "v5-upgrade",
+	Short:        "Test provider v5 upgrades for v5→v5 migrations",
+	SilenceUsage: true,
+	Long: `Tests that provider v5 upgrades work correctly when upgrading between v5 versions.
+
+This command validates that users can safely upgrade from older v5 provider versions
+(e.g., 5.18.0) to newer versions without state corruption or unexpected drift.
+
+Unlike v4→v5 migration tests, these tests:
+  - Do NOT use tf-migrate (configs are already v5 syntax)
+  - Test the provider's built-in UpgradeState mechanism
+  - Create resources with an older v5 version, then upgrade the provider
+
+Examples:
+  # Run with local provider (recommended)
+  e2e v5-upgrade --from-version 5.18.0 --provider ../provider --apply-exemptions
+
+  # Run with registry provider
+  e2e v5-upgrade --from-version 5.18.0 --to-version latest --apply-exemptions
+
+  # Run and clean up after
+  e2e v5-upgrade --from-version 5.18.0 --provider ../provider --clean
+
+  # Test specific resources
+  e2e v5-upgrade --from-version 5.18.0 --resources dns_record,ruleset --provider ../provider`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		parallelism, _ := cmd.Flags().GetInt("parallelism")
+
+		cfg := &e2e.V5UpgradeConfig{
+			FromVersion:     cmd.Flag("from-version").Value.String(),
+			ToVersion:       cmd.Flag("to-version").Value.String(),
+			Resources:       cmd.Flag("resources").Value.String(),
+			Exclude:         cmd.Flag("exclude").Value.String(),
+			ApplyExemptions: cmd.Flag("apply-exemptions").Changed,
+			Parallelism:     parallelism,
+			SkipCreate:      cmd.Flag("skip-create").Changed,
+			ProviderPath:    cmd.Flag("provider").Value.String(),
+			Clean:           cmd.Flag("clean").Changed,
+		}
+		return e2e.RunV5UpgradeTests(cfg)
+	},
+}
+
 func init() {
 	// Init command flags
 	initCmd.Flags().String("resources", "", "Target specific resources (comma-separated)")
@@ -135,11 +209,29 @@ func init() {
 	// Clean command flags
 	cleanCmd.Flags().String("modules", "", "Modules to remove from state (comma-separated)")
 
+	// V5 Upgrade command flags
+	v5UpgradeCmd.Flags().String("from-version", e2e.DefaultFromVersion, "Source provider version (e.g., 5.18.0)")
+	v5UpgradeCmd.Flags().String("to-version", e2e.DefaultToVersion, "Target provider version (e.g., latest, 5.20.0)")
+	v5UpgradeCmd.Flags().String("resources", "", "Target specific resources (comma-separated)")
+	v5UpgradeCmd.Flags().String("exclude", "", "Exclude specific resources (comma-separated)")
+	v5UpgradeCmd.Flags().Bool("apply-exemptions", false, "Apply drift exemptions from global and resource-specific configs")
+	v5UpgradeCmd.Flags().Int("parallelism", 0, "Terraform parallelism for plan/apply (0 uses Terraform default)")
+	v5UpgradeCmd.Flags().Bool("skip-create", false, "Skip resource creation, use existing state")
+	v5UpgradeCmd.Flags().String("provider", "", "Path to local provider source directory (will be built automatically)")
+	v5UpgradeCmd.Flags().Bool("clean", false, "Destroy resources and clean up state after test completes")
+
+	// V5 Upgrade Clean command flags
+	v5UpgradeCleanCmd.Flags().String("from-version", e2e.DefaultFromVersion, "Source provider version (e.g., 5.18.0)")
+	v5UpgradeCleanCmd.Flags().String("to-version", e2e.DefaultToVersion, "Target provider version (e.g., latest, 5.20.0)")
+	v5UpgradeCleanCmd.Flags().String("modules", "", "Modules to clean (comma-separated, e.g., 'page_rule,dns_record')")
+
 	rootCmd.AddCommand(initCmd)
 	rootCmd.AddCommand(migrateCmd)
 	rootCmd.AddCommand(runCmd)
 	rootCmd.AddCommand(bootstrapCmd)
 	rootCmd.AddCommand(cleanCmd)
+	rootCmd.AddCommand(v5UpgradeCmd)
+	rootCmd.AddCommand(v5UpgradeCleanCmd)
 }
 
 func main() {

--- a/e2e-v5/global-drift-exemptions.yaml
+++ b/e2e-v5/global-drift-exemptions.yaml
@@ -1,0 +1,84 @@
+# Global Drift Exemptions for v5→v5 State Upgrader Tests
+#
+# These exemptions apply to ALL resources during state upgrader testing.
+# Since we're testing within v5 versions, we expect minimal drift compared to v4→v5 migrations.
+
+version: 1
+
+exemptions:
+  # Standard computed field exemptions
+  - name: "computed_value_refreshes"
+    description: "Some attributes are marked as '(known after apply)' because their value is computed server-side. This is normal Terraform behavior and not caused by state upgraders."
+    patterns:
+      - '\(known after apply\)'
+      - '= \{\} -> null'
+    enabled: true
+
+  # Null to empty object/array changes
+  - name: "null_to_empty"
+    description: "Provider may normalize null values to empty objects/arrays between versions."
+    patterns:
+      - '= null -> \[\]'
+      - '= null -> \{\}'
+      - '= \[\] -> null'
+      - '= \{\} -> null'
+    enabled: true
+
+  # Gateway policy provider normalization/computed-default drift (matches v4->v5 exemptions)
+  - name: "gateway_policy_duration_normalization"
+    description: "Gateway policy duration values may normalize between config and API representations (for example 24h vs 24h0m0s)."
+    patterns:
+      - 'duration.*0m0s.*->'
+      - '~ duration'
+    enabled: true
+
+  - name: "gateway_policy_audit_ssh_computed_defaults"
+    description: "Gateway policy audit_ssh command_logging may be returned as a computed default by the API."
+    patterns:
+      - 'command_logging = true'
+      - 'audit_ssh\s*=\s*\{'
+    enabled: true
+
+  - name: "gateway_policy_rule_settings_computed_defaults"
+    description: "Gateway policy computed defaults like block_page_enabled and ip_categories may reappear in plans."
+    patterns:
+      - 'block_page_enabled.*=.*false'
+      - 'ip_categories.*=.*false'
+    enabled: true
+
+  - name: "gateway_policy_precedence_normalization"
+    description: "Gateway policy precedence may be normalized by the provider/API during refresh."
+    patterns:
+      - '~ precedence\s*='
+      - 'precedence\s*=\s*\d{4,}\s*->\s*\d{1,4}'
+    enabled: true
+
+  - name: "gateway_policy_filters_computed_to_null"
+    description: "Gateway policy filters may drift from inferred values in state to null in config."
+    patterns:
+      - '-\s*filters\s*=\s*\['
+      - 'filters.*->.*null'
+    enabled: true
+
+  # Gateway settings block_page API default-field drift (matches v4->v5 exemptions)
+  - name: "gateway_settings_block_page_api_default_fields"
+    description: "Gateway settings block_page optional fields may be returned with API defaults and appear as perpetual drift."
+    patterns:
+      - '\-\s+mode\s*='
+      - '\-\s+include_context\s*='
+      - '\-\s+suppress_footer\s*='
+      - '\-\s+target_uri\s*='
+      - '\-\s+mailto_address\s*='
+      - '\-\s+mailto_subject\s*='
+    enabled: true
+
+# Global settings
+settings:
+  apply_exemptions: true
+  verbose_exemptions: false
+
+  # Warn if exemption doesn't match anything (helps catch stale exemptions)
+  warn_unused_exemptions: false
+
+  # Load resource-specific exemption configs
+  load_resource_exemptions: true

--- a/e2e-v5/testdata/access_rule/access_rule.tf
+++ b/e2e-v5/testdata/access_rule/access_rule.tf
@@ -1,0 +1,107 @@
+variable "cloudflare_account_id" {
+  type = string
+}
+
+variable "cloudflare_zone_id" {
+  type = string
+}
+
+variable "cloudflare_domain" {
+  type = string
+}
+
+variable "from_version" {
+  description = "Provider version under test, used to namespace resource names"
+  type        = string
+}
+
+locals {
+  # Use different IPs from v4→v5 tests to avoid "duplicate_of_existing" errors.
+  # v4→v5 uses 198.51.100.x and 192.0.2.x; v5 upgrade uses 100.64.x.x (shared address space RFC 6598).
+  minor = tonumber(split(".", var.from_version)[1])
+}
+
+resource "cloudflare_access_rule" "example_block" {
+  account_id = var.cloudflare_account_id
+  mode       = "block"
+  notes      = "v5-upgrade block IP"
+  configuration = {
+    target = "ip"
+    value  = "100.64.${local.minor}.10"
+  }
+}
+
+resource "cloudflare_access_rule" "example_challenge" {
+  account_id = var.cloudflare_account_id
+  mode       = "challenge"
+  notes      = "v5-upgrade challenge IP"
+  configuration = {
+    target = "ip"
+    value  = "100.64.${local.minor}.11"
+  }
+}
+
+resource "cloudflare_access_rule" "example_whitelist" {
+  zone_id = var.cloudflare_zone_id
+  mode    = "whitelist"
+  notes   = "v5-upgrade allow IP"
+  configuration = {
+    target = "ip"
+    value  = "100.64.${local.minor}.12"
+  }
+}
+
+resource "cloudflare_access_rule" "example_js_challenge" {
+  account_id = var.cloudflare_account_id
+  mode       = "js_challenge"
+  notes      = "v5-upgrade js_challenge IP"
+  configuration = {
+    target = "ip"
+    value  = "100.64.${local.minor}.13"
+  }
+}
+
+resource "cloudflare_access_rule" "target_ip_range" {
+  account_id = var.cloudflare_account_id
+  mode       = "block"
+  notes      = "v5-upgrade block range"
+  configuration = {
+    target = "ip_range"
+    value  = "100.64.${local.minor}.0/24"
+  }
+}
+
+resource "cloudflare_access_rule" "target_ip6" {
+  account_id = var.cloudflare_account_id
+  mode       = "block"
+  notes      = "v5-upgrade block IPv6"
+  configuration = {
+    target = "ip6"
+    value  = "2001:0db8:00${local.minor}:0000:0000:0000:0000:0001"
+  }
+}
+
+resource "cloudflare_access_rule" "with_lifecycle" {
+  account_id = var.cloudflare_account_id
+  mode       = "block"
+  notes      = "v5-upgrade lifecycle"
+  configuration = {
+    target = "ip"
+    value  = "100.64.${local.minor}.99"
+  }
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "cloudflare_access_rule" "backup_blocks" {
+  count = 2
+
+  account_id = var.cloudflare_account_id
+  mode       = "block"
+  notes      = "v5-upgrade backup ${count.index}"
+  configuration = {
+    target = "ip"
+    value  = "100.64.${local.minor}.${count.index + 20}"
+  }
+}

--- a/e2e-v5/testdata/account/account.tf
+++ b/e2e-v5/testdata/account/account.tf
@@ -1,0 +1,30 @@
+locals {
+  name_prefix = "v5-upgrade-${replace(var.from_version, ".", "-")}"
+}
+
+variable "cloudflare_account_id" {
+  description = "Cloudflare account ID"
+  type        = string
+}
+
+variable "cloudflare_zone_id" {
+  description = "Cloudflare zone ID"
+  type        = string
+}
+
+variable "cloudflare_domain" {
+  description = "Cloudflare domain for testing"
+  type        = string
+}
+
+resource "cloudflare_account" "basic_account" {
+  name = "${local.name_prefix}-account-e2e"
+  settings = {
+    enforce_twofactor = false
+  }
+}
+
+variable "from_version" {
+  description = "Provider version under test, used to namespace resource names"
+  type        = string
+}

--- a/e2e-v5/testdata/account_member/account_member.tf
+++ b/e2e-v5/testdata/account_member/account_member.tf
@@ -1,0 +1,33 @@
+locals {
+  name_prefix = "v5-upgrade-${replace(var.from_version, ".", "-")}"
+}
+
+variable "cloudflare_account_id" {
+  description = "Cloudflare account ID"
+  type        = string
+}
+
+variable "cloudflare_zone_id" {
+  description = "Cloudflare zone ID"
+  type        = string
+}
+
+variable "cloudflare_domain" {
+  description = "Cloudflare domain for testing"
+  type        = string
+}
+
+resource "cloudflare_account_member" "basic_am" {
+  account_id = var.cloudflare_account_id
+  status     = "accepted"
+  email      = "v5-upgrade-test-user@cfapi.net"
+  roles = [
+    "e58cefd75d7adae0b761796c28815e5c",
+    "a4154d230e664f8b3e6e5c95a8cc812f"
+  ]
+}
+
+variable "from_version" {
+  description = "Provider version under test, used to namespace resource names"
+  type        = string
+}

--- a/e2e-v5/testdata/api_shield/api_shield.tf
+++ b/e2e-v5/testdata/api_shield/api_shield.tf
@@ -1,0 +1,51 @@
+locals {
+  name_prefix = "v5-upgrade-${replace(var.from_version, ".", "-")}"
+}
+
+variable "cloudflare_account_id" {
+  description = "Cloudflare account ID"
+  type        = string
+}
+
+variable "cloudflare_zone_id" {
+  description = "Cloudflare zone ID"
+  type        = string
+}
+
+variable "cloudflare_domain" {
+  description = "Cloudflare domain for testing"
+  type        = string
+}
+
+# Test Case 8: Multiple characteristics with varied order
+resource "cloudflare_api_shield" "varied_order" {
+  zone_id = var.cloudflare_zone_id
+
+
+
+
+  auth_id_characteristics = [
+    {
+      type = "cookie"
+      name = "auth_cookie"
+    },
+    {
+      type = "header"
+      name = "Authorization"
+    },
+    {
+      type = "cookie"
+      name = "session"
+    },
+    {
+      type = "header"
+      name = "X-Forwarded-For"
+    }
+  ]
+}
+
+
+variable "from_version" {
+  description = "Provider version under test, used to namespace resource names"
+  type        = string
+}

--- a/e2e-v5/testdata/api_shield_operation/api_shield_operation.tf
+++ b/e2e-v5/testdata/api_shield_operation/api_shield_operation.tf
@@ -1,0 +1,143 @@
+variable "cloudflare_account_id" {
+  description = "Cloudflare account ID"
+  type        = string
+}
+
+variable "cloudflare_zone_id" {
+  description = "Cloudflare zone ID"
+  type        = string
+}
+
+variable "cloudflare_domain" {
+  description = "Cloudflare domain for testing"
+  type        = string
+}
+
+# Test case 1: Basic GET operation
+locals {
+  name_prefix = "v5-upgrade-${replace(var.from_version, ".", "-")}"
+}
+
+resource "cloudflare_api_shield_operation" "get_users" {
+  zone_id  = var.cloudflare_zone_id
+  method   = "GET"
+  host     = "api.${var.cloudflare_domain}"
+  endpoint = "/${local.name_prefix}/api/users"
+}
+
+# Test case 2: POST operation with single parameter
+resource "cloudflare_api_shield_operation" "create_user" {
+  zone_id  = var.cloudflare_zone_id
+  method   = "POST"
+  host     = "api.${var.cloudflare_domain}"
+  endpoint = "/${local.name_prefix}/api/users"
+}
+
+# Test case 3: GET operation with single parameter
+resource "cloudflare_api_shield_operation" "get_user_by_id" {
+  zone_id  = var.cloudflare_zone_id
+  method   = "GET"
+  host     = "api.${var.cloudflare_domain}"
+  endpoint = "/${local.name_prefix}/api/users/{var1}"
+}
+
+# Test case 4: PUT operation with parameter
+resource "cloudflare_api_shield_operation" "update_user" {
+  zone_id  = var.cloudflare_zone_id
+  method   = "PUT"
+  host     = "api.${var.cloudflare_domain}"
+  endpoint = "/${local.name_prefix}/api/users/{var1}"
+}
+
+# Test case 5: DELETE operation with parameter
+resource "cloudflare_api_shield_operation" "delete_user" {
+  zone_id  = var.cloudflare_zone_id
+  method   = "DELETE"
+  host     = "api.${var.cloudflare_domain}"
+  endpoint = "/${local.name_prefix}/api/users/{var1}"
+}
+
+# Test case 6: PATCH operation with multi-parameter endpoint
+resource "cloudflare_api_shield_operation" "update_user_post" {
+  zone_id  = var.cloudflare_zone_id
+  method   = "PATCH"
+  host     = "api.${var.cloudflare_domain}"
+  endpoint = "/${local.name_prefix}/api/users/{var1}/posts/{var2}"
+}
+
+# Test case 7: GET operation with multi-parameter endpoint
+resource "cloudflare_api_shield_operation" "get_user_comment" {
+  zone_id  = var.cloudflare_zone_id
+  method   = "GET"
+  host     = "api.${var.cloudflare_domain}"
+  endpoint = "/${local.name_prefix}/api/users/{var1}/posts/{var2}/comments/{var3}"
+}
+
+# Test case 8: POST operation with subdomain host
+resource "cloudflare_api_shield_operation" "v2_create_resource" {
+  zone_id  = var.cloudflare_zone_id
+  method   = "POST"
+  host     = "v2.api.${var.cloudflare_domain}"
+  endpoint = "/${local.name_prefix}/api/resources"
+}
+
+# Test case 9: GET operation with health check endpoint
+resource "cloudflare_api_shield_operation" "staging_get_health" {
+  zone_id  = var.cloudflare_zone_id
+  method   = "GET"
+  host     = "api.staging.${var.cloudflare_domain}"
+  endpoint = "/${local.name_prefix}/health"
+}
+
+# Test case 10: OPTIONS operation (for CORS preflight)
+resource "cloudflare_api_shield_operation" "options_users" {
+  zone_id  = var.cloudflare_zone_id
+  method   = "OPTIONS"
+  host     = "api.${var.cloudflare_domain}"
+  endpoint = "/${local.name_prefix}/api/users"
+}
+
+# Test case 11: HEAD operation
+resource "cloudflare_api_shield_operation" "head_users" {
+  zone_id  = var.cloudflare_zone_id
+  method   = "HEAD"
+  host     = "api.${var.cloudflare_domain}"
+  endpoint = "/${local.name_prefix}/api/users"
+}
+
+# Test case 12: POST with versioned API path
+resource "cloudflare_api_shield_operation" "v1_create_order" {
+  zone_id  = var.cloudflare_zone_id
+  method   = "POST"
+  host     = "api.${var.cloudflare_domain}"
+  endpoint = "/${local.name_prefix}/api/v1/orders"
+}
+
+# Test case 13: GET with nested resource path
+resource "cloudflare_api_shield_operation" "get_account_settings" {
+  zone_id  = var.cloudflare_zone_id
+  method   = "GET"
+  host     = "api.${var.cloudflare_domain}"
+  endpoint = "/${local.name_prefix}/api/v1/accounts/{var1}/settings"
+}
+
+# Test case 14: PATCH with query-like endpoint
+resource "cloudflare_api_shield_operation" "search_users" {
+  zone_id  = var.cloudflare_zone_id
+  method   = "GET"
+  host     = "api.${var.cloudflare_domain}"
+  endpoint = "/${local.name_prefix}/api/users/search"
+}
+
+# Test case 15: DELETE with nested resource
+resource "cloudflare_api_shield_operation" "delete_user_session" {
+  zone_id  = var.cloudflare_zone_id
+  method   = "DELETE"
+  host     = "api.${var.cloudflare_domain}"
+  endpoint = "/${local.name_prefix}/api/users/{var1}/sessions/{var2}"
+}
+
+variable "from_version" {
+  description = "Provider version under test, used to namespace resource names"
+  type        = string
+}

--- a/e2e-v5/testdata/api_token/api_token.tf
+++ b/e2e-v5/testdata/api_token/api_token.tf
@@ -1,0 +1,281 @@
+locals {
+  name_prefix = "v5-upgrade-${replace(var.from_version, ".", "-")}"
+}
+
+variable "cloudflare_account_id" {
+  description = "Cloudflare account ID"
+  type        = string
+}
+
+variable "cloudflare_zone_id" {
+  description = "Cloudflare zone ID"
+  type        = string
+}
+
+variable "cloudflare_domain" {
+  description = "Cloudflare domain for testing"
+  type        = string
+}
+
+# Test Case 1: Basic API token with single policy
+resource "cloudflare_api_token" "basic_token" {
+  name = "${local.name_prefix} Basic API Token"
+
+  policies = [{
+    effect = "allow"
+    resources = jsonencode({
+      "com.cloudflare.api.account.*" = "*"
+    })
+    permission_groups = [{
+      id = "c8fed203ed3043cba015a93ad1616f1f"
+      }, {
+      id = "82e64a83756745bbbb1c9c2701bf816b"
+    }]
+  }]
+}
+
+# Test Case 2: API token with multiple policies
+resource "cloudflare_api_token" "multi_policy_token" {
+  name = "${local.name_prefix} Multi Policy Token"
+
+
+  policies = [{
+    effect = "allow"
+    resources = jsonencode({
+      "com.cloudflare.api.account.*" = "*"
+    })
+    permission_groups = [{
+      id = "c8fed203ed3043cba015a93ad1616f1f"
+    }]
+    }, {
+    effect = "deny"
+    resources = jsonencode({
+      "com.cloudflare.api.account.zone.*" = "*"
+    })
+    permission_groups = [{
+      id = "82e64a83756745bbbb1c9c2701bf816b"
+    }]
+  }]
+}
+
+# Test Case 3: API token with condition block
+resource "cloudflare_api_token" "conditional_token" {
+  name = "${local.name_prefix} Conditional Token"
+
+
+  policies = [{
+    effect = "allow"
+    resources = jsonencode({
+      "com.cloudflare.api.account.*" = "*"
+    })
+    permission_groups = [{
+      id = "c8fed203ed3043cba015a93ad1616f1f"
+    }]
+  }]
+  condition = {
+    request_ip = {
+      in = [
+        "192.168.1.0/24",
+        "10.0.0.0/8"
+      ]
+    }
+  }
+}
+
+# Test Case 4: API token with condition including not_in
+resource "cloudflare_api_token" "advanced_condition_token" {
+  name = "${local.name_prefix} Advanced Condition Token"
+
+
+  policies = [{
+    effect = "allow"
+    resources = jsonencode({
+      "com.cloudflare.api.account.*"      = "*"
+      "com.cloudflare.api.account.zone.*" = "*"
+    })
+    permission_groups = [{
+      id = "c8fed203ed3043cba015a93ad1616f1f"
+    }]
+  }]
+  condition = {
+    request_ip = {
+      in = [
+        "192.168.0.0/16",
+        "10.0.0.0/8",
+        "172.16.0.0/12"
+      ]
+      not_in = [
+        "192.168.1.100/32",
+        "10.0.0.1/32"
+      ]
+    }
+  }
+}
+
+# Test Case 5: API token with TTL fields
+resource "cloudflare_api_token" "time_limited_token" {
+  name       = "${local.name_prefix} Time Limited Token"
+  expires_on = "2135-12-31T23:59:59Z"
+  not_before = "2126-01-01T00:00:00Z"
+
+  policies = [{
+    effect = "allow"
+    resources = jsonencode({
+      "com.cloudflare.api.account.*" = "*"
+    })
+    permission_groups = [{
+      id = "c8fed203ed3043cba015a93ad1616f1f"
+    }]
+  }]
+}
+
+# Test Case 6: API token with minimal permission groups
+resource "cloudflare_api_token" "empty_perms_token" {
+  name = "${local.name_prefix} Minimal Permissions Token"
+
+  policies = [{
+    effect = "allow"
+    resources = jsonencode({
+      "com.cloudflare.api.account.*" = "*"
+    })
+    permission_groups = [{
+      id = "c8fed203ed3043cba015a93ad1616f1f"
+    }]
+  }]
+}
+
+# Test Case 7: Full example with all features
+resource "cloudflare_api_token" "full_example" {
+  name       = "${local.name_prefix} Full Example Token"
+  expires_on = "2135-12-31T23:59:59Z"
+  not_before = "2126-01-01T00:00:00Z"
+
+
+
+  policies = [{
+    effect = "allow"
+    resources = jsonencode({
+      "com.cloudflare.api.account.*"      = "*"
+      "com.cloudflare.api.account.zone.*" = "*"
+    })
+    permission_groups = [{
+      id = "c8fed203ed3043cba015a93ad1616f1f"
+    }]
+    }, {
+    effect = "deny"
+    resources = jsonencode({
+      "com.cloudflare.api.account.zone.*" = "*"
+    })
+    permission_groups = [{
+      id = "e086da7e2179491d91ee5f35b3ca210a"
+    }]
+  }]
+  condition = {
+    request_ip = {
+      in = [
+        "192.168.0.0/16",
+        "10.0.0.0/8",
+        "172.16.0.0/12",
+        "fd00::/8"
+      ]
+      not_in = [
+        "192.168.1.1/32",
+        "10.0.0.1/32"
+      ]
+    }
+  }
+}
+
+# Test Case 8: Token with data reference and timestamps
+resource "cloudflare_api_token" "api_token_create" {
+  name = "${local.name_prefix} api_token_create"
+
+
+  not_before = "2126-01-01T00:00:00Z"
+  expires_on = "2135-12-31T23:59:59Z"
+
+  policies = [{
+    resources = jsonencode({
+      "com.cloudflare.api.account.*" = "*"
+    })
+    effect = "allow"
+    permission_groups = [{
+      id = "c8fed203ed3043cba015a93ad1616f1f"
+    }]
+  }]
+  condition = {
+    request_ip = {
+      in     = ["192.0.2.1/32"]
+      not_in = ["198.51.100.1/32"]
+    }
+  }
+}
+
+# Test Case 9: Token with complex multi-key resources map
+resource "cloudflare_api_token" "complex_resources_token" {
+  name = "${local.name_prefix} Complex Resources Token"
+
+  policies = [{
+    effect = "allow"
+    resources = jsonencode({
+      "com.cloudflare.api.account.*"      = "*"
+      "com.cloudflare.api.account.zone.*" = "*"
+    })
+    permission_groups = [{
+      id = "c8fed203ed3043cba015a93ad1616f1f"
+    }]
+  }]
+}
+
+# Test Case 10: Token with multiple permission groups (v4 string format)
+resource "cloudflare_api_token" "multi_perms_token" {
+  name = "${local.name_prefix} Multiple Permissions Token"
+
+  policies = [{
+    effect = "allow"
+    resources = jsonencode({
+      "com.cloudflare.api.account.*" = "*"
+    })
+    permission_groups = [{
+      id = "c8fed203ed3043cba015a93ad1616f1f"
+      }, {
+      id = "82e64a83756745bbbb1c9c2701bf816b"
+    }]
+  }]
+}
+
+# Test Case 11: Token without effect (should default to allow)
+resource "cloudflare_api_token" "no_effect_token" {
+  name = "${local.name_prefix} No Effect Token"
+
+  policies = [{
+    resources = jsonencode({
+      "com.cloudflare.api.account.*" = "*"
+    })
+    effect = "allow"
+    permission_groups = [{
+      id = "c8fed203ed3043cba015a93ad1616f1f"
+    }]
+  }]
+}
+
+# Test Case 12: Token with variable references in resources
+resource "cloudflare_api_token" "variable_resources_token" {
+  name = "${local.name_prefix} Variable Resources Token"
+
+  policies = [{
+    effect = "allow"
+    resources = jsonencode({
+      "com.cloudflare.api.account.${var.cloudflare_account_id}"   = "*"
+      "com.cloudflare.api.account.zone.${var.cloudflare_zone_id}" = "*"
+    })
+    permission_groups = [{
+      id = "c8fed203ed3043cba015a93ad1616f1f"
+    }]
+  }]
+}
+
+variable "from_version" {
+  description = "Provider version under test, used to namespace resource names"
+  type        = string
+}

--- a/e2e-v5/testdata/argo/argo.tf
+++ b/e2e-v5/testdata/argo/argo.tf
@@ -1,0 +1,37 @@
+variable "cloudflare_account_id" {
+  description = "Cloudflare account ID"
+  type        = string
+}
+
+variable "cloudflare_zone_id" {
+  description = "Cloudflare zone ID"
+  type        = string
+}
+
+variable "cloudflare_domain" {
+  description = "Cloudflare domain for testing"
+  type        = string
+}
+
+
+resource "cloudflare_argo_smart_routing" "both_with_lifecycle" {
+  zone_id = var.cloudflare_zone_id
+  value   = "on"
+  lifecycle {
+    ignore_changes = [value]
+  }
+}
+
+
+resource "cloudflare_argo_tiered_caching" "both_with_lifecycle_tiered" {
+  zone_id = var.cloudflare_zone_id
+  value   = "on"
+  lifecycle {
+    ignore_changes = [value]
+  }
+}
+
+variable "from_version" {
+  description = "Provider version under test, used to namespace resource names"
+  type        = string
+}

--- a/e2e-v5/testdata/authenticated_origin_pulls/authenticated_origin_pulls.tf
+++ b/e2e-v5/testdata/authenticated_origin_pulls/authenticated_origin_pulls.tf
@@ -1,0 +1,30 @@
+# Test authenticated_origin_pulls migration
+
+# Variables
+variable "cloudflare_account_id" {
+  description = "Cloudflare account ID"
+  type        = string
+}
+
+variable "cloudflare_zone_id" {
+  description = "Cloudflare zone ID for testing"
+  type        = string
+}
+
+variable "cloudflare_domain" {
+  description = "Cloudflare domain for testing"
+  type        = string
+}
+
+
+# Basic zone-wide AOP
+resource "cloudflare_authenticated_origin_pulls_settings" "zone_wide" {
+  zone_id = var.cloudflare_zone_id
+  enabled = true
+}
+
+
+variable "from_version" {
+  description = "Provider version under test, used to namespace resource names"
+  type        = string
+}

--- a/e2e-v5/testdata/authenticated_origin_pulls_certificate/authenticated_origin_pulls_certificate.tf
+++ b/e2e-v5/testdata/authenticated_origin_pulls_certificate/authenticated_origin_pulls_certificate.tf
@@ -1,0 +1,84 @@
+variable "cloudflare_account_id" {
+  description = "Cloudflare account ID"
+  type        = string
+}
+
+variable "cloudflare_zone_id" {
+  type = string
+}
+
+variable "cloudflare_domain" {
+  description = "Cloudflare domain for testing"
+  type        = string
+}
+
+variable "from_version" {
+  description = "Provider version under test, used to namespace resource names"
+  type        = string
+}
+
+locals {
+  name_prefix = "v5-upgrade-${replace(var.from_version, ".", "-")}"
+}
+
+resource "tls_private_key" "zone" {
+  algorithm = "RSA"
+  rsa_bits  = 2048
+}
+
+resource "tls_self_signed_cert" "zone" {
+  private_key_pem       = tls_private_key.zone.private_key_pem
+  validity_period_hours = 8760
+  is_ca_certificate     = false
+
+  subject {
+    common_name  = "${local.name_prefix}-aop-zone.${var.cloudflare_domain}"
+    organization = "tf-migrate"
+  }
+
+  allowed_uses = [
+    "key_encipherment",
+    "digital_signature",
+    "server_auth",
+    "client_auth",
+  ]
+}
+
+resource "tls_private_key" "hostname" {
+  algorithm = "RSA"
+  rsa_bits  = 2048
+}
+
+resource "tls_self_signed_cert" "hostname" {
+  private_key_pem       = tls_private_key.hostname.private_key_pem
+  validity_period_hours = 8760
+  is_ca_certificate     = false
+
+  subject {
+    common_name  = "${local.name_prefix}-aop-host.${var.cloudflare_domain}"
+    organization = "tf-migrate"
+  }
+
+  allowed_uses = [
+    "key_encipherment",
+    "digital_signature",
+    "server_auth",
+    "client_auth",
+  ]
+}
+
+resource "cloudflare_authenticated_origin_pulls_certificate" "per_zone_1" {
+  zone_id     = var.cloudflare_zone_id
+  certificate = tls_self_signed_cert.zone.cert_pem
+  private_key = tls_private_key.zone.private_key_pem
+}
+
+resource "cloudflare_authenticated_origin_pulls_hostname_certificate" "per_hostname_1" {
+  zone_id     = var.cloudflare_zone_id
+  certificate = tls_self_signed_cert.hostname.cert_pem
+  private_key = tls_private_key.hostname.private_key_pem
+}
+
+output "per_zone_1_status" {
+  value = cloudflare_authenticated_origin_pulls_certificate.per_zone_1.status
+}

--- a/e2e-v5/testdata/bot_management/bot_management.tf
+++ b/e2e-v5/testdata/bot_management/bot_management.tf
@@ -1,0 +1,37 @@
+# E2E test for bot_management migration
+# This is a simplified version for actual API testing (singleton resource)
+
+variable "cloudflare_account_id" {
+  description = "Cloudflare account ID"
+  type        = string
+}
+
+variable "cloudflare_zone_id" {
+  description = "Cloudflare zone ID"
+  type        = string
+}
+
+variable "cloudflare_domain" {
+  description = "Cloudflare domain for testing"
+  type        = string
+}
+
+# Comprehensive bot management test with available fields
+# Note: bot_management is a singleton per zone - only one config per zone
+resource "cloudflare_bot_management" "test" {
+  zone_id   = var.cloudflare_zone_id
+  enable_js = true
+  # sbfm_definitely_automated       = "block"
+  # sbfm_likely_automated           = "managed_challenge"
+  # sbfm_verified_bots              = "allow"
+  # sbfm_static_resource_protection = true
+  optimize_wordpress     = false
+  suppress_session_score = false
+  auto_update_model      = true
+  ai_bots_protection     = "disabled"
+}
+
+variable "from_version" {
+  description = "Provider version under test, used to namespace resource names"
+  type        = string
+}

--- a/e2e-v5/testdata/certificate_pack/certificate_pack.tf
+++ b/e2e-v5/testdata/certificate_pack/certificate_pack.tf
@@ -1,0 +1,214 @@
+# Terraform v4 to v5 Migration Integration Test - Certificate Pack
+# This file contains 20+ certificate pack instances using various Terraform patterns
+
+# Variables without defaults (passed at runtime)
+variable "cloudflare_zone_id" {
+  type = string
+}
+
+variable "cloudflare_account_id" {
+  type = string
+}
+
+variable "cloudflare_domain" {
+  type = string
+}
+
+# Locals and computed values
+locals {
+  name_prefix = "v5-upgrade-${replace(var.from_version, ".", "-")}"
+  zones = {
+    primary   = var.cloudflare_zone_id
+    secondary = var.cloudflare_zone_id
+  }
+
+  validation_methods = ["txt", "http"]
+
+  certificate_configs = {
+    lets-encrypt-90d = {
+      authority     = "lets_encrypt"
+      validity_days = 90
+      branding      = false
+    }
+    google-90d = {
+      authority     = "google"
+      validity_days = 90
+      branding      = true
+    }
+    ssl-com-30d = {
+      authority     = "ssl_com"
+      validity_days = 30
+      branding      = false
+    }
+  }
+}
+
+# Pattern 1: Simple resource with all required fields
+resource "cloudflare_certificate_pack" "basic" {
+  zone_id               = var.cloudflare_zone_id
+  type                  = "advanced"
+  hosts                 = ["${local.name_prefix}.${var.cloudflare_domain}", "*.${local.name_prefix}.${var.cloudflare_domain}"]
+  validation_method     = "txt"
+  validity_days         = 90
+  certificate_authority = "lets_encrypt"
+}
+
+# Pattern 2: Resource with wait_for_active_status (v4 only - will be removed)
+resource "cloudflare_certificate_pack" "with_wait" {
+  count = 0
+
+  zone_id               = var.cloudflare_zone_id
+  type                  = "advanced"
+  hosts                 = ["test.${var.cloudflare_domain}"]
+  validation_method     = "http"
+  validity_days         = 90
+  certificate_authority = "google"
+}
+
+# Pattern 3: Resource with cloudflare_branding
+resource "cloudflare_certificate_pack" "with_branding" {
+  count = 0
+
+  zone_id               = var.cloudflare_zone_id
+  type                  = "advanced"
+  hosts                 = ["branded.${var.cloudflare_domain}", "*.branded.${var.cloudflare_domain}"]
+  validation_method     = "txt"
+  validity_days         = 30
+  certificate_authority = "ssl_com"
+  cloudflare_branding   = true
+}
+
+# Pattern 4: for_each with maps (3 resources)
+resource "cloudflare_certificate_pack" "by_config" {
+  for_each = {}
+
+  zone_id               = var.cloudflare_zone_id
+  type                  = "advanced"
+  hosts                 = ["${each.key}.${var.cloudflare_domain}"]
+  validation_method     = "txt"
+  validity_days         = each.value.validity_days
+  certificate_authority = each.value.authority
+  cloudflare_branding   = each.value.branding
+}
+
+# Pattern 5: for_each with sets (2 resources)
+resource "cloudflare_certificate_pack" "by_validation" {
+  for_each = toset([])
+
+  zone_id = var.cloudflare_zone_id
+  type    = "advanced"
+  # HTTP validation doesn't support wildcards, TXT does
+  hosts                 = each.value == "http" ? ["${each.value}.${var.cloudflare_domain}"] : ["${each.value}.${var.cloudflare_domain}", "*.${each.value}.${var.cloudflare_domain}"]
+  validation_method     = each.value
+  validity_days         = 90
+  certificate_authority = "lets_encrypt"
+}
+
+# Pattern 6: count-based resources (4 resources)
+resource "cloudflare_certificate_pack" "count_based" {
+  count = 0
+
+  zone_id               = var.cloudflare_zone_id
+  type                  = "advanced"
+  hosts                 = ["count-${count.index}.${var.cloudflare_domain}"]
+  validation_method     = element(["txt", "http", "txt", "txt"], count.index)
+  validity_days         = element([90, 90, 30, 14], count.index)
+  certificate_authority = element(["lets_encrypt", "google", "ssl_com", "google"], count.index)
+}
+
+# Pattern 7: Conditional resource creation (ternary)
+resource "cloudflare_certificate_pack" "conditional" {
+  count = 0
+
+  zone_id               = var.cloudflare_zone_id
+  type                  = "advanced"
+  hosts                 = ["conditional.${var.cloudflare_domain}"]
+  validation_method     = "txt"
+  validity_days         = 90
+  certificate_authority = "lets_encrypt"
+}
+
+# Pattern 8: Cross-resource references (depends on zone variable)
+resource "cloudflare_certificate_pack" "with_reference" {
+  count = 0
+
+  zone_id               = local.zones.primary
+  type                  = "advanced"
+  hosts                 = ["ref.${var.cloudflare_domain}"]
+  validation_method     = "http"
+  validity_days         = 90
+  certificate_authority = "google"
+  cloudflare_branding   = false
+}
+
+# Pattern 9: Lifecycle meta-arguments
+resource "cloudflare_certificate_pack" "with_lifecycle" {
+  count = 0
+
+  zone_id               = var.cloudflare_zone_id
+  type                  = "advanced"
+  hosts                 = ["lifecycle.${var.cloudflare_domain}"]
+  validation_method     = "txt"
+  validity_days         = 90
+  certificate_authority = "lets_encrypt"
+
+  lifecycle {
+    create_before_destroy = true
+    prevent_destroy       = false
+  }
+}
+
+# Pattern 10: Terraform functions (join, length, etc.)
+resource "cloudflare_certificate_pack" "with_functions" {
+  count = 0
+
+  zone_id               = var.cloudflare_zone_id
+  type                  = "advanced"
+  hosts                 = [for i in range(2) : "${local.name_prefix}-${i}.${var.cloudflare_domain}"]
+  validation_method     = length(local.validation_methods) > 0 ? local.validation_methods[0] : "txt"
+  validity_days         = 90
+  certificate_authority = "lets_encrypt"
+}
+
+# Pattern 11: Complex for_each with filtering (2 resources after filtering)
+resource "cloudflare_certificate_pack" "filtered" {
+  for_each = {}
+
+  zone_id               = var.cloudflare_zone_id
+  type                  = "advanced"
+  hosts                 = ["filtered-${each.key}.${var.cloudflare_domain}"]
+  validation_method     = "txt"
+  validity_days         = each.value.validity_days
+  certificate_authority = each.value.authority
+}
+
+# Pattern 12: Dynamic expressions with coalescence
+resource "cloudflare_certificate_pack" "with_coalesce" {
+  count = 0
+
+  zone_id               = var.cloudflare_zone_id
+  type                  = "advanced"
+  hosts                 = ["coalesce.${var.cloudflare_domain}"]
+  validation_method     = "txt"
+  validity_days         = 90
+  certificate_authority = "lets_encrypt"
+  cloudflare_branding   = coalesce(false, true)
+}
+
+# Total: 22 certificate pack resources
+# - 3 simple resources (basic, with_wait, with_branding)
+# - 3 for_each with maps
+# - 3 for_each with sets
+# - 4 count-based resources
+# - 1 conditional
+# - 1 with cross-resource reference
+# - 1 with lifecycle
+# - 1 with terraform functions
+# - 2 filtered for_each
+# - 1 with coalesce
+# = 20+ total instances
+
+variable "from_version" {
+  description = "Provider version under test, used to namespace resource names"
+  type        = string
+}

--- a/e2e-v5/testdata/custom_hostname/custom_hostname.tf
+++ b/e2e-v5/testdata/custom_hostname/custom_hostname.tf
@@ -1,0 +1,102 @@
+variable "cloudflare_account_id" {
+  type = string
+}
+
+variable "cloudflare_zone_id" {
+  type = string
+}
+
+variable "cloudflare_domain" {
+  type = string
+}
+
+variable "from_version" {
+  description = "Provider version under test, used to namespace resource names"
+  type        = string
+}
+
+locals {
+  name_prefix = "v5-upgrade-${replace(var.from_version, ".", "-")}"
+}
+
+resource "cloudflare_custom_hostname" "basic" {
+  zone_id  = var.cloudflare_zone_id
+  hostname = "${local.name_prefix}-app.${var.cloudflare_domain}"
+
+  custom_metadata = {
+    environment = "test"
+  }
+
+  ssl = {
+    method   = "txt"
+    type     = "dv"
+    wildcard = false
+    settings = {
+      http2           = "on"
+      min_tls_version = "1.2"
+      tls_1_3         = "on"
+    }
+  }
+}
+
+resource "cloudflare_custom_hostname" "no_settings" {
+  zone_id  = var.cloudflare_zone_id
+  hostname = "${local.name_prefix}-nosettings.${var.cloudflare_domain}"
+
+  ssl = {
+    method   = "txt"
+    type     = "dv"
+    wildcard = false
+  }
+}
+
+resource "cloudflare_custom_hostname" "wildcard_true" {
+  zone_id  = var.cloudflare_zone_id
+  hostname = "${local.name_prefix}-wildcard-true.${var.cloudflare_domain}"
+
+  ssl = {
+    method   = "txt"
+    type     = "dv"
+    wildcard = true
+    settings = {
+      tls_1_3 = "on"
+    }
+  }
+}
+
+resource "cloudflare_custom_hostname" "wildcard_false" {
+  zone_id  = var.cloudflare_zone_id
+  hostname = "${local.name_prefix}-wildcard-false.${var.cloudflare_domain}"
+
+  ssl = {
+    method   = "txt"
+    type     = "dv"
+    wildcard = false
+    settings = {
+      http2 = "on"
+    }
+  }
+}
+
+resource "cloudflare_custom_hostname" "settings_passthrough" {
+  zone_id  = var.cloudflare_zone_id
+  hostname = "${local.name_prefix}-settings.${var.cloudflare_domain}"
+
+  custom_metadata = {
+    environment = "test"
+    owner       = "terraform"
+  }
+
+  ssl = {
+    method   = "txt"
+    type     = "dv"
+    wildcard = false
+    settings = {
+      http2           = "on"
+      min_tls_version = "1.2"
+      early_hints     = "off"
+      ciphers         = ["ECDHE-RSA-AES128-GCM-SHA256"]
+      tls_1_3         = "on"
+    }
+  }
+}

--- a/e2e-v5/testdata/custom_hostname_fallback_origin/custom_hostname_fallback_origin.tf
+++ b/e2e-v5/testdata/custom_hostname_fallback_origin/custom_hostname_fallback_origin.tf
@@ -1,0 +1,69 @@
+# E2E test for custom_hostname_fallback_origin migration
+# This tests the real-life singleton scenario (one fallback origin per zone)
+locals {
+  name_prefix = "v5-upgrade-${replace(var.from_version, ".", "-")}"
+}
+variable "cloudflare_account_id" {
+  description = "Cloudflare account ID"
+  type        = string
+}
+
+variable "cloudflare_zone_id" {
+  description = "Cloudflare zone ID"
+  type        = string
+}
+
+variable "cloudflare_domain" {
+  description = "Cloudflare domain for testing"
+  type        = string
+}
+
+# CrowdStrike variables (not used by this resource, but required by E2E framework)
+variable "crowdstrike_client_id" {
+  description = "CrowdStrike client ID (unused)"
+  type        = string
+  default     = ""
+}
+
+variable "crowdstrike_client_secret" {
+  description = "CrowdStrike client secret (unused)"
+  type        = string
+  default     = ""
+}
+
+variable "crowdstrike_api_url" {
+  description = "CrowdStrike API URL (unused)"
+  type        = string
+  default     = ""
+}
+
+variable "crowdstrike_customer_id" {
+  description = "CrowdStrike customer ID (unused)"
+  type        = string
+  default     = ""
+}
+
+# Test: Single instance (singleton resource - only one per zone)
+# Note: This is a SINGLETON resource - only ONE fallback origin per zone
+# Note: Custom Hostname Fallback Origin requires Cloudflare for SaaS (Business+ plan)
+# Note: The origin MUST be a proxied A/AAAA/CNAME DNS record within Cloudflare
+resource "cloudflare_custom_hostname_fallback_origin" "e2e_test" {
+  zone_id = var.cloudflare_zone_id
+  origin  = "${local.name_prefix}-fallback.${var.cloudflare_domain}"
+
+  depends_on = [cloudflare_dns_record.fallback_origin]
+}
+
+resource "cloudflare_dns_record" "fallback_origin" {
+  zone_id = var.cloudflare_zone_id
+  name    = "${local.name_prefix}-fallback"
+  type    = "A"
+  content = "192.0.2.1"
+  proxied = true
+  ttl     = 1
+}
+
+variable "from_version" {
+  description = "Provider version under test, used to namespace resource names"
+  type        = string
+}

--- a/e2e-v5/testdata/custom_pages/custom_pages.tf
+++ b/e2e-v5/testdata/custom_pages/custom_pages.tf
@@ -1,0 +1,33 @@
+# Variables (no defaults as per pattern)
+variable "cloudflare_account_id" {
+  description = "Cloudflare account ID"
+  type        = string
+}
+
+variable "cloudflare_zone_id" {
+  description = "Cloudflare zone ID"
+  type        = string
+}
+
+variable "cloudflare_domain" {
+  description = "Cloudflare domain for testing"
+  type        = string
+}
+
+# URL for custom pages - this URL contains the required tokens for all error page types
+locals {
+  custom_pages_url = "https://custom-pages-basic.terraform-provider-acceptance-testing.workers.dev/"
+}
+
+# Basic zone-scoped custom page with real URL
+resource "cloudflare_custom_pages" "error_500" {
+  zone_id    = var.cloudflare_zone_id
+  url        = local.custom_pages_url
+  state      = "customized"
+  identifier = "500_errors"
+}
+
+variable "from_version" {
+  description = "Provider version under test, used to namespace resource names"
+  type        = string
+}

--- a/e2e-v5/testdata/custom_ssl/custom_ssl.tf
+++ b/e2e-v5/testdata/custom_ssl/custom_ssl.tf
@@ -1,0 +1,145 @@
+# E2E test file for custom_ssl.
+#
+# Uses the tls provider to dynamically generate certificates for the test domain.
+# This allows the test to work with any zone configured via var.cloudflare_domain.
+# Note: The tls provider is included by default in the generated versions.tf.
+#
+# Key migration paths covered:
+#   - geo_restrictions string -> { label = "..." } nested attribute  (full)
+#   - minimal config (no optional fields)                           (minimal)
+#   - custom_ssl_priority blocks removed on migration               (with_priority)
+
+variable "cloudflare_zone_id" {
+  type = string
+}
+
+variable "cloudflare_account_id" {
+  type = string
+}
+
+variable "cloudflare_domain" {
+  type = string
+}
+
+locals {
+  name_prefix = "v5-upgrade-${replace(var.from_version, ".", "-")}"
+}
+
+# Generate a private key for the certificate
+resource "tls_private_key" "custom_ssl_full" {
+  algorithm = "RSA"
+  rsa_bits  = 2048
+}
+
+# Generate a self-signed certificate for the test domain
+resource "tls_self_signed_cert" "custom_ssl_full" {
+  private_key_pem = tls_private_key.custom_ssl_full.private_key_pem
+
+  subject {
+    common_name = var.cloudflare_domain
+  }
+
+  # Valid for 1 year
+  validity_period_hours = 8760
+
+  # Certificate for the domain and wildcard subdomain
+  dns_names = [
+    var.cloudflare_domain,
+    "*.${var.cloudflare_domain}",
+  ]
+
+  allowed_uses = [
+    "key_encipherment",
+    "digital_signature",
+    "server_auth",
+  ]
+}
+
+# Pattern 1: Full config - exercises geo_restrictions string -> { label } transform
+resource "cloudflare_custom_ssl" "full" {
+  zone_id = var.cloudflare_zone_id
+
+  certificate   = tls_self_signed_cert.custom_ssl_full.cert_pem
+  private_key   = tls_private_key.custom_ssl_full.private_key_pem
+  bundle_method = "force"
+  type          = "legacy_custom"
+  geo_restrictions = {
+    label = "us"
+  }
+}
+
+resource "tls_private_key" "custom_ssl_minimal" {
+  algorithm = "RSA"
+  rsa_bits  = 2048
+}
+
+resource "tls_self_signed_cert" "custom_ssl_minimal" {
+  private_key_pem       = tls_private_key.custom_ssl_minimal.private_key_pem
+  validity_period_hours = 8760
+
+  subject {
+    common_name = "${local.name_prefix}-minimal.${var.cloudflare_domain}"
+  }
+
+  dns_names = [
+    "${local.name_prefix}-minimal.${var.cloudflare_domain}",
+    "*.${local.name_prefix}-minimal.${var.cloudflare_domain}",
+  ]
+
+  allowed_uses = [
+    "key_encipherment",
+    "digital_signature",
+    "server_auth",
+  ]
+}
+
+# Pattern 2: Minimal config - no geo_restrictions or priority blocks
+resource "cloudflare_custom_ssl" "minimal" {
+  zone_id = var.cloudflare_zone_id
+
+  certificate   = tls_self_signed_cert.custom_ssl_minimal.cert_pem
+  private_key   = tls_private_key.custom_ssl_minimal.private_key_pem
+  bundle_method = "force"
+  type          = "legacy_custom"
+}
+
+resource "tls_private_key" "custom_ssl_priority" {
+  algorithm = "RSA"
+  rsa_bits  = 2048
+}
+
+resource "tls_self_signed_cert" "custom_ssl_priority" {
+  private_key_pem       = tls_private_key.custom_ssl_priority.private_key_pem
+  validity_period_hours = 8760
+
+  subject {
+    common_name = "${local.name_prefix}-priority.${var.cloudflare_domain}"
+  }
+
+  dns_names = [
+    "${local.name_prefix}-priority.${var.cloudflare_domain}",
+    "*.${local.name_prefix}-priority.${var.cloudflare_domain}",
+  ]
+
+  allowed_uses = [
+    "key_encipherment",
+    "digital_signature",
+    "server_auth",
+  ]
+}
+
+# Pattern 3: custom_ssl_priority blocks - must be removed on migration
+resource "cloudflare_custom_ssl" "with_priority" {
+  zone_id = var.cloudflare_zone_id
+
+
+  certificate   = tls_self_signed_cert.custom_ssl_priority.cert_pem
+  private_key   = tls_private_key.custom_ssl_priority.private_key_pem
+  bundle_method = "force"
+  type          = "legacy_custom"
+}
+
+variable "from_version" {
+  description = "Provider version under test, used to namespace resource names"
+  type        = string
+}

--- a/e2e-v5/testdata/dns_record/dns_record.tf
+++ b/e2e-v5/testdata/dns_record/dns_record.tf
@@ -1,0 +1,256 @@
+variable "cloudflare_account_id" {
+  description = "Cloudflare account ID"
+  type        = string
+}
+
+variable "cloudflare_zone_id" {
+  description = "Cloudflare zone ID"
+  type        = string
+}
+
+variable "cloudflare_domain" {
+  description = "Cloudflare domain for testing"
+  type        = string
+}
+
+variable "from_version" {
+  description = "Provider version under test, used to namespace resource names"
+  type        = string
+}
+
+variable "domain_name" {
+  type    = string
+  default = "cf-tf-test.com"
+}
+
+variable "record_ttl" {
+  type    = number
+  default = 3600
+}
+
+variable "backup_mx_count" {
+  type    = number
+  default = 3
+}
+
+variable "enable_ipv6" {
+  type    = bool
+  default = true
+}
+
+locals {
+  name_prefix    = "v5-upgrade-${replace(var.from_version, ".", "-")}"
+  proxied_ttl    = 1
+  common_zone_id = var.cloudflare_zone_id
+}
+
+# A record
+resource "cloudflare_dns_record" "example_a" {
+  zone_id = var.cloudflare_zone_id
+  name    = "${local.name_prefix}-example"
+  type    = "A"
+  proxied = true
+  ttl     = 1
+  content = "192.0.2.1"
+}
+
+# MX record - use name_prefix to avoid collision with v4->v5 @ MX records
+resource "cloudflare_dns_record" "example_mx" {
+  zone_id  = var.cloudflare_zone_id
+  name     = "${local.name_prefix}-mail"
+  type     = "MX"
+  priority = 10
+  ttl      = 3600
+  content  = "${local.name_prefix}-mail.cf-tf-test.com"
+}
+
+# CAA record
+resource "cloudflare_dns_record" "example_caa" {
+  zone_id = var.cloudflare_zone_id
+  name    = "${local.name_prefix}-caa"
+  type    = "CAA"
+  ttl     = 3600
+  data = {
+    flags = "0"
+    tag   = "issue"
+    value = "ca.cf-tf-test.com"
+  }
+}
+
+# CAA record with data attribute map
+resource "cloudflare_dns_record" "example_caa_map" {
+  zone_id = var.cloudflare_zone_id
+  name    = "${local.name_prefix}-caa-map"
+  type    = "CAA"
+  ttl     = 3600
+  data = {
+    flags = "128"
+    tag   = "issuewild"
+    value = "ca.cf-tf-test.com"
+  }
+}
+
+# SRV record
+resource "cloudflare_dns_record" "example_srv" {
+  zone_id  = var.cloudflare_zone_id
+  name     = "${local.name_prefix}-service._tcp"
+  type     = "SRV"
+  priority = 5
+  ttl      = 3600
+  data = {
+    priority = 5
+    weight   = 10
+    port     = 5060
+    target   = "sip.cf-tf-test.com"
+  }
+}
+
+# URI record
+resource "cloudflare_dns_record" "example_uri" {
+  zone_id  = var.cloudflare_zone_id
+  name     = "${local.name_prefix}-http._tcp"
+  type     = "URI"
+  priority = 10
+  ttl      = 3600
+  data = {
+    weight = 20
+    target = "http://cf-tf-test.com/path"
+  }
+}
+
+# CNAME record
+resource "cloudflare_dns_record" "example_cname" {
+  zone_id = var.cloudflare_zone_id
+  name    = "${local.name_prefix}-www"
+  type    = "CNAME"
+  proxied = false
+  ttl     = 3600
+  content = "cf-tf-test.com"
+}
+
+# TXT record - use name_prefix to avoid collision
+resource "cloudflare_dns_record" "example_txt" {
+  zone_id = var.cloudflare_zone_id
+  name    = "${local.name_prefix}-spf"
+  type    = "TXT"
+  ttl     = 3600
+  content = "v=spf1 include:${local.name_prefix}._spf.cf-tf-test.com ~all"
+}
+
+# TXT record - OPENPGPKEY style
+resource "cloudflare_dns_record" "example_openpgpkey" {
+  zone_id = var.cloudflare_zone_id
+  name    = "${local.name_prefix}-user._openpgpkey"
+  type    = "TXT"
+  ttl     = 3600
+  content = "mQENBFzjqGoBCADTKLKfh..."
+}
+
+# for_each with map - prefix keys through name_prefix
+resource "cloudflare_dns_record" "subdomain_a_records" {
+  for_each = {
+    "${local.name_prefix}-api"    = { value = "192.0.2.10", proxied = true }
+    "${local.name_prefix}-www2"   = { value = "192.0.2.11", proxied = true }
+    "${local.name_prefix}-static" = { value = "192.0.2.12", proxied = false }
+  }
+
+  zone_id = local.common_zone_id
+  name    = each.key
+  type    = "A"
+  proxied = each.value.proxied
+  ttl     = each.value.proxied ? local.proxied_ttl : var.record_ttl
+  content = each.value.value
+}
+
+# for_each TXT records - use name_prefix in names
+resource "cloudflare_dns_record" "security_txt_records" {
+  for_each = {
+    "${local.name_prefix}-dmarc" = "v=DMARC1; p=quarantine; rua=mailto:dmarc@cf-tf-test.com"
+    "${local.name_prefix}-dkim"  = "v=DKIM1; k=rsa; p=MIGfMA0GCS..."
+  }
+
+  zone_id = var.cloudflare_zone_id
+  name    = each.key
+  type    = "TXT"
+  ttl     = var.record_ttl
+  content = each.value
+}
+
+# count-based MX records - use name_prefix
+resource "cloudflare_dns_record" "backup_mx" {
+  count = var.backup_mx_count
+
+  zone_id  = var.cloudflare_zone_id
+  name     = "${local.name_prefix}-mx"
+  type     = "MX"
+  priority = (count.index + 2) * 10
+  ttl      = var.record_ttl
+  content  = "${local.name_prefix}-mx${count.index + 2}.${var.domain_name}"
+}
+
+# AAAA record
+resource "cloudflare_dns_record" "ipv6_aaaa" {
+  count = var.enable_ipv6 ? 1 : 0
+
+  zone_id = var.cloudflare_zone_id
+  name    = "${local.name_prefix}-ipv6"
+  type    = "AAAA"
+  proxied = true
+  ttl     = 1
+  content = "2001:db8:85a3::8a2e:370:7334"
+}
+
+# TXT with complex content
+resource "cloudflare_dns_record" "dnslink" {
+  zone_id = var.cloudflare_zone_id
+  name    = "${local.name_prefix}-dnslink"
+  type    = "TXT"
+  ttl     = var.record_ttl
+  content = "dnslink=/ipfs/QmXoypizjW3WknFiJnKLwHCnL72vedxjQkDDP1mXWo6uco"
+}
+
+# CNAME cross-reference
+resource "cloudflare_dns_record" "cname_to_a" {
+  zone_id = var.cloudflare_zone_id
+  name    = "${local.name_prefix}-alias"
+  type    = "CNAME"
+  proxied = false
+  ttl     = var.record_ttl
+  content = "example.${var.domain_name}"
+}
+
+# lifecycle
+resource "cloudflare_dns_record" "protected_record" {
+  zone_id = var.cloudflare_zone_id
+  name    = "${local.name_prefix}-protected"
+  type    = "A"
+  proxied = true
+  ttl     = 1
+  content = "192.0.2.99"
+
+  lifecycle {
+    prevent_destroy       = false
+    create_before_destroy = true
+  }
+}
+
+# conditional type
+resource "cloudflare_dns_record" "conditional_value" {
+  zone_id = var.cloudflare_zone_id
+  name    = "${local.name_prefix}-conditional"
+  type    = var.enable_ipv6 ? "AAAA" : "A"
+  proxied = true
+  ttl     = 1
+  content = var.enable_ipv6 ? "2001:db8::1" : "192.0.2.100"
+}
+
+# with comment
+resource "cloudflare_dns_record" "tagged_record" {
+  zone_id = var.cloudflare_zone_id
+  name    = "${local.name_prefix}-tagged"
+  type    = "A"
+  proxied = true
+  ttl     = 1
+  comment = "This is a test record for e2e migration testing"
+  content = "192.0.2.200"
+}

--- a/e2e-v5/testdata/healthcheck/healthcheck.tf
+++ b/e2e-v5/testdata/healthcheck/healthcheck.tf
@@ -1,0 +1,106 @@
+variable "cloudflare_account_id" {
+  description = "Cloudflare account ID"
+  type        = string
+}
+
+variable "cloudflare_zone_id" {
+  description = "Cloudflare zone ID"
+  type        = string
+}
+
+variable "cloudflare_domain" {
+  description = "Cloudflare domain for testing"
+  type        = string
+}
+
+# ============================================================================
+# E2E Tests: Healthcheck v4 → v5 Migration
+#
+# These tests cover the key migration paths:
+#   1. HTTP healthcheck: top-level HTTP fields → http_config nested attribute
+#   2. HTTP with headers: header blocks → http_config.header map
+#   3. TCP healthcheck: top-level TCP fields → tcp_config nested attribute
+#   4. Common fields (check_regions, consecutive_fails, etc.) stay top-level
+#
+# Note: cloudflare_healthcheck is a zone-scoped resource. Each test uses a
+# distinct name to avoid conflicts. The address uses httpbin.org which is a
+# stable public endpoint suitable for healthcheck testing.
+# ============================================================================
+
+locals {
+  name_prefix = "v5-upgrade-${replace(var.from_version, ".", "-")}"
+  hc_prefix   = "${local.name_prefix}-e2e-hc"
+  hc_address  = "httpbin.org"
+}
+
+# Test 1: Minimal HTTP healthcheck
+# Covers: type=HTTP, check_regions (top-level), expected_codes → http_config
+resource "cloudflare_healthcheck" "e2e_http_minimal" {
+  zone_id = var.cloudflare_zone_id
+  name    = "${local.hc_prefix}-http-minimal"
+  address = local.hc_address
+  type    = "HTTP"
+
+  check_regions = ["WNAM"]
+  http_config = {
+    expected_codes = ["200"]
+  }
+}
+
+# Test 2: Full HTTP healthcheck
+# Covers: all HTTP-specific fields → http_config, common fields stay top-level,
+#         header blocks → http_config.header map
+resource "cloudflare_healthcheck" "e2e_http_full" {
+  zone_id = var.cloudflare_zone_id
+  name    = "${local.hc_prefix}-http-full"
+  address = local.hc_address
+  type    = "HTTP"
+
+
+
+  # Common fields (stay top-level in v5)
+  description           = "E2E full HTTP healthcheck"
+  consecutive_fails     = 2
+  consecutive_successes = 2
+  retries               = 2
+  timeout               = 5
+  interval              = 60
+  suspended             = false
+  check_regions         = ["WNAM"]
+  http_config = {
+    allow_insecure   = false
+    expected_codes   = ["200"]
+    follow_redirects = false
+    header = {
+      "User-Agent" = ["HealthChecker/1.0"]
+    }
+    method = "GET"
+    path   = "/get"
+    port   = 80
+  }
+}
+
+# Test 3: TCP healthcheck
+# Covers: type=TCP, method + port → tcp_config, common fields stay top-level
+resource "cloudflare_healthcheck" "e2e_tcp" {
+  zone_id = var.cloudflare_zone_id
+  name    = "${local.hc_prefix}-tcp"
+  address = local.hc_address
+  type    = "TCP"
+
+
+  # Common fields (stay top-level in v5)
+  consecutive_fails = 2
+  timeout           = 5
+  interval          = 30
+  check_regions     = ["WNAM"]
+  tcp_config = {
+    method = "connection_established"
+    port   = 80
+  }
+}
+
+variable "from_version" {
+  description = "Provider version under test, used to namespace resource names"
+  type        = string
+}

--- a/e2e-v5/testdata/leaked_credential_check/leaked_credential_check.tf
+++ b/e2e-v5/testdata/leaked_credential_check/leaked_credential_check.tf
@@ -1,0 +1,27 @@
+# E2E test for leaked_credential_check migration
+# This resource is a singleton (one per zone)
+
+variable "cloudflare_account_id" {
+  description = "Cloudflare account ID"
+  type        = string
+}
+
+variable "cloudflare_zone_id" {
+  description = "Cloudflare zone ID"
+  type        = string
+}
+
+variable "cloudflare_domain" {
+  description = "Cloudflare domain for testing"
+  type        = string
+}
+
+resource "cloudflare_leaked_credential_check" "test" {
+  zone_id = var.cloudflare_zone_id
+  enabled = true
+}
+
+variable "from_version" {
+  description = "Provider version under test, used to namespace resource names"
+  type        = string
+}

--- a/e2e-v5/testdata/leaked_credential_check_rule/leaked_credential_check_rule.tf
+++ b/e2e-v5/testdata/leaked_credential_check_rule/leaked_credential_check_rule.tf
@@ -1,0 +1,27 @@
+# E2E test for leaked_credential_check_rule migration
+
+variable "cloudflare_account_id" {
+  description = "Cloudflare account ID"
+  type        = string
+}
+
+variable "cloudflare_zone_id" {
+  description = "Cloudflare zone ID"
+  type        = string
+}
+
+variable "cloudflare_domain" {
+  description = "Cloudflare domain for testing"
+  type        = string
+}
+
+resource "cloudflare_leaked_credential_check_rule" "basic" {
+  zone_id  = var.cloudflare_zone_id
+  username = "lookup_json_string(http.request.body.raw, \"v5_upgrade_user\")"
+  password = "lookup_json_string(http.request.body.raw, \"v5_upgrade_secret\")"
+}
+
+variable "from_version" {
+  description = "Provider version under test, used to namespace resource names"
+  type        = string
+}

--- a/e2e-v5/testdata/list/list.tf
+++ b/e2e-v5/testdata/list/list.tf
@@ -1,0 +1,270 @@
+variable "cloudflare_account_id" {
+  description = "Cloudflare account ID"
+  type        = string
+}
+
+variable "cloudflare_zone_id" {
+  description = "Cloudflare zone ID"
+  type        = string
+}
+
+variable "cloudflare_domain" {
+  description = "Cloudflare domain for testing"
+  type        = string
+}
+
+locals {
+  name_prefix    = "v5_upgrade_${replace(var.from_version, ".", "_")}"
+  common_account = var.cloudflare_account_id
+}
+
+# ========================================
+# List 1: IP list with multiple items (CIDR, IPv6, static)
+# ========================================
+resource "cloudflare_list" "ip_list" {
+  account_id  = var.cloudflare_account_id
+  name        = "${local.name_prefix}_ip_list"
+  kind        = "ip"
+  description = "IP list with various formats"
+
+
+
+
+  items = [{
+    comment = "Single IP"
+    ip      = "1.1.1.1"
+    }, {
+    comment = "CIDR block"
+    ip      = "10.0.0.0/8"
+    }, {
+    comment = "IPv6 address"
+    ip      = "2001:db8::1"
+    }, {
+    ip = "192.168.1.1"
+  }]
+}
+
+# ========================================
+# List 2: ASN list with dynamic items
+# ========================================
+variable "dynamic_asn_list" {
+  type = list(object({
+    number      = number
+    description = string
+  }))
+  default = [
+    { number = 15169, description = "Google ASN" },
+    { number = 13335, description = "Cloudflare ASN" },
+    { number = 20940, description = "Akamai ASN" }
+  ]
+}
+
+resource "cloudflare_list" "asn_list" {
+  account_id  = local.common_account
+  name        = "${local.name_prefix}_asn_list"
+  kind        = "asn"
+  description = "ASN list with dynamic items"
+
+  items = [for item in var.dynamic_asn_list : {
+    asn     = item.number
+    comment = item.description
+  }]
+}
+
+# ========================================
+# List 3: Hostname list with mixed static and dynamic
+# ========================================
+variable "dynamic_hostnames" {
+  type    = list(string)
+  default = ["app1.example.com", "app2.example.com"]
+}
+
+resource "cloudflare_list" "hostname_list" {
+  account_id  = var.cloudflare_account_id
+  name        = "${local.name_prefix}_hostname_list"
+  kind        = "hostname"
+  description = "Hostname list with mixed items"
+
+
+  items = concat([{ hostname = { url_hostname = "example.com" }, comment = "Static hostname" }], [for host in var.dynamic_hostnames : {
+    hostname = { url_hostname = host }
+  }])
+}
+
+# ========================================
+# List 4: Redirect list with full options
+# ========================================
+resource "cloudflare_list" "redirect_list" {
+  account_id  = var.cloudflare_account_id
+  name        = "${local.name_prefix}_redirect_list"
+  kind        = "redirect"
+  description = "Redirect list with full options"
+
+
+
+  items = [{
+    comment = "Full options redirect"
+    redirect = {
+      include_subdomains    = true
+      preserve_path_suffix  = false
+      preserve_query_string = true
+      source_url            = "example.com/old"
+      status_code           = 301
+      subpath_matching      = false
+      target_url            = "https://example.com/new"
+    }
+    }, {
+    comment = "Simple redirect"
+    redirect = {
+      include_subdomains = false
+      source_url         = "test.com/"
+      status_code        = 302
+      target_url         = "https://newtest.com"
+    }
+    }, {
+    redirect = {
+      include_subdomains    = true
+      preserve_path_suffix  = true
+      preserve_query_string = false
+      source_url            = "old.example.com/"
+      status_code           = 307
+      subpath_matching      = true
+      target_url            = "https://new.example.com"
+    }
+  }]
+}
+
+# ========================================
+# List 5: Hostname with for_each (single item map)
+# ========================================
+variable "hostname_map" {
+  type = map(string)
+  default = {
+    "api" = "api.example.com"
+  }
+}
+
+resource "cloudflare_list" "hostname_foreach" {
+  for_each = var.hostname_map
+
+  account_id  = var.cloudflare_account_id
+  name        = "${local.name_prefix}_hostname_${each.key}"
+  kind        = "hostname"
+  description = "Hostname list via for_each"
+
+  items = [{
+    comment = each.key
+    hostname = {
+      url_hostname = each.value
+    }
+  }]
+}
+
+# ========================================
+# List 6: ASN with count = 1
+# ========================================
+resource "cloudflare_list" "asn_count" {
+  count = 1
+
+  account_id  = var.cloudflare_account_id
+  name        = "${local.name_prefix}_asn_count"
+  kind        = "asn"
+  description = "ASN list with count"
+
+
+  items = [{
+    asn     = 65001
+    comment = "Private ASN"
+    }, {
+    asn = 65002
+  }]
+}
+
+# ========================================
+# List 7: Redirect conditional
+# ========================================
+variable "enable_redirect" {
+  type    = bool
+  default = true
+}
+
+resource "cloudflare_list" "redirect_conditional" {
+  count = var.enable_redirect ? 1 : 0
+
+  account_id  = var.cloudflare_account_id
+  name        = "${local.name_prefix}_redirect_cond"
+  kind        = "redirect"
+  description = "Conditional redirect list"
+
+  items = [{
+    comment = "Conditional redirect"
+    redirect = {
+      include_subdomains = true
+      source_url         = "conditional.example.com/"
+      status_code        = 301
+      target_url         = "https://target.example.com"
+    }
+  }]
+}
+
+# ========================================
+# List 8: IP with lifecycle meta-arguments
+# ========================================
+resource "cloudflare_list" "ip_lifecycle" {
+  account_id  = var.cloudflare_account_id
+  name        = "${local.name_prefix}_ip_lifecycle"
+  kind        = "ip"
+  description = "IP list with lifecycle rules"
+
+
+  lifecycle {
+    create_before_destroy = true
+    prevent_destroy       = false
+  }
+  items = [{
+    comment = "Protected IP"
+    ip      = "198.51.100.10"
+  }]
+}
+
+# ========================================
+# List 9: Redirect parent (for cross-resource reference)
+# ========================================
+resource "cloudflare_list" "redirect_parent" {
+  account_id  = var.cloudflare_account_id
+  name        = "${local.name_prefix}_redirect_parent"
+  kind        = "redirect"
+  description = "Parent redirect list"
+
+  items = [{
+    comment = "Parent redirect"
+    redirect = {
+      include_subdomains = false
+      source_url         = "parent.example.com/"
+      status_code        = 301
+      target_url         = "https://parent-target.example.com"
+    }
+  }]
+}
+
+# ========================================
+# List 10: Hostname referencing another list
+# ========================================
+resource "cloudflare_list" "hostname_child" {
+  account_id  = var.cloudflare_account_id
+  name        = "${cloudflare_list.redirect_parent.name}_child"
+  kind        = "hostname"
+  description = "Child list referencing parent"
+
+  items = [{
+    comment = "Child hostname"
+    hostname = {
+      url_hostname = "child.example.com"
+    }
+  }]
+}
+
+variable "from_version" {
+  description = "Provider version under test, used to namespace resource names"
+  type        = string
+}

--- a/e2e-v5/testdata/load_balancer/load_balancer.tf
+++ b/e2e-v5/testdata/load_balancer/load_balancer.tf
@@ -1,0 +1,166 @@
+# E2E Test: cloudflare_load_balancer
+# Minimal e2e test that can be applied with real infrastructure
+# Creates pools and load balancers in the same module to avoid dependency issues
+
+variable "cloudflare_account_id" {
+  type = string
+}
+
+variable "cloudflare_zone_id" {
+  type = string
+}
+
+variable "cloudflare_domain" {
+  type        = string
+  description = "Domain for testing"
+}
+
+locals {
+  name_prefix = "v5-upgrade-${replace(var.from_version, ".", "-")}"
+}
+
+##########################
+# E2E TEST POOLS
+##########################
+
+resource "cloudflare_load_balancer_pool" "lb_e2e_basic" {
+  account_id      = var.cloudflare_account_id
+  name            = "${local.name_prefix}-lb-e2e-basic-pool"
+  minimum_origins = 1
+  enabled         = true
+
+  origins = [{
+    name    = "origin-1"
+    address = "192.0.2.100"
+    enabled = true
+  }]
+}
+
+resource "cloudflare_load_balancer_pool" "lb_e2e_fallback" {
+  account_id      = var.cloudflare_account_id
+  name            = "${local.name_prefix}-lb-e2e-fallback-pool"
+  minimum_origins = 1
+  enabled         = true
+
+  origins = [{
+    name    = "origin-fallback"
+    address = "192.0.2.101"
+    enabled = true
+  }]
+}
+
+##########################
+# E2E TEST LOAD BALANCERS
+##########################
+
+# 1. Basic load balancer (v4 syntax - will be migrated to v5)
+resource "cloudflare_load_balancer" "e2e_basic" {
+  zone_id         = var.cloudflare_zone_id
+  name            = "${local.name_prefix}-e2e-basic-lb.${var.cloudflare_domain}"
+  enabled         = true
+  steering_policy = "off"
+  ttl             = 30
+  default_pools   = [cloudflare_load_balancer_pool.lb_e2e_basic.id]
+  fallback_pool   = cloudflare_load_balancer_pool.lb_e2e_fallback.id
+}
+
+# 2. Load balancer with session_affinity_attributes (v4 syntax - will be migrated to v5)
+resource "cloudflare_load_balancer" "e2e_affinity" {
+  zone_id              = var.cloudflare_zone_id
+  name                 = "${local.name_prefix}-e2e-affinity-lb.${var.cloudflare_domain}"
+  session_affinity     = "cookie"
+  session_affinity_ttl = 3600
+
+
+  enabled         = true
+  steering_policy = "off"
+  ttl             = 30
+  default_pools   = [cloudflare_load_balancer_pool.lb_e2e_basic.id]
+  fallback_pool   = cloudflare_load_balancer_pool.lb_e2e_fallback.id
+  session_affinity_attributes = {
+    samesite = "Lax"
+    secure   = "Always"
+  }
+}
+
+# 3. Load balancer with adaptive_routing (v4 syntax - will be migrated to v5)
+resource "cloudflare_load_balancer" "e2e_adaptive_routing" {
+  zone_id         = var.cloudflare_zone_id
+  name            = "${local.name_prefix}-e2e-adaptive-lb.${var.cloudflare_domain}"
+  enabled         = true
+  steering_policy = "off"
+  ttl             = 30
+
+  default_pools = [cloudflare_load_balancer_pool.lb_e2e_basic.id]
+  fallback_pool = cloudflare_load_balancer_pool.lb_e2e_fallback.id
+  adaptive_routing = {
+    failover_across_pools = false
+  }
+}
+
+# 4. Load balancer with location_strategy (v4 syntax - will be migrated to v5)
+resource "cloudflare_load_balancer" "e2e_location_strategy" {
+  zone_id         = var.cloudflare_zone_id
+  name            = "${local.name_prefix}-e2e-location-lb.${var.cloudflare_domain}"
+  enabled         = true
+  steering_policy = "off"
+  ttl             = 30
+
+  default_pools = [cloudflare_load_balancer_pool.lb_e2e_basic.id]
+  fallback_pool = cloudflare_load_balancer_pool.lb_e2e_fallback.id
+  location_strategy = {
+    prefer_ecs = "proximity"
+    mode       = "pop"
+  }
+}
+
+# 5. Load balancer with random_steering (v4 syntax - will be migrated to v5)
+resource "cloudflare_load_balancer" "e2e_random_steering" {
+  zone_id         = var.cloudflare_zone_id
+  name            = "${local.name_prefix}-e2e-random-lb.${var.cloudflare_domain}"
+  enabled         = true
+  steering_policy = "random"
+  ttl             = 30
+
+  default_pools = [cloudflare_load_balancer_pool.lb_e2e_basic.id]
+  fallback_pool = cloudflare_load_balancer_pool.lb_e2e_fallback.id
+  random_steering = {
+    default_weight = 0.5
+  }
+}
+
+# 6. Load balancer with all single-object attributes (v4 syntax - will be migrated to v5)
+resource "cloudflare_load_balancer" "e2e_all_attributes" {
+  zone_id              = var.cloudflare_zone_id
+  name                 = "${local.name_prefix}-e2e-all-attrs-lb.${var.cloudflare_domain}"
+  session_affinity     = "cookie"
+  session_affinity_ttl = 3600
+  enabled              = true
+  steering_policy      = "random"
+  ttl                  = 30
+
+
+
+
+  default_pools = [cloudflare_load_balancer_pool.lb_e2e_basic.id]
+  fallback_pool = cloudflare_load_balancer_pool.lb_e2e_fallback.id
+  session_affinity_attributes = {
+    samesite = "Lax"
+    secure   = "Always"
+  }
+  adaptive_routing = {
+    failover_across_pools = false
+  }
+  location_strategy = {
+    prefer_ecs = "proximity"
+    mode       = "pop"
+  }
+  random_steering = {
+    default_weight = 0.5
+  }
+}
+
+variable "from_version" {
+  description = "Provider version under test, used to namespace resource names"
+  type        = string
+}

--- a/e2e-v5/testdata/load_balancer_monitor/load_balancer_monitor.tf
+++ b/e2e-v5/testdata/load_balancer_monitor/load_balancer_monitor.tf
@@ -1,0 +1,262 @@
+# Terraform v4 Load Balancer Monitor Test Configuration
+# This file tests the migration from cloudflare_load_balancer_monitor (v4) to cloudflare_load_balancer_monitor (v5)
+# NOTE: Resource name stays the same, but field structures change
+
+# Variables - auto-provided by test infrastructure
+
+variable "cloudflare_zone_id" {
+  description = "Cloudflare zone ID"
+  type        = string
+}
+
+variable "cloudflare_domain" {
+  description = "Cloudflare domain for testing"
+  type        = string
+}
+
+variable "cloudflare_account_id" {
+  description = "Cloudflare account ID"
+  type        = string
+}
+
+# Locals for DRY and testing
+locals {
+  name_prefix    = "v5-upgrade-${replace(var.from_version, ".", "-")}"
+  common_account = var.cloudflare_account_id
+  monitor_types  = ["http", "https", "tcp"]
+}
+
+# Test Case 1: Minimal monitor (only required fields)
+resource "cloudflare_load_balancer_monitor" "minimal" {
+  account_id     = var.cloudflare_account_id
+  expected_codes = "200"
+}
+
+# Test Case 3: HTTPS monitor with multiple headers
+resource "cloudflare_load_balancer_monitor" "https_with_headers" {
+  account_id     = var.cloudflare_account_id
+  type           = "https"
+  method         = "GET"
+  path           = "/api/health"
+  expected_codes = "200"
+  expected_body  = "OK"
+  interval       = 45
+  retries        = 3
+  timeout        = 10
+  port           = 443
+  header = {
+    "Host"          = ["api.cf-tf-test.com"]
+    "Authorization" = ["Bearer token123"]
+  }
+}
+
+# Test Case 4: TCP monitor (no headers)
+resource "cloudflare_load_balancer_monitor" "tcp" {
+  account_id = var.cloudflare_account_id
+  type       = "tcp"
+  method     = "connection_established"
+  port       = 8080
+  interval   = 60
+  retries    = 2
+  timeout    = 5
+}
+
+# Test Case 5: Monitor with all optional fields
+resource "cloudflare_load_balancer_monitor" "maximal" {
+  account_id       = var.cloudflare_account_id
+  description      = "Comprehensive test monitor"
+  type             = "https"
+  method           = "GET"
+  path             = "/status"
+  port             = 8443
+  interval         = 120
+  retries          = 5
+  timeout          = 10
+  expected_codes   = "2xx,3xx"
+  expected_body    = "healthy"
+  follow_redirects = true
+  allow_insecure   = false
+  consecutive_down = 3
+  consecutive_up   = 2
+  header = {
+    "Host"            = ["status.cf-tf-test.com"]
+    "X-Custom-Header" = ["custom-value"]
+  }
+}
+
+# Test Case 7: for_each with set
+resource "cloudflare_load_balancer_monitor" "set_monitors" {
+  for_each = toset([
+    "alpha",
+    "beta",
+    "gamma",
+    "delta"
+  ])
+
+  account_id     = var.cloudflare_account_id
+  description    = "${local.name_prefix}-monitor-${each.value}"
+  type           = "http"
+  method         = "GET"
+  path           = "/healthz"
+  interval       = 60
+  expected_codes = "200"
+}
+
+# Test Case 8: count-based resources
+resource "cloudflare_load_balancer_monitor" "counted" {
+  count = 3
+
+  account_id     = var.cloudflare_account_id
+  description    = "${local.name_prefix}-monitor-${count.index}"
+  type           = "http"
+  method         = "GET"
+  path           = "/health${count.index}"
+  port           = 8080 + count.index
+  interval       = 30 + (count.index * 10)
+  expected_codes = "200"
+}
+
+# Test Case 9: Conditional creation
+resource "cloudflare_load_balancer_monitor" "conditional_enabled" {
+  count = true ? 1 : 0
+
+  account_id     = var.cloudflare_account_id
+  description    = "${local.name_prefix}-conditional-enabled"
+  type           = "http"
+  method         = "GET"
+  path           = "/enabled"
+  expected_codes = "200"
+}
+
+resource "cloudflare_load_balancer_monitor" "conditional_disabled" {
+  count = false ? 1 : 0
+
+  account_id  = var.cloudflare_account_id
+  description = "${local.name_prefix}-conditional-disabled"
+  type        = "http"
+  method      = "GET"
+  path        = "/disabled"
+}
+
+# Test Case 10: Using Terraform functions
+resource "cloudflare_load_balancer_monitor" "with_functions" {
+  account_id     = var.cloudflare_account_id
+  description    = join("-", [local.name_prefix, "function", "test"])
+  type           = "https"
+  method         = "GET"
+  path           = "/check"
+  interval       = 60
+  expected_codes = "200"
+
+  header = {
+    "Host" = [join(".", [local.name_prefix, "example", "com"])]
+  }
+}
+
+# Test Case 11: Lifecycle meta-arguments
+resource "cloudflare_load_balancer_monitor" "with_lifecycle" {
+  account_id     = var.cloudflare_account_id
+  description    = "${local.name_prefix}-lifecycle-test"
+  type           = "http"
+  method         = "GET"
+  path           = "/lifecycle"
+  expected_codes = "200"
+
+  lifecycle {
+    create_before_destroy = true
+    ignore_changes        = [description]
+  }
+}
+
+# Test Case 12: Monitor with empty optional fields
+resource "cloudflare_load_balancer_monitor" "empty_optionals" {
+  account_id     = var.cloudflare_account_id
+  type           = "http"
+  method         = "GET"
+  expected_codes = "200"
+  # No path, no port, no headers - test default handling
+}
+
+# Test Case 13: SMTP monitor type
+resource "cloudflare_load_balancer_monitor" "smtp" {
+  account_id = var.cloudflare_account_id
+  type       = "smtp"
+  port       = 25
+  interval   = 60
+  retries    = 3
+  timeout    = 10
+}
+
+# Test Case 14: UDP-ICMP monitor type
+resource "cloudflare_load_balancer_monitor" "udp_icmp" {
+  account_id = var.cloudflare_account_id
+  type       = "udp_icmp"
+  port       = 53
+  interval   = 30
+  timeout    = 1
+}
+
+# Test Case 15: ICMP-PING monitor type
+resource "cloudflare_load_balancer_monitor" "icmp_ping" {
+  account_id = var.cloudflare_account_id
+  type       = "icmp_ping"
+  interval   = 60
+  retries    = 2
+  timeout    = 1
+}
+
+# Test Case 16: Header with multiple values
+resource "cloudflare_load_balancer_monitor" "multi_value_header" {
+  account_id     = var.cloudflare_account_id
+  type           = "https"
+  method         = "GET"
+  path           = "/multi"
+  expected_codes = "200"
+  header = {
+    "Accept"          = ["application/json", "application/xml", "text/html"]
+    "Accept-Language" = ["en-US", "en", "fr"]
+  }
+}
+
+# Test Case 17: String interpolation
+resource "cloudflare_load_balancer_monitor" "with_interpolation" {
+  account_id     = var.cloudflare_account_id
+  description    = "Monitor for account ${var.cloudflare_account_id}"
+  type           = "http"
+  method         = "GET"
+  path           = "/check"
+  expected_codes = "200"
+}
+
+# Test Case 18: Special characters in fields
+resource "cloudflare_load_balancer_monitor" "special_chars" {
+  account_id     = var.cloudflare_account_id
+  description    = "Test: Special & chars <> in \"description\""
+  type           = "https"
+  method         = "GET"
+  path           = "/api/v2/status?detailed=true&format=json"
+  expected_body  = "Status: OK | Ready: true"
+  expected_codes = "200"
+  header = {
+    "X-Api-Key" = ["key_with-dashes.and_underscores"]
+  }
+}
+
+# Test Case 19: Edge case - consecutive values
+resource "cloudflare_load_balancer_monitor" "consecutive_values" {
+  account_id       = var.cloudflare_account_id
+  type             = "http"
+  method           = "GET"
+  path             = "/check"
+  consecutive_down = 5
+  consecutive_up   = 3
+  interval         = 45
+  retries          = 4
+  timeout          = 8
+  expected_codes   = "200"
+}
+
+variable "from_version" {
+  description = "Provider version under test, used to namespace resource names"
+  type        = string
+}

--- a/e2e-v5/testdata/load_balancer_pool/load_balancer_pool.tf
+++ b/e2e-v5/testdata/load_balancer_pool/load_balancer_pool.tf
@@ -1,0 +1,199 @@
+# E2E Test: cloudflare_load_balancer_pool
+# Minimal e2e test that can be applied with real infrastructure
+
+variable "cloudflare_account_id" {
+  type = string
+}
+
+variable "cloudflare_zone_id" {
+  type = string
+}
+
+variable "cloudflare_domain" {
+  type        = string
+  description = "Domain for testing"
+}
+
+locals {
+  name_prefix = "v5-upgrade-${replace(var.from_version, ".", "-")}"
+
+  # List of backend origins for dynamic configuration
+  backend_origins = [
+    {
+      name    = "backend-1"
+      address = "192.0.2.100"
+      host    = "api1.${var.cloudflare_domain}"
+      weight  = 1.0
+    },
+    {
+      name    = "backend-2"
+      address = "192.0.2.101"
+      host    = "api2.${var.cloudflare_domain}"
+      weight  = 1.0
+    },
+    {
+      name    = "backend-3"
+      address = "192.0.2.102"
+      host    = "api3.${var.cloudflare_domain}"
+      weight  = 0.5
+    }
+  ]
+}
+
+##########################
+# E2E TEST POOLS
+##########################
+
+# 1. Basic pool with single origin (v4 syntax - will be migrated to v5)
+resource "cloudflare_load_balancer_pool" "e2e_basic" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-e2e-basic-pool"
+
+
+  minimum_origins = 1
+  enabled         = true
+  origins = [{
+    name    = "origin-1"
+    address = "192.0.2.1"
+    enabled = true
+  }]
+}
+
+# 2. Pool with multiple origins (v4 syntax - will be migrated to v5)
+resource "cloudflare_load_balancer_pool" "e2e_multi" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-e2e-multi-pool"
+
+
+
+  minimum_origins = 1
+  enabled         = true
+  origins = [{
+    name    = "origin-1"
+    address = "192.0.2.10"
+    enabled = true
+    weight  = 1
+    }, {
+    name    = "origin-2"
+    address = "192.0.2.11"
+    enabled = true
+    weight  = 1
+  }]
+}
+
+# 3. Pool with load_shedding (v4 syntax - will be migrated to v5)
+resource "cloudflare_load_balancer_pool" "e2e_shedding" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-e2e-shedding-pool"
+
+
+
+  minimum_origins = 1
+  enabled         = true
+  origins = [{
+    name    = "origin-1"
+    address = "192.0.2.20"
+    enabled = true
+  }]
+  load_shedding = {
+    default_percent = 55
+    default_policy  = "random"
+    session_percent = 30
+    session_policy  = "hash"
+  }
+}
+
+# 4. Pool with dynamic origins and headers (v4 syntax - will be migrated to v5 for expression)
+resource "cloudflare_load_balancer_pool" "e2e_dynamic_with_headers" {
+  account_id      = var.cloudflare_account_id
+  name            = "${local.name_prefix}-e2e-dynamic-headers-pool"
+  minimum_origins = 1
+  enabled         = true
+  description     = "Pool with dynamic origins and headers"
+
+
+  origins = [for value in local.backend_origins : {
+    name    = value.name
+    address = value.address
+    enabled = true
+    weight  = value.weight
+    header  = { host = [value.host] }
+  }]
+  origin_steering = {
+    policy = "random"
+  }
+}
+
+# 5. Pool with dynamic origins without headers (v4 syntax - will be migrated to v5 for expression)
+resource "cloudflare_load_balancer_pool" "e2e_dynamic_simple" {
+  account_id      = var.cloudflare_account_id
+  name            = "${local.name_prefix}-e2e-dynamic-simple-pool"
+  minimum_origins = 1
+  enabled         = true
+
+  origins = [for value in local.backend_origins : {
+    name    = value.name
+    address = value.address
+    enabled = true
+  }]
+}
+
+# 6. Pool with static origins and headers (v4 syntax - will be migrated to v5 array)
+# Note: The second origin (static-origin-2) is disabled and intentionally has no header
+# configuration because the Cloudflare API does not return header values for disabled
+# origins, which would cause persistent drift.
+resource "cloudflare_load_balancer_pool" "e2e_static_with_headers" {
+  account_id      = var.cloudflare_account_id
+  name            = "${local.name_prefix}-e2e-static-headers-pool"
+  minimum_origins = 1
+  enabled         = true
+
+
+
+  origins = [{
+    name    = "static-origin-1"
+    address = "192.0.2.200"
+    enabled = true
+    header  = { host = ["static1.${var.cloudflare_domain}"] }
+    }, {
+    name    = "static-origin-2"
+    address = "192.0.2.201"
+    enabled = false
+  }]
+  load_shedding = {
+    default_percent = 75
+    default_policy  = "random"
+    session_percent = 50
+    session_policy  = "hash"
+  }
+}
+
+# Output pool IDs for use by load balancers
+output "e2e_basic_pool_id" {
+  value = cloudflare_load_balancer_pool.e2e_basic.id
+}
+
+output "e2e_multi_pool_id" {
+  value = cloudflare_load_balancer_pool.e2e_multi.id
+}
+
+output "e2e_shedding_pool_id" {
+  value = cloudflare_load_balancer_pool.e2e_shedding.id
+}
+
+output "e2e_dynamic_headers_pool_id" {
+  value = cloudflare_load_balancer_pool.e2e_dynamic_with_headers.id
+}
+
+output "e2e_dynamic_simple_pool_id" {
+  value = cloudflare_load_balancer_pool.e2e_dynamic_simple.id
+}
+
+output "e2e_static_headers_pool_id" {
+  value = cloudflare_load_balancer_pool.e2e_static_with_headers.id
+}
+
+variable "from_version" {
+  description = "Provider version under test, used to namespace resource names"
+  type        = string
+}

--- a/e2e-v5/testdata/logpull_retention/logpull_retention.tf
+++ b/e2e-v5/testdata/logpull_retention/logpull_retention.tf
@@ -1,0 +1,33 @@
+locals {
+  name_prefix = "v5-upgrade-${replace(var.from_version, ".", "-")}"
+}
+
+# Integration Test for cloudflare_logpull_retention v4 → v5 Migration
+# Simplified to single resource since logpull_retention is a zone-level setting
+
+variable "cloudflare_zone_id" {
+  description = "Cloudflare zone ID"
+  type        = string
+}
+
+variable "cloudflare_domain" {
+  description = "Cloudflare domain for testing"
+  type        = string
+}
+
+variable "cloudflare_account_id" {
+  description = "Cloudflare account ID"
+  type        = string
+}
+
+# Single logpull retention resource
+# Tests the basic enabled → flag migration
+resource "cloudflare_logpull_retention" "basic" {
+  zone_id = var.cloudflare_zone_id
+  flag    = true
+}
+
+variable "from_version" {
+  description = "Provider version under test, used to namespace resource names"
+  type        = string
+}

--- a/e2e-v5/testdata/logpush_job/logpush_job.tf
+++ b/e2e-v5/testdata/logpush_job/logpush_job.tf
@@ -1,0 +1,115 @@
+locals {
+  name_prefix = "v5-upgrade-${replace(var.from_version, ".", "-")}"
+}
+
+variable "cloudflare_account_id" {
+  description = "Cloudflare account ID"
+  type        = string
+}
+
+variable "cloudflare_zone_id" {
+  description = "Cloudflare zone ID"
+  type        = string
+}
+
+variable "cloudflare_domain" {
+  description = "Cloudflare domain for testing"
+  type        = string
+}
+
+# Minimal logpush job
+resource "cloudflare_logpush_job" "minimal" {
+  account_id       = var.cloudflare_account_id
+  dataset          = "audit_logs"
+  destination_conf = "https://logpush-receiver.sd.cfplat.com"
+}
+
+# Job with logpull_options only (no output_options)
+resource "cloudflare_logpush_job" "with_logpull_options" {
+  account_id       = var.cloudflare_account_id
+  dataset          = "audit_logs"
+  destination_conf = "https://logpush-receiver.sd.cfplat.com"
+  logpull_options  = "fields=ClientIP,EdgeStartTimestamp&timestamps=unixnano"
+}
+
+# Job with output_options block
+resource "cloudflare_logpush_job" "with_output_options" {
+  account_id       = var.cloudflare_account_id
+  dataset          = "audit_logs"
+  destination_conf = "https://logpush-receiver.sd.cfplat.com"
+
+  output_options = {
+    batch_prefix     = "{"
+    batch_suffix     = "}"
+    field_names      = ["ClientIP", "EdgeStartTimestamp"]
+    output_type      = "ndjson"
+    cve_2021_44228   = false
+    field_delimiter  = ","
+    record_prefix    = "{"
+    record_suffix    = "}\n"
+    timestamp_format = "unixnano"
+    sample_rate      = 1
+  }
+}
+
+# Job with cve20214428 field (should be renamed)
+resource "cloudflare_logpush_job" "with_cve_field" {
+  account_id       = var.cloudflare_account_id
+  dataset          = "audit_logs"
+  destination_conf = "https://logpush-receiver.sd.cfplat.com"
+
+  output_options = {
+    output_type      = "ndjson"
+    cve_2021_44228   = true
+    field_delimiter  = ","
+    record_prefix    = "{"
+    record_suffix    = "}\n"
+    timestamp_format = "unixnano"
+    sample_rate      = 1
+  }
+}
+
+# Job with edge kind (should be preserved)
+resource "cloudflare_logpush_job" "edge_logs" {
+  zone_id          = var.cloudflare_zone_id
+  dataset          = "http_requests"
+  destination_conf = "https://logpush-receiver.sd.cfplat.com"
+  kind             = "edge"
+}
+
+# Job with "" kind (should be preserved)
+resource "cloudflare_logpush_job" "empty_kind" {
+  zone_id          = var.cloudflare_zone_id
+  dataset          = "http_requests"
+  destination_conf = "https://logpush-receiver.sd.cfplat.com"
+  kind             = ""
+}
+
+# Full featured job with all transformations
+resource "cloudflare_logpush_job" "full" {
+  zone_id          = var.cloudflare_zone_id
+  dataset          = "http_requests"
+  destination_conf = "https://logpush-receiver.sd.cfplat.com"
+  kind             = "edge"
+  enabled          = true
+  name             = "${local.name_prefix}-my-logpush-job"
+  frequency        = "high"
+
+  output_options = {
+    batch_prefix     = "{"
+    batch_suffix     = "}"
+    field_names      = ["ClientIP", "EdgeStartTimestamp", "RayID"]
+    output_type      = "ndjson"
+    sample_rate      = 1.0
+    timestamp_format = "unixnano"
+    cve_2021_44228   = true
+    field_delimiter  = ","
+    record_prefix    = "{"
+    record_suffix    = "}\n"
+  }
+}
+
+variable "from_version" {
+  description = "Provider version under test, used to namespace resource names"
+  type        = string
+}

--- a/e2e-v5/testdata/logpush_ownership_challenge/logpush_ownership_challenge.tf
+++ b/e2e-v5/testdata/logpush_ownership_challenge/logpush_ownership_challenge.tf
@@ -1,0 +1,30 @@
+# E2E test for logpush_ownership_challenge migration
+# This resource has 3rd party storage requirements, and you can only have 1 per configured storage.
+# The integration tests have various storage URIs
+
+variable "cloudflare_account_id" {
+  description = "Cloudflare account ID"
+  type        = string
+}
+
+variable "cloudflare_zone_id" {
+  description = "Cloudflare zone ID"
+  type        = string
+}
+
+variable "cloudflare_domain" {
+  description = "Cloudflare domain for testing"
+  type        = string
+}
+
+# Test: Single instance (singleton resource - only one per zone)
+# Note: This is a SINGLETON resource - only ONE instance per zone
+resource "cloudflare_logpush_ownership_challenge" "gcs_zone" {
+  zone_id          = var.cloudflare_zone_id
+  destination_conf = "gs://cf-terraform-provider-acct-test/ownership_challenges"
+}
+
+variable "from_version" {
+  description = "Provider version under test, used to namespace resource names"
+  type        = string
+}

--- a/e2e-v5/testdata/managed_transforms/managed_transforms.tf
+++ b/e2e-v5/testdata/managed_transforms/managed_transforms.tf
@@ -1,0 +1,44 @@
+variable "cloudflare_account_id" {
+  description = "Cloudflare account ID"
+  type        = string
+}
+
+variable "cloudflare_zone_id" {
+  description = "Cloudflare zone ID"
+  type        = string
+}
+
+variable "cloudflare_domain" {
+  description = "Cloudflare domain for testing"
+  type        = string
+}
+
+
+# Single comprehensive test covering all valid header types
+resource "cloudflare_managed_transforms" "test" {
+  zone_id = var.cloudflare_zone_id
+
+
+
+
+  managed_request_headers = [{
+    id      = "add_true_client_ip_headers"
+    enabled = true
+    }, {
+    id      = "add_visitor_location_headers"
+    enabled = false
+  }]
+  managed_response_headers = [{
+    id      = "add_security_headers"
+    enabled = true
+    }, {
+    id      = "remove_x-powered-by_header"
+    enabled = false
+  }]
+}
+
+
+variable "from_version" {
+  description = "Provider version under test, used to namespace resource names"
+  type        = string
+}

--- a/e2e-v5/testdata/mtls_certificate/mtls_certificate.tf
+++ b/e2e-v5/testdata/mtls_certificate/mtls_certificate.tf
@@ -1,0 +1,82 @@
+variable "cloudflare_account_id" {
+  type = string
+}
+
+variable "cloudflare_zone_id" {
+  type = string
+}
+
+variable "cloudflare_domain" {
+  type        = string
+  description = "Domain for testing (unused by this module)"
+}
+
+variable "from_version" {
+  description = "Provider version under test, used to namespace resource names"
+  type        = string
+}
+
+locals {
+  name_prefix = "v5-upgrade-${replace(var.from_version, ".", "-")}"
+}
+
+resource "tls_private_key" "ca" {
+  algorithm = "RSA"
+  rsa_bits  = 2048
+}
+
+resource "tls_self_signed_cert" "ca" {
+  private_key_pem       = tls_private_key.ca.private_key_pem
+  validity_period_hours = 8760
+  is_ca_certificate     = true
+
+  subject {
+    common_name  = "${local.name_prefix}-mtls-ca"
+    organization = "tf-migrate"
+  }
+
+  allowed_uses = [
+    "cert_signing",
+    "crl_signing",
+    "digital_signature",
+    "key_encipherment",
+  ]
+}
+
+resource "tls_private_key" "leaf" {
+  algorithm = "RSA"
+  rsa_bits  = 2048
+}
+
+resource "tls_self_signed_cert" "leaf" {
+  private_key_pem       = tls_private_key.leaf.private_key_pem
+  validity_period_hours = 8760
+  is_ca_certificate     = false
+
+  subject {
+    common_name  = "${local.name_prefix}-mtls-leaf"
+    organization = "tf-migrate"
+  }
+
+  allowed_uses = [
+    "digital_signature",
+    "key_encipherment",
+    "server_auth",
+    "client_auth",
+  ]
+}
+
+resource "cloudflare_mtls_certificate" "basic_ca" {
+  account_id   = var.cloudflare_account_id
+  ca           = true
+  certificates = tls_self_signed_cert.ca.cert_pem
+  name         = "${local.name_prefix}-basic-ca"
+}
+
+resource "cloudflare_mtls_certificate" "basic_leaf" {
+  account_id   = var.cloudflare_account_id
+  ca           = false
+  certificates = tls_self_signed_cert.leaf.cert_pem
+  private_key  = tls_private_key.leaf.private_key_pem
+  name         = "${local.name_prefix}-basic-leaf"
+}

--- a/e2e-v5/testdata/notification_policy/notification_policy.tf
+++ b/e2e-v5/testdata/notification_policy/notification_policy.tf
@@ -1,0 +1,148 @@
+# E2E Test: cloudflare_notification_policy
+# Creates webhook integrations and notification policies that can be applied with real infrastructure
+# Note: Email and PagerDuty integrations require external setup and cannot be tested here
+
+# ========================================
+# Variables
+# ========================================
+variable "cloudflare_account_id" {
+  description = "Cloudflare account ID"
+  type        = string
+}
+
+variable "cloudflare_zone_id" {
+  description = "Cloudflare zone ID"
+  type        = string
+}
+
+variable "cloudflare_domain" {
+  description = "Cloudflare domain for testing"
+  type        = string
+}
+
+# ========================================
+# Locals
+# ========================================
+locals {
+  name_prefix = "v5-upgrade-${replace(var.from_version, ".", "-")}"
+}
+
+##########################
+# E2E TEST WEBHOOKS
+##########################
+# Create webhook integrations to use with notification policies
+
+resource "cloudflare_notification_policy_webhooks" "e2e_webhook_1" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-e2e-webhook-1"
+  url        = "https://www.cloudflare.com/cdn-cgi/trace"
+}
+
+resource "cloudflare_notification_policy_webhooks" "e2e_webhook_2" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-e2e-webhook-2"
+  url        = "https://www.cloudflare.com/cdn-cgi/trace"
+}
+
+resource "cloudflare_notification_policy_webhooks" "e2e_webhook_3" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-e2e-webhook-3"
+  url        = "https://www.cloudflare.com/cdn-cgi/trace"
+}
+
+##########################
+# E2E TEST NOTIFICATION POLICIES
+##########################
+
+# Test Case 1: Expiring service token alert (account-level, no filters required)
+resource "cloudflare_notification_policy" "e2e_billing" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-e2e-billing"
+  enabled    = true
+  alert_type = "expiring_service_token_alert"
+
+  mechanisms = {
+    webhooks = [{
+      id = cloudflare_notification_policy_webhooks.e2e_webhook_1.id
+    }]
+  }
+}
+
+# Test Case 2: Expiring service token alert (account-level)
+resource "cloudflare_notification_policy" "e2e_service_token" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-e2e-service-token"
+  enabled    = true
+  alert_type = "expiring_service_token_alert"
+
+  mechanisms = {
+    webhooks = [{
+      id = cloudflare_notification_policy_webhooks.e2e_webhook_1.id
+    }]
+  }
+}
+
+# Test Case 3: Policy with multiple webhooks
+resource "cloudflare_notification_policy" "e2e_multi_webhook" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-e2e-multi-webhook"
+  enabled    = true
+  alert_type = "expiring_service_token_alert"
+
+
+  mechanisms = {
+    webhooks = [{
+      id = cloudflare_notification_policy_webhooks.e2e_webhook_1.id
+      }, {
+      id = cloudflare_notification_policy_webhooks.e2e_webhook_2.id
+    }]
+  }
+}
+
+# Test Case 4: Policy with description
+resource "cloudflare_notification_policy" "e2e_with_description" {
+  account_id  = var.cloudflare_account_id
+  name        = "${local.name_prefix}-e2e-description"
+  description = "E2E test notification policy with description"
+  enabled     = true
+  alert_type  = "expiring_service_token_alert"
+
+  mechanisms = {
+    webhooks = [{
+      id = cloudflare_notification_policy_webhooks.e2e_webhook_2.id
+    }]
+  }
+}
+
+# Test Case 5: Disabled policy (enabled=false - CRITICAL to preserve during migration)
+resource "cloudflare_notification_policy" "e2e_disabled" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-e2e-disabled"
+  enabled    = false
+  alert_type = "expiring_service_token_alert"
+
+  mechanisms = {
+    webhooks = [{
+      id = cloudflare_notification_policy_webhooks.e2e_webhook_3.id
+    }]
+  }
+}
+
+# Test Case 6: Policy with special characters in name
+resource "cloudflare_notification_policy" "e2e_special_chars" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-e2e-policy_with-dashes"
+  enabled    = true
+  alert_type = "expiring_service_token_alert"
+
+  mechanisms = {
+    webhooks = [{
+      id = cloudflare_notification_policy_webhooks.e2e_webhook_1.id
+    }]
+  }
+}
+
+variable "from_version" {
+  description = "Provider version under test, used to namespace resource names"
+  type        = string
+}

--- a/e2e-v5/testdata/notification_policy_webhooks/notification_policy_webhooks.tf
+++ b/e2e-v5/testdata/notification_policy_webhooks/notification_policy_webhooks.tf
@@ -1,0 +1,186 @@
+# ========================================
+# Variables
+# ========================================
+variable "cloudflare_account_id" {
+  description = "Cloudflare account ID"
+  type        = string
+}
+
+variable "cloudflare_zone_id" {
+  description = "Cloudflare zone ID"
+  type        = string
+}
+
+variable "cloudflare_domain" {
+  description = "Cloudflare domain for testing"
+  type        = string
+}
+
+# Use Cloudflare trace endpoint for webhook testing
+# URL: https://www.cloudflare.com/cdn-cgi/trace
+# This endpoint responds with 200 OK to all requests for webhook validation
+
+# ========================================
+# Locals
+# ========================================
+locals {
+  common_account   = var.cloudflare_account_id
+  name_prefix      = "v5-upgrade-${replace(var.from_version, ".", "-")}"
+  webhook_base_url = "https://www.cloudflare.com/cdn-cgi/trace"
+  enable_backup    = true
+  enable_test      = false
+}
+
+# ========================================
+# Basic Resources
+# ========================================
+
+# Test Case 1: Basic webhook with minimal fields
+resource "cloudflare_notification_policy_webhooks" "basic_webhook" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-basic-webhook"
+  url        = "https://www.cloudflare.com/cdn-cgi/trace"
+}
+
+# Test Case 2: Full webhook with all fields
+resource "cloudflare_notification_policy_webhooks" "full_webhook" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-production-webhook"
+  url        = "https://www.cloudflare.com/cdn-cgi/trace"
+  secret     = "webhook-secret-token-12345"
+}
+
+# ========================================
+# for_each with Maps Pattern (3 resources)
+# ========================================
+resource "cloudflare_notification_policy_webhooks" "map_example" {
+  for_each = {
+    "alerts" = {
+      name   = "${local.name_prefix}-alerts-webhook"
+      secret = "alerts-secret-123"
+    }
+    "monitoring" = {
+      name   = "${local.name_prefix}-monitoring-webhook"
+      secret = "monitoring-secret-456"
+    }
+    "security" = {
+      name   = "${local.name_prefix}-security-webhook"
+      secret = "security-secret-789"
+    }
+  }
+
+  account_id = local.common_account
+  name       = each.value.name
+  url        = local.webhook_base_url
+  secret     = each.value.secret
+}
+
+# ========================================
+# for_each with Sets Pattern (4 resources)
+# ========================================
+resource "cloudflare_notification_policy_webhooks" "set_example" {
+  for_each = toset([
+    "alpha",
+    "beta",
+    "gamma",
+    "delta"
+  ])
+
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-set-${each.value}"
+  url        = local.webhook_base_url
+}
+
+# ========================================
+# count-based Resources (3 resources)
+# ========================================
+resource "cloudflare_notification_policy_webhooks" "counted" {
+  count = 3
+
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-webhook-${count.index}"
+  url        = local.webhook_base_url
+}
+
+# ========================================
+# Conditional Creation
+# ========================================
+resource "cloudflare_notification_policy_webhooks" "conditional_enabled" {
+  count = local.enable_backup ? 1 : 0
+
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-conditional-enabled"
+  url        = local.webhook_base_url
+}
+
+resource "cloudflare_notification_policy_webhooks" "conditional_disabled" {
+  count = local.enable_test ? 1 : 0
+
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-conditional-disabled"
+  url        = local.webhook_base_url
+}
+
+# ========================================
+# Terraform Functions
+# ========================================
+resource "cloudflare_notification_policy_webhooks" "with_functions" {
+  account_id = local.common_account
+  name       = join("-", [local.name_prefix, "function", "example"])
+  url        = local.webhook_base_url
+  secret     = "function-test-secret"
+}
+
+# ========================================
+# Lifecycle Meta-Arguments
+# ========================================
+resource "cloudflare_notification_policy_webhooks" "with_lifecycle" {
+  account_id = var.cloudflare_account_id
+  name       = "lifecycle-test"
+  url        = local.webhook_base_url
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "cloudflare_notification_policy_webhooks" "with_prevent_destroy" {
+  account_id = var.cloudflare_account_id
+  name       = "prevent-destroy-test"
+  url        = local.webhook_base_url
+
+  lifecycle {
+    prevent_destroy = false
+  }
+}
+
+# ========================================
+# Edge Cases
+# ========================================
+
+# Minimal resource (only required fields)
+resource "cloudflare_notification_policy_webhooks" "minimal" {
+  account_id = var.cloudflare_account_id
+  name       = "minimal"
+  url        = local.webhook_base_url
+}
+
+# Maximal resource (all fields populated)
+resource "cloudflare_notification_policy_webhooks" "maximal" {
+  account_id = var.cloudflare_account_id
+  name       = "maximal-webhook-with-all-fields"
+  url        = local.webhook_base_url
+  secret     = "maximal-secret-token-with-special-chars-!@#$"
+}
+
+# URL with special characters
+resource "cloudflare_notification_policy_webhooks" "special_chars" {
+  account_id = var.cloudflare_account_id
+  name       = "special-chars-test"
+  url        = local.webhook_base_url
+}
+
+variable "from_version" {
+  description = "Provider version under test, used to namespace resource names"
+  type        = string
+}

--- a/e2e-v5/testdata/observatory_scheduled_test/observatory_scheduled_test.tf
+++ b/e2e-v5/testdata/observatory_scheduled_test/observatory_scheduled_test.tf
@@ -1,0 +1,37 @@
+variable "cloudflare_account_id" {
+  description = "Cloudflare account ID"
+  type        = string
+}
+
+variable "cloudflare_zone_id" {
+  description = "Cloudflare zone ID"
+  type        = string
+}
+
+variable "cloudflare_domain" {
+  description = "Cloudflare domain for testing"
+  type        = string
+}
+
+locals {
+  normalized_observatory_domain = format(
+    "%s/",
+    trimsuffix(
+      trimprefix(
+        trimprefix(trimspace(var.cloudflare_domain), "https://"),
+        "http://",
+      ),
+      "/",
+    ),
+  )
+}
+
+resource "cloudflare_observatory_scheduled_test" "test_e2e" {
+  zone_id = var.cloudflare_zone_id
+  url     = local.normalized_observatory_domain
+}
+
+variable "from_version" {
+  description = "Provider version under test, used to namespace resource names"
+  type        = string
+}

--- a/e2e-v5/testdata/origin_ca_certificate/origin_ca_certificate.tf
+++ b/e2e-v5/testdata/origin_ca_certificate/origin_ca_certificate.tf
@@ -1,0 +1,358 @@
+# Comprehensive Integration Test for origin_ca_certificate v4 → v5 Migration
+# This file tests all attributes, transformations, and Terraform patterns
+
+# ========================================
+# Variables
+# ========================================
+variable "cloudflare_account_id" {
+  description = "Cloudflare account ID"
+  type        = string
+}
+
+variable "cloudflare_zone_id" {
+  description = "Cloudflare zone ID"
+  type        = string
+}
+
+variable "cloudflare_domain" {
+  description = "Cloudflare domain for testing"
+  type        = string
+}
+
+# Variables for testing variable references
+variable "test_prefix" {
+  default = "v5-upgrade"
+}
+
+variable "validity_days" {
+  default = 365
+}
+
+# Locals for testing local references
+locals {
+  name_prefix = "v5-upgrade-${replace(var.from_version, ".", "-")}"
+  test_domain     = "${local.name_prefix}-example.${var.cloudflare_domain}"
+  wildcard_domain = "*.${local.name_prefix}-example.${var.cloudflare_domain}"
+  ecc_type        = "origin-ecc"
+  default_csr     = <<EOT
+-----BEGIN CERTIFICATE REQUEST-----
+MIICuDCCAaACAQAwczELMAkGA1UEBhMCVVMxEzARBgNVBAgMCkNhbGlmb3JuaWEx
+FjAUBgNVBAcMDVNhbiBGcmFuY2lzY28xGDAWBgNVBAoMD0V4YW1wbGUgQ29tcGFu
+eTEdMBsGA1UEAwwUY2Z0ZnRlc3QtZXhhbXBsZS5jb20wggEiMA0GCSqGSIb3DQEB
+AQUAA4IBDwAwggEKAoIBAQC5l3PKiysEmgXNLDtZUtNJCiiCmihql7JHefBltZ+H
+7RmIJ5NKWpq+xkZrHmmZ+j7kfAmHPb6+eFNks70XfdjAZZoc86aFCNT6U4OUBY/1
+75HkXU6NYfZfuFvK8OvtoiJB6sOs9Mz31XHGIpT2AY7XvsmOHWUGIc84bhYNF5mG
+VwJpCPfMJqczcoJGZn1mHdPMHQdygAMVql/Hpy9DiMPIMVYk/o+jMj5QV7nOxNW/
+NpKp1ncLReXpSDURBX2Wx+SVpVRbovrsbEL0Mm2xSeBsavTmPo0XZrCLnQ3xGWmo
+5so6CLCqbv+PNyGirDgQN3qHHSAf9vZtW9xTK0kRLOGDAgMBAAGgADANBgkqhkiG
+9w0BAQsFAAOCAQEAGoFZnK8h72y37n7xu5PVbAeLRKBTr4Txtu6ewFJbfCVZ8ZLu
+RvHwomcBtvNXd9seTwY00mW9Gko9R6glASsJPvJCqQvMYLWd4hQaMffZOXH5Z2Hg
+CCNKreZX8KwX7/TzNtbBnnq359T+DzYDyvPfrkz1Cx+GRoNPHqIpOX50Mw7Gmxdr
+J7urFodSDFCKS9WMKe3CBfkO1Gn0w3HBxoz9Ts8ctdA9bAof4/YQH7lLw7pL9uqn
+TcBVKhDK/f+AO8xZkTV9/jJ7YvMJ9PxDAZlLtnMWZmVd/VcLQx8vtBzA7JWL+Mba
+t/PQliLH+Ty70y/Y6+lz/E94rdN8zujVfUMuxg==
+-----END CERTIFICATE REQUEST-----
+EOT
+}
+
+# =============================================================================
+# 1. BASIC RESOURCES - Simple configurations
+# =============================================================================
+
+# Test 1: Minimal configuration (only required fields)
+resource "cloudflare_origin_ca_certificate" "minimal" {
+  csr          = local.default_csr
+  request_type = "origin-rsa"
+  hostnames    = ["${local.name_prefix}-minimal.${var.cloudflare_domain}"]
+}
+
+# Test 2: Basic configuration with requested_validity
+resource "cloudflare_origin_ca_certificate" "basic" {
+  csr                = local.default_csr
+  request_type       = "origin-rsa"
+  hostnames          = ["${local.name_prefix}-basic.${var.cloudflare_domain}"]
+  requested_validity = 365
+}
+
+# Test 3: Configuration with min_days_for_renewal
+resource "cloudflare_origin_ca_certificate" "with_renewal" {
+  csr                = local.default_csr
+  request_type       = "origin-rsa"
+  hostnames          = ["${local.name_prefix}-renewal.${var.cloudflare_domain}"]
+  requested_validity = 730
+}
+
+# =============================================================================
+# 2. REQUEST TYPES - Test all valid request types
+# =============================================================================
+
+resource "cloudflare_origin_ca_certificate" "type_rsa" {
+  csr                = local.default_csr
+  request_type       = "origin-rsa"
+  hostnames          = ["${local.name_prefix}-rsa.${var.cloudflare_domain}"]
+  requested_validity = 365
+}
+
+resource "cloudflare_origin_ca_certificate" "type_ecc" {
+  csr                = local.default_csr
+  request_type       = local.ecc_type
+  hostnames          = ["${local.name_prefix}-ecc.${var.cloudflare_domain}"]
+  requested_validity = 365
+}
+
+# =============================================================================
+# 3. REQUESTED VALIDITY - Test all valid values (7, 30, 90, 365, 730, 1095, 5475)
+# =============================================================================
+
+resource "cloudflare_origin_ca_certificate" "validity_7days" {
+  csr                = local.default_csr
+  request_type       = "origin-rsa"
+  hostnames          = ["${local.name_prefix}-7day.${var.cloudflare_domain}"]
+  requested_validity = 7
+}
+
+resource "cloudflare_origin_ca_certificate" "validity_30days" {
+  csr                = local.default_csr
+  request_type       = "origin-rsa"
+  hostnames          = ["${local.name_prefix}-30day.${var.cloudflare_domain}"]
+  requested_validity = 30
+}
+
+resource "cloudflare_origin_ca_certificate" "validity_90days" {
+  csr                = local.default_csr
+  request_type       = "origin-rsa"
+  hostnames          = ["${local.name_prefix}-90day.${var.cloudflare_domain}"]
+  requested_validity = 90
+}
+
+resource "cloudflare_origin_ca_certificate" "validity_365days" {
+  csr                = local.default_csr
+  request_type       = "origin-rsa"
+  hostnames          = ["${local.name_prefix}-1year.${var.cloudflare_domain}"]
+  requested_validity = var.validity_days
+}
+
+resource "cloudflare_origin_ca_certificate" "validity_730days" {
+  csr                = local.default_csr
+  request_type       = "origin-rsa"
+  hostnames          = ["${local.name_prefix}-2year.${var.cloudflare_domain}"]
+  requested_validity = 730
+}
+
+resource "cloudflare_origin_ca_certificate" "validity_1095days" {
+  csr                = local.default_csr
+  request_type       = "origin-rsa"
+  hostnames          = ["${local.name_prefix}-3year.${var.cloudflare_domain}"]
+  requested_validity = 1095
+}
+
+resource "cloudflare_origin_ca_certificate" "validity_5475days" {
+  csr                = local.default_csr
+  request_type       = "origin-rsa"
+  hostnames          = ["${local.name_prefix}-15year.${var.cloudflare_domain}"]
+  requested_validity = 5475
+}
+
+# Test default validity (omit requested_validity, should default to 5475 in v5)
+resource "cloudflare_origin_ca_certificate" "validity_default" {
+  csr          = local.default_csr
+  request_type = "origin-rsa"
+  hostnames    = ["${local.name_prefix}-default-validity.${var.cloudflare_domain}"]
+}
+
+# =============================================================================
+# 4. HOSTNAME VARIATIONS - Single, multiple, wildcards
+# =============================================================================
+
+resource "cloudflare_origin_ca_certificate" "single_hostname" {
+  csr                = local.default_csr
+  request_type       = "origin-rsa"
+  hostnames          = ["${var.test_prefix}-single.${var.cloudflare_domain}"]
+  requested_validity = 365
+}
+
+resource "cloudflare_origin_ca_certificate" "multiple_hostnames" {
+  csr          = local.default_csr
+  request_type = "origin-rsa"
+  hostnames = [
+    "${local.name_prefix}-multi1.${var.cloudflare_domain}",
+    "${local.name_prefix}-multi2.${var.cloudflare_domain}",
+    "${local.name_prefix}-multi3.${var.cloudflare_domain}",
+  ]
+  requested_validity = 365
+}
+
+resource "cloudflare_origin_ca_certificate" "wildcard_hostname" {
+  csr                = local.default_csr
+  request_type       = "origin-rsa"
+  hostnames          = [local.wildcard_domain]
+  requested_validity = 365
+}
+
+resource "cloudflare_origin_ca_certificate" "mixed_hostnames" {
+  csr          = local.default_csr
+  request_type = "origin-rsa"
+  hostnames = [
+    local.wildcard_domain,
+    local.test_domain,
+    "${local.name_prefix}-subdomain.${var.cloudflare_domain}",
+  ]
+  requested_validity = 730
+}
+
+# =============================================================================
+# 5. FOR_EACH PATTERNS - Dynamic resources from map
+# =============================================================================
+
+locals {
+  certificates_map = {
+    api = {
+      hostname = "${local.name_prefix}-api.${var.cloudflare_domain}"
+      validity = 365
+    }
+    web = {
+      hostname = "${local.name_prefix}-web.${var.cloudflare_domain}"
+      validity = 730
+    }
+    admin = {
+      hostname = "${local.name_prefix}-admin.${var.cloudflare_domain}"
+      validity = 90
+    }
+  }
+}
+
+resource "cloudflare_origin_ca_certificate" "foreach_map" {
+  for_each = local.certificates_map
+
+  csr                = local.default_csr
+  request_type       = "origin-rsa"
+  hostnames          = [each.value.hostname]
+  requested_validity = each.value.validity
+}
+
+# =============================================================================
+# 6. FOR_EACH WITH SET - Dynamic resources from set
+# =============================================================================
+
+locals {
+  service_names = toset(["${local.name_prefix}-service1", "${local.name_prefix}-service2", "${local.name_prefix}-service3"])
+}
+
+resource "cloudflare_origin_ca_certificate" "foreach_set" {
+  for_each = local.service_names
+
+  csr                = local.default_csr
+  request_type       = "origin-ecc"
+  hostnames          = ["${each.key}.${var.cloudflare_domain}"]
+  requested_validity = 365
+}
+
+# =============================================================================
+# 7. COUNT PATTERN - Multiple instances with count
+# =============================================================================
+
+resource "cloudflare_origin_ca_certificate" "count_pattern" {
+  count = 3
+
+  csr                = local.default_csr
+  request_type       = "origin-rsa"
+  hostnames          = ["${local.name_prefix}-count-${count.index}.${var.cloudflare_domain}"]
+  requested_validity = 365
+}
+
+# =============================================================================
+# 8. CONDITIONAL RESOURCES - count with condition
+# =============================================================================
+
+variable "create_staging_cert" {
+  default = true
+}
+
+resource "cloudflare_origin_ca_certificate" "conditional" {
+  count = var.create_staging_cert ? 1 : 0
+
+  csr                = local.default_csr
+  request_type       = "origin-rsa"
+  hostnames          = ["${local.name_prefix}-staging.${var.cloudflare_domain}"]
+  requested_validity = 90
+}
+
+# =============================================================================
+# 9. LIFECYCLE META-ARGUMENTS - Testing ignore_changes, etc.
+# =============================================================================
+
+resource "cloudflare_origin_ca_certificate" "with_lifecycle" {
+  csr                = local.default_csr
+  request_type       = "origin-rsa"
+  hostnames          = ["${local.name_prefix}-lifecycle.${var.cloudflare_domain}"]
+  requested_validity = 365
+
+  lifecycle {
+    ignore_changes = [requested_validity]
+  }
+}
+
+# =============================================================================
+# 10. TERRAFORM FUNCTIONS - format(), etc.
+# =============================================================================
+
+resource "cloudflare_origin_ca_certificate" "with_functions" {
+  csr          = local.default_csr
+  request_type = "origin-rsa"
+  hostnames = [
+    "${local.name_prefix}-app.${var.cloudflare_domain}",
+    format("%s-backup.${var.cloudflare_domain}", var.test_prefix),
+  ]
+  requested_validity = 365
+}
+
+# =============================================================================
+# 11. EDGE CASES
+# =============================================================================
+
+# Maximal configuration (all possible fields)
+resource "cloudflare_origin_ca_certificate" "maximal" {
+  csr                = <<EOT
+-----BEGIN CERTIFICATE REQUEST-----
+MIICuDCCAaACAQAwczELMAkGA1UEBhMCVVMxEzARBgNVBAgMCkNhbGlmb3JuaWEx
+FjAUBgNVBAcMDVNhbiBGcmFuY2lzY28xGDAWBgNVBAoMD0V4YW1wbGUgQ29tcGFu
+eTEdMBsGA1UEAwwUY2Z0ZnRlc3QtbWF4aW1hbC5jb20wggEiMA0GCSqGSIb3DQEB
+AQUAA4IBDwAwggEKAoIBAQDG0vu0QgKEq5YoZLPikBmxWjR5k5WGKQYKcScHR80Y
+y4HDKGMuMTdm6VedQWY96GQ8v+Hj2qMVj5FSfV2HZs9JZQm/ICkKpUfBEvT/wh+V
+P9FgLgJFpIN/m6pU6m0swY9LPi7vNkB01THu7Sya9GCO8CoQItabD9RejDfVz9ox
+LLND24LM/dRwVCYH4TRQLAOC13bol1xWwUp85n/6tLFa7169z6FD7zjjzhKbFC5H
+sYr2V6PmrWSMxBqR7Yf/hCTQ20qqtjhYthwr+soN+POpHuxT1A31rjXSxbTQS0hO
+CSD6ZfTKAD2mauKLyi01tiBhdPs42OM5MxWXd3CiCe3NAgMBAAGgADANBgkqhkiG
+9w0BAQsFAAOCAQEAv3w7o4B5xpEmEbVJel29U4P1XHEbWy52DqdlXWXPB3QCPtMH
+ohqJvwG2VeuxjTT3CXKuW0rFPuaD7ko8hpnUPgWyaHhUXqSraEshzlC2mJLgNoIH
+Tq9rjcy1alsyXKQ7gM8MCF00myPFOhBiNFpI4UQ4v5oixg5NuNhbeZJF2NOBqVV0
+pbd0T1jTBsLasPBDC80Pw/KCtGRHsyS7nYIo372Wghmp20x1N8YQ/x74ntpfl6Mw
+BFFiw6UIGjlCdQr1SHfy9PElWi8AEo0ICyYM8ay+5zc1+nDjzibXxjjocG0smolR
+HQbz7GoyzUHbssJAq1unWphMHf5RQo9SFu/EMA==
+-----END CERTIFICATE REQUEST-----
+EOT
+  request_type       = "origin-rsa"
+  hostnames          = ["*.${local.name_prefix}-maximal.${var.cloudflare_domain}", "${local.name_prefix}-maximal.${var.cloudflare_domain}"]
+  requested_validity = 5475
+}
+
+# =============================================================================
+# Summary: Total Resources
+# - Basic: 3
+# - Request types: 2
+# - Validity values: 8
+# - Hostname variations: 4
+# - for_each map: 3
+# - for_each set: 3
+# - count: 3
+# - conditional: 1
+# - lifecycle: 1
+# - functions: 1
+# - maximal: 1
+# TOTAL: 30 resource instances
+# =============================================================================
+
+variable "from_version" {
+  description = "Provider version under test, used to namespace resource names"
+  type        = string
+}

--- a/e2e-v5/testdata/page_rule/page_rule.tf
+++ b/e2e-v5/testdata/page_rule/page_rule.tf
@@ -1,0 +1,104 @@
+# ========================================
+# Variables
+# ========================================
+variable "cloudflare_account_id" {
+  description = "Cloudflare account ID"
+  type        = string
+}
+
+variable "cloudflare_zone_id" {
+  description = "Cloudflare zone ID"
+  type        = string
+}
+
+variable "cloudflare_domain" {
+  description = "Cloudflare domain for testing"
+  type        = string
+}
+
+locals {
+  name_prefix = "v5-upgrade-${replace(var.from_version, ".", "-")}"
+}
+
+resource "cloudflare_page_rule" "minimal" {
+  zone_id  = var.cloudflare_zone_id
+  target   = "${local.name_prefix}.${var.cloudflare_domain}/minimal"
+  priority = 1
+  status   = "active"
+
+  actions = {
+    cache_level = "bypass"
+  }
+}
+
+resource "cloudflare_page_rule" "with_cache_ttl" {
+  zone_id  = var.cloudflare_zone_id
+  target   = "${local.name_prefix}.${var.cloudflare_domain}/cached/*"
+  priority = 2
+
+  status = "active"
+  actions = {
+    cache_level = "cache_everything"
+    cache_ttl_by_status = {
+      "200" = "3600"
+      "404" = "300"
+    }
+  }
+}
+
+resource "cloudflare_page_rule" "with_forwarding" {
+  zone_id  = var.cloudflare_zone_id
+  target   = "${local.name_prefix}.${var.cloudflare_domain}/old/*"
+  priority = 3
+
+  status = "active"
+  actions = {
+    forwarding_url = {
+      url         = "https://${local.name_prefix}.${var.cloudflare_domain}/new/$1"
+      status_code = 301
+    }
+  }
+}
+
+resource "cloudflare_page_rule" "with_cache_key_fields" {
+  zone_id  = var.cloudflare_zone_id
+  target   = "${local.name_prefix}.${var.cloudflare_domain}/api/*"
+  priority = 4
+
+  status = "active"
+  actions = {
+    cache_level = "cache_everything"
+    cache_key_fields = {
+      cookie = {
+        check_presence = ["sessionid"]
+      }
+      host = {
+        resolved = true
+      }
+      query_string = {
+        exclude = ["utm_*"]
+      }
+      user = {
+        device_type = true
+        geo         = false
+        lang        = false
+      }
+    }
+  }
+}
+
+resource "cloudflare_page_rule" "with_deprecated_fields" {
+  zone_id  = var.cloudflare_zone_id
+  target   = "${local.name_prefix}.${var.cloudflare_domain}/legacy/*"
+  priority = 5
+
+  status = "active"
+  actions = {
+    cache_level = "bypass"
+  }
+}
+
+variable "from_version" {
+  description = "Provider version under test, used to namespace resource names"
+  type        = string
+}

--- a/e2e-v5/testdata/pages_domain/pages_domain.tf
+++ b/e2e-v5/testdata/pages_domain/pages_domain.tf
@@ -1,0 +1,60 @@
+variable "cloudflare_account_id" {
+  description = "Cloudflare account ID"
+  type        = string
+}
+
+variable "cloudflare_zone_id" {
+  description = "Cloudflare zone ID"
+  type        = string
+}
+
+variable "cloudflare_domain" {
+  description = "Cloudflare domain for testing"
+  type        = string
+}
+
+variable "from_version" {
+  description = "Provider version under test, used to namespace resource names"
+  type        = string
+}
+
+locals {
+  name_prefix = "v5-upgrade-${replace(var.from_version, ".", "-")}"
+}
+
+resource "cloudflare_pages_project" "domain_project" {
+  account_id        = var.cloudflare_account_id
+  name              = "${local.name_prefix}-pages-domain-project"
+  production_branch = "main"
+  deployment_configs = {
+    preview = {
+      fail_open = false
+    }
+    production = {
+      fail_open = false
+    }
+  }
+}
+
+# Primary domain mapping
+resource "cloudflare_pages_domain" "primary" {
+  account_id   = var.cloudflare_account_id
+  project_name = cloudflare_pages_project.domain_project.name
+  name         = "${local.name_prefix}-primary.${var.cloudflare_domain}"
+}
+
+# Additional environment domains using for_each to retain reference-pattern coverage
+locals {
+  environment_domains = {
+    staging = "${local.name_prefix}-staging.${var.cloudflare_domain}"
+    preview = "${local.name_prefix}-preview.${var.cloudflare_domain}"
+  }
+}
+
+resource "cloudflare_pages_domain" "environments" {
+  for_each = local.environment_domains
+
+  account_id   = var.cloudflare_account_id
+  project_name = cloudflare_pages_project.domain_project.name
+  name         = each.value
+}

--- a/e2e-v5/testdata/pages_project/pages_project.tf
+++ b/e2e-v5/testdata/pages_project/pages_project.tf
@@ -1,0 +1,70 @@
+locals {
+  name_prefix = "v5-upgrade-${replace(var.from_version, ".", "-")}"
+}
+
+variable "cloudflare_account_id" {
+  description = "Cloudflare account ID"
+  type        = string
+}
+
+variable "cloudflare_zone_id" {
+  description = "Cloudflare zone ID"
+  type        = string
+}
+
+variable "cloudflare_domain" {
+  description = "Cloudflare domain for testing"
+  type        = string
+}
+
+variable "from_version" {
+  description = "Provider version under test, used to namespace resource names"
+  type        = string
+}
+
+# Minimal baseline project
+resource "cloudflare_pages_project" "minimal" {
+  account_id        = var.cloudflare_account_id
+  name              = "${local.name_prefix}-pages-project-minimal"
+  production_branch = "main"
+  deployment_configs = {
+    preview = {
+      fail_open = false
+    }
+    production = {
+      fail_open = false
+    }
+  }
+}
+
+# Feature-rich project covering build + deployment settings
+resource "cloudflare_pages_project" "feature_rich" {
+  account_id        = var.cloudflare_account_id
+  name              = "${local.name_prefix}-pages-project-feature"
+  production_branch = "main"
+
+  build_config = {
+    build_command   = "npm run build"
+    destination_dir = "dist"
+    root_dir        = "/app"
+  }
+
+  deployment_configs = {
+    preview = {
+      compatibility_date = "2024-01-01"
+      usage_model        = "bundled"
+      fail_open          = false
+      placement = {
+        mode = "smart"
+      }
+    }
+    production = {
+      compatibility_date = "2024-01-01"
+      usage_model        = "bundled"
+      fail_open          = false
+      placement = {
+        mode = "smart"
+      }
+    }
+  }
+}

--- a/e2e-v5/testdata/queue/queue.tf
+++ b/e2e-v5/testdata/queue/queue.tf
@@ -1,0 +1,214 @@
+# Integration test for cloudflare_queue migration (v4 → v5)
+# This test covers all Terraform patterns and queue field transformations
+
+# Standard variables provided by test infrastructure
+variable "cloudflare_account_id" {
+  description = "Cloudflare account ID"
+  type        = string
+}
+
+variable "cloudflare_zone_id" {
+  description = "Cloudflare zone ID"
+  type        = string
+}
+
+variable "cloudflare_domain" {
+  description = "Cloudflare domain for testing"
+  type        = string
+}
+
+# Locals for DRY configuration
+locals {
+  common_account = var.cloudflare_account_id
+  name_prefix    = "v5-upgrade-${replace(var.from_version, ".", "-")}"
+  environment    = "test"
+  queue_names = [
+    "queue-alpha",
+    "queue-beta",
+    "queue-gamma"
+  ]
+}
+
+# ============================================================================
+# Pattern 1-2: Basic Resources with Variables and Locals
+# ============================================================================
+
+# Minimal queue with required fields only
+resource "cloudflare_queue" "minimal" {
+  account_id = var.cloudflare_account_id
+  queue_name = "${local.name_prefix}-minimal-queue"
+}
+
+# Queue using locals
+resource "cloudflare_queue" "with_locals" {
+  account_id = local.common_account
+  queue_name = "${local.name_prefix}-locals-queue"
+}
+
+# Queue with string interpolation
+resource "cloudflare_queue" "with_interpolation" {
+  account_id = var.cloudflare_account_id
+  queue_name = "${local.name_prefix}-${local.environment}-queue"
+}
+
+# Queue with numbers and hyphens in name
+resource "cloudflare_queue" "special_chars" {
+  account_id = var.cloudflare_account_id
+  queue_name = "${local.name_prefix}-special-chars-queue-123"
+}
+
+# ============================================================================
+# Pattern 3: for_each with Maps
+# ============================================================================
+
+# Create multiple queues using for_each with a map
+resource "cloudflare_queue" "map_based" {
+  for_each = {
+    "events"   = "events-processing"
+    "jobs"     = "background-jobs"
+    "messages" = "user-messages"
+    "webhooks" = "webhook-delivery"
+  }
+
+  account_id = var.cloudflare_account_id
+  queue_name = "${local.name_prefix}-${each.value}-queue"
+}
+
+# ============================================================================
+# Pattern 4: for_each with Sets (using toset())
+# ============================================================================
+
+# Create queues from a set of names
+resource "cloudflare_queue" "set_based" {
+  for_each = toset(local.queue_names)
+
+  account_id = var.cloudflare_account_id
+  queue_name = "${local.name_prefix}-${each.value}"
+}
+
+# ============================================================================
+# Pattern 5: Count-based Resources
+# ============================================================================
+
+# Create numbered queues using count
+resource "cloudflare_queue" "count_based" {
+  count = 5
+
+  account_id = var.cloudflare_account_id
+  queue_name = "${local.name_prefix}-numbered-queue-${count.index + 1}"
+}
+
+# ============================================================================
+# Pattern 6: Conditional Resource Creation
+# ============================================================================
+
+locals {
+  enable_priority_queue   = true
+  enable_deadletter_queue = false
+}
+
+# Queue created conditionally
+resource "cloudflare_queue" "priority" {
+  count = local.enable_priority_queue ? 1 : 0
+
+  account_id = var.cloudflare_account_id
+  queue_name = "${local.name_prefix}-priority-queue"
+}
+
+# Queue NOT created (condition false)
+resource "cloudflare_queue" "deadletter" {
+  count = local.enable_deadletter_queue ? 1 : 0
+
+  account_id = var.cloudflare_account_id
+  queue_name = "${local.name_prefix}-deadletter-queue"
+}
+
+# ============================================================================
+# Pattern 7: Cross-resource References
+# ============================================================================
+
+# Queue that could be referenced by other resources
+resource "cloudflare_queue" "main" {
+  account_id = var.cloudflare_account_id
+  queue_name = "${local.name_prefix}-main-processing-queue"
+}
+
+# Another queue that could reference the first (simulated dependency)
+resource "cloudflare_queue" "dependent" {
+  account_id = cloudflare_queue.main.account_id
+  queue_name = "${local.name_prefix}-dependent-queue"
+}
+
+# ============================================================================
+# Pattern 8: Lifecycle Meta-arguments
+# ============================================================================
+
+# Queue with lifecycle configuration
+resource "cloudflare_queue" "with_lifecycle" {
+  account_id = var.cloudflare_account_id
+
+  lifecycle {
+    create_before_destroy = true
+    prevent_destroy       = false
+  }
+  queue_name = "${local.name_prefix}-lifecycle-queue"
+}
+
+# Queue with ignore_changes
+resource "cloudflare_queue" "ignore_changes" {
+  account_id = var.cloudflare_account_id
+
+  lifecycle {
+    ignore_changes = [queue_name]
+  }
+  queue_name = "${local.name_prefix}-ignore-changes-queue"
+}
+
+# ============================================================================
+# Pattern 9: Terraform Functions
+# ============================================================================
+
+# Queue using join() function
+resource "cloudflare_queue" "with_join" {
+  account_id = var.cloudflare_account_id
+  queue_name = join("-", [local.name_prefix, "joined", "queue"])
+}
+
+# Queue using lower() function
+resource "cloudflare_queue" "with_lower" {
+  account_id = var.cloudflare_account_id
+  queue_name = lower("${local.name_prefix}-LOWERCASE-QUEUE")
+}
+
+# Queue using format() function
+resource "cloudflare_queue" "with_format" {
+  account_id = var.cloudflare_account_id
+  queue_name = format("%s-formatted-queue-%02d", local.name_prefix, 42)
+}
+
+# ============================================================================
+# Additional Edge Cases
+# ============================================================================
+
+# Queue with longer name (within 63 char limit)
+resource "cloudflare_queue" "long_name" {
+  account_id = var.cloudflare_account_id
+  queue_name = "${local.name_prefix}-long-name-queue-test-example"
+}
+
+# Queue with numbers in name
+resource "cloudflare_queue" "with_numbers" {
+  account_id = var.cloudflare_account_id
+  queue_name = "${local.name_prefix}-queue-123-456-789"
+}
+
+# Queue with multiple hyphens
+resource "cloudflare_queue" "mixed_separators" {
+  account_id = var.cloudflare_account_id
+  queue_name = "${local.name_prefix}-queue-with-multiple-hyphens"
+}
+
+variable "from_version" {
+  description = "Provider version under test, used to namespace resource names"
+  type        = string
+}

--- a/e2e-v5/testdata/r2_bucket/r2_bucket.tf
+++ b/e2e-v5/testdata/r2_bucket/r2_bucket.tf
@@ -1,0 +1,223 @@
+# ============================================================================
+# Standard Variables (Auto-provided by test infrastructure)
+# ============================================================================
+variable "cloudflare_account_id" {
+  description = "Cloudflare account ID"
+  type        = string
+}
+
+variable "cloudflare_zone_id" {
+  description = "Cloudflare zone ID"
+  type        = string
+}
+
+variable "cloudflare_domain" {
+  description = "Cloudflare domain for testing"
+  type        = string
+}
+
+# ============================================================================
+# Pattern Group 1: Locals for Common Values
+# ============================================================================
+locals {
+  common_account = var.cloudflare_account_id
+  name_prefix    = "v5-upgrade-${replace(var.from_version, ".", "-")}"
+  locations = {
+    "wnam" = "WNAM"
+    "enam" = "ENAM"
+    "weur" = "WEUR"
+    "eeur" = "EEUR"
+    "apac" = "APAC"
+    "oc"   = "OC"
+  }
+  enable_feature = true
+  enable_test    = false
+}
+
+# ============================================================================
+# Pattern Group 2: Basic Resource Configurations
+# ============================================================================
+
+# Test Case 1: Minimal bucket with only required fields
+resource "cloudflare_r2_bucket" "minimal" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-minimal-bucket"
+}
+
+# Test Case 2: Bucket with all locations tested
+resource "cloudflare_r2_bucket" "location_wnam" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-bucket-wnam"
+  location   = "WNAM"
+}
+
+resource "cloudflare_r2_bucket" "location_enam" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-bucket-enam"
+  location   = "ENAM"
+}
+
+resource "cloudflare_r2_bucket" "location_weur" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-bucket-weur"
+  location   = "WEUR"
+}
+
+resource "cloudflare_r2_bucket" "location_eeur" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-bucket-eeur"
+  location   = "EEUR"
+}
+
+resource "cloudflare_r2_bucket" "location_apac" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-bucket-apac"
+  location   = "APAC"
+}
+
+resource "cloudflare_r2_bucket" "location_oc" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-bucket-oc"
+  location   = "OC"
+}
+
+# ============================================================================
+# Pattern Group 3: for_each with Maps
+# ============================================================================
+
+resource "cloudflare_r2_bucket" "map_example" {
+  for_each = {
+    "data" = {
+      name     = "${local.name_prefix}-data-bucket"
+      location = "WNAM"
+    }
+    "logs" = {
+      name     = "${local.name_prefix}-logs-bucket"
+      location = "ENAM"
+    }
+    "backups" = {
+      name     = "${local.name_prefix}-backups-bucket"
+      location = "WEUR"
+    }
+  }
+
+  account_id = var.cloudflare_account_id
+  name       = each.value.name
+  location   = each.value.location
+}
+
+# ============================================================================
+# Pattern Group 4: for_each with Sets
+# ============================================================================
+
+resource "cloudflare_r2_bucket" "set_example" {
+  for_each = toset([
+    "alpha",
+    "beta",
+    "gamma",
+    "delta",
+  ])
+
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-set-${each.value}-bucket"
+}
+
+# ============================================================================
+# Pattern Group 5: count-based Resources
+# ============================================================================
+
+resource "cloudflare_r2_bucket" "counted" {
+  count = 3
+
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-counted-bucket-${count.index}"
+  location   = count.index == 0 ? "WNAM" : count.index == 1 ? "EEUR" : "APAC"
+}
+
+# ============================================================================
+# Pattern Group 6: Conditional Creation
+# ============================================================================
+
+resource "cloudflare_r2_bucket" "conditional_enabled" {
+  count = local.enable_feature ? 1 : 0
+
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-conditional-enabled-bucket"
+  location   = "WNAM"
+}
+
+resource "cloudflare_r2_bucket" "conditional_disabled" {
+  count = local.enable_test ? 1 : 0
+
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-conditional-disabled-bucket"
+  location   = "EEUR"
+}
+
+# ============================================================================
+# Pattern Group 7: Terraform Functions
+# ============================================================================
+
+resource "cloudflare_r2_bucket" "with_functions" {
+  account_id = var.cloudflare_account_id
+  name       = join("-", [local.name_prefix, "function", "test"])
+  location   = lookup(local.locations, "wnam", "WNAM")
+}
+
+resource "cloudflare_r2_bucket" "with_interpolation" {
+  account_id = local.common_account
+  name       = "${local.name_prefix}-interpolated-bucket"
+  location   = local.locations["eeur"]
+}
+
+# ============================================================================
+# Pattern Group 8: Lifecycle Meta-Arguments
+# ============================================================================
+
+resource "cloudflare_r2_bucket" "with_lifecycle" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-lifecycle-test-bucket"
+  location   = "WNAM"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "cloudflare_r2_bucket" "with_prevent_destroy" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-prevent-destroy-bucket"
+  location   = "EEUR"
+
+  lifecycle {
+    prevent_destroy = false
+  }
+}
+
+# ============================================================================
+# Pattern Group 9: Edge Cases
+# ============================================================================
+
+# Special characters in bucket names (hyphens and numbers)
+resource "cloudflare_r2_bucket" "special_chars" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-bucket-with-dashes-and-numbers-123"
+}
+
+# Long bucket name (testing near max length - 63 chars max)
+resource "cloudflare_r2_bucket" "long_name" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-long-bucket-name-test"
+}
+
+# Bucket name with all allowed characters (lowercase, numbers, hyphens)
+resource "cloudflare_r2_bucket" "all_chars" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-bucket-name-with-all-valid-chars-123-test"
+  location   = "WNAM"
+}
+
+variable "from_version" {
+  description = "Provider version under test, used to namespace resource names"
+  type        = string
+}

--- a/e2e-v5/testdata/regional_hostname/regional_hostname.tf
+++ b/e2e-v5/testdata/regional_hostname/regional_hostname.tf
@@ -1,0 +1,110 @@
+variable "cloudflare_account_id" {
+  description = "Cloudflare account ID"
+  type        = string
+}
+
+variable "cloudflare_zone_id" {
+  description = "Cloudflare zone ID"
+  type        = string
+}
+
+variable "cloudflare_domain" {
+  description = "Cloudflare domain for testing"
+  type        = string
+}
+
+data "cloudflare_zone" "this" {
+  zone_id = var.cloudflare_zone_id
+}
+
+locals {
+  name_prefix = "v5-upgrade-${replace(var.from_version, ".", "-")}"
+  domain = data.cloudflare_zone.this.name
+}
+
+
+
+
+
+# Regional hostname with no timeouts
+resource "cloudflare_regional_hostname" "minimal" {
+  zone_id    = var.cloudflare_zone_id
+  hostname   = "${local.name_prefix}-rh-minimal.${local.domain}"
+  region_key = "us"
+
+  depends_on = [cloudflare_dns_record.rh_minimal]
+}
+
+# Regional hostname with timeouts (timeouts should be removed in v5)
+resource "cloudflare_regional_hostname" "with_timeouts" {
+  zone_id    = var.cloudflare_zone_id
+  hostname   = "${local.name_prefix}-rh-timeouts.${local.domain}"
+  region_key = "eu"
+
+
+  depends_on = [cloudflare_dns_record.rh_timeouts]
+}
+
+# Regional hostname with only create timeout
+resource "cloudflare_regional_hostname" "create_timeout" {
+  zone_id    = var.cloudflare_zone_id
+  hostname   = "${local.name_prefix}-rh-create-timeout.${local.domain}"
+  region_key = "ca"
+
+
+  depends_on = [cloudflare_dns_record.rh_create_timeout]
+}
+
+resource "cloudflare_regional_hostname" "no_timeouts" {
+  zone_id    = var.cloudflare_zone_id
+  hostname   = "${local.name_prefix}-rh-no-timeouts.${local.domain}"
+  region_key = "ca"
+
+  depends_on = [cloudflare_dns_record.rh_no_timeouts]
+}
+
+# DNS Records (required before creating regional hostnames)
+resource "cloudflare_dns_record" "rh_minimal" {
+  zone_id = var.cloudflare_zone_id
+  name    = "${local.name_prefix}-rh-minimal"
+  type    = "A"
+  proxied = true
+  ttl     = 1
+  content = "192.0.2.1"
+}
+
+
+resource "cloudflare_dns_record" "rh_timeouts" {
+  zone_id = var.cloudflare_zone_id
+  name    = "${local.name_prefix}-rh-timeouts"
+  type    = "A"
+  proxied = true
+  ttl     = 1
+  content = "192.0.2.2"
+}
+
+
+resource "cloudflare_dns_record" "rh_create_timeout" {
+  zone_id = var.cloudflare_zone_id
+  name    = "${local.name_prefix}-rh-create-timeout"
+  type    = "A"
+  proxied = true
+  ttl     = 1
+  content = "192.0.2.3"
+}
+
+
+resource "cloudflare_dns_record" "rh_no_timeouts" {
+  zone_id = var.cloudflare_zone_id
+  name    = "${local.name_prefix}-rh-no-timeouts"
+  type    = "A"
+  proxied = true
+  ttl     = 1
+  content = "192.0.2.4"
+}
+
+
+variable "from_version" {
+  description = "Provider version under test, used to namespace resource names"
+  type        = string
+}

--- a/e2e-v5/testdata/regional_tiered_cache/regional_tiered_cache.tf
+++ b/e2e-v5/testdata/regional_tiered_cache/regional_tiered_cache.tf
@@ -1,0 +1,30 @@
+# E2E test for regional_tiered_cache migration
+# This is a simplified version for actual API testing (singleton resource)
+
+variable "cloudflare_account_id" {
+  description = "Cloudflare account ID"
+  type        = string
+}
+
+variable "cloudflare_zone_id" {
+  description = "Cloudflare zone ID"
+  type        = string
+}
+
+variable "cloudflare_domain" {
+  description = "Cloudflare domain for testing"
+  type        = string
+}
+
+# Test: Single instance (singleton resource - only one per zone)
+# Note: This is a SINGLETON resource - only ONE instance per zone
+# Note: Regional Tiered Cache requires Enterprise plan
+resource "cloudflare_regional_tiered_cache" "test" {
+  zone_id = var.cloudflare_zone_id
+  value   = "on"
+}
+
+variable "from_version" {
+  description = "Provider version under test, used to namespace resource names"
+  type        = string
+}

--- a/e2e-v5/testdata/ruleset/ruleset.tf
+++ b/e2e-v5/testdata/ruleset/ruleset.tf
@@ -1,0 +1,331 @@
+# ========================================
+# Variables
+# ========================================
+variable "cloudflare_zone_id" {
+  description = "Cloudflare zone ID"
+  type        = string
+}
+
+variable "cloudflare_account_id" {
+  description = "Cloudflare account ID"
+  type        = string
+}
+
+variable "cloudflare_domain" {
+  type        = string
+  description = "Domain for testing"
+}
+
+variable "from_version" {
+  description = "Provider version under test, used to namespace resource names"
+  type        = string
+}
+
+locals {
+  name_prefix = "v5-upgrade-${replace(var.from_version, ".", "-")}"
+}
+
+# Test Case 2: Ruleset with headers transformation
+resource "cloudflare_ruleset" "with_headers" {
+  zone_id     = var.cloudflare_zone_id
+  name        = "${local.name_prefix}-headers-ruleset"
+  kind        = "zone"
+  phase       = "http_request_late_transform"
+  description = "Ruleset with header transformations"
+
+  rules = [
+    {
+      action      = "rewrite"
+      expression  = "true"
+      description = "Modify request headers"
+      enabled     = true
+      action_parameters = {
+        headers = {
+          "X-Custom-Header" = {
+            operation = "set"
+            value     = "custom-value"
+          }
+          "X-Dynamic-Header" = {
+            expression = "cf.bot_management.score"
+            operation  = "set"
+          }
+          "X-Remove-Header" = {
+            operation = "remove"
+          }
+        }
+      }
+    }
+  ]
+}
+
+# Test Case 4: Block action with custom response
+resource "cloudflare_ruleset" "block_with_response" {
+  zone_id     = var.cloudflare_zone_id
+  name        = "${local.name_prefix}-block-ruleset"
+  kind        = "zone"
+  phase       = "http_request_firewall_custom"
+  description = "Ruleset with block action and custom response"
+
+  rules = [
+    {
+      action      = "block"
+      expression  = "(http.request.uri.path contains \"/admin\")"
+      description = "Block admin access with custom response"
+      enabled     = true
+      action_parameters = {
+        response = {
+          content      = "{\"error\": \"Access denied\"}"
+          content_type = "application/json"
+          status_code  = 403
+        }
+      }
+    }
+  ]
+}
+
+# Test Case 5: Redirect action with dynamic target
+resource "cloudflare_ruleset" "redirect" {
+  zone_id     = var.cloudflare_zone_id
+  name        = "${local.name_prefix}-redirect-ruleset"
+  kind        = "zone"
+  phase       = "http_request_dynamic_redirect"
+  description = "Ruleset with redirect action"
+
+  rules = [
+    {
+      action      = "redirect"
+      expression  = "(http.request.uri.path eq \"/old-page\")"
+      description = "Redirect old page to new location"
+      enabled     = true
+      action_parameters = {
+        from_value = {
+          status_code           = 301
+          preserve_query_string = true
+          target_url = {
+            value = "https://example.com/new-page"
+          }
+        }
+      }
+    }
+  ]
+}
+
+# Test Case 6: Rewrite action with URI modification
+resource "cloudflare_ruleset" "rewrite_uri" {
+  zone_id     = var.cloudflare_zone_id
+  name        = "${local.name_prefix}-rewrite-uri-ruleset"
+  kind        = "zone"
+  phase       = "http_request_transform"
+  description = "Ruleset with URI rewriting"
+
+  rules = [
+    {
+      action      = "rewrite"
+      expression  = "(http.request.uri.path contains \"/api/v1/\")"
+      description = "Rewrite API v1 to v2"
+      enabled     = true
+      action_parameters = {
+        uri = {
+          path = {
+            value = "/api/v2/endpoint"
+          }
+          query = {
+            expression = "concat(\"version=2&\", http.request.uri.query)"
+          }
+        }
+      }
+    }
+  ]
+}
+
+# Test Case 8: Set config action with multiple settings
+resource "cloudflare_ruleset" "set_config" {
+  zone_id     = var.cloudflare_zone_id
+  name        = "${local.name_prefix}-config-ruleset"
+  kind        = "zone"
+  phase       = "http_config_settings"
+  description = "Ruleset with configuration overrides"
+
+  rules = [
+    {
+      action      = "set_config"
+      expression  = "(http.host eq \"staging.example.com\")"
+      description = "Apply staging configuration"
+      enabled     = true
+      action_parameters = {
+        automatic_https_rewrites = true
+        email_obfuscation        = true
+        security_level           = "medium"
+        ssl                      = "strict"
+        autominify = {
+          css  = true
+          html = true
+          js   = true
+        }
+      }
+    }
+  ]
+}
+
+# Test Case 11: Log custom fields transformation
+resource "cloudflare_ruleset" "log_custom_fields" {
+  zone_id     = var.cloudflare_zone_id
+  name        = "${local.name_prefix}-log-custom-fields"
+  kind        = "zone"
+  phase       = "http_log_custom_fields"
+  description = "Ruleset with custom field logging"
+
+  rules = [
+    {
+      action      = "log_custom_field"
+      expression  = "true"
+      description = "Log custom fields from request"
+      enabled     = true
+      action_parameters = {
+        cookie_fields = [
+          { name = "preferences" },
+          { name = "session_id" },
+          { name = "user_token" },
+        ]
+        request_fields = [
+          { name = "cf.bot_score" },
+          { name = "cf.threat_score" },
+        ]
+        response_fields = [
+          { name = "cf.cache_status" },
+        ]
+      }
+    }
+  ]
+}
+
+# Test Case 12: WAF managed ruleset with overrides
+resource "cloudflare_ruleset" "waf_with_overrides" {
+  zone_id     = var.cloudflare_zone_id
+  name        = "${local.name_prefix}-waf-overrides"
+  kind        = "zone"
+  phase       = "http_request_firewall_managed"
+  description = "WAF ruleset with basic overrides"
+
+  rules = [
+    {
+      action      = "execute"
+      expression  = "true"
+      description = "Execute OWASP ruleset with sensitivity override"
+      enabled     = true
+      action_parameters = {
+        id = "4814384a9e5d4991b9815dcfc25d2f1f"
+        overrides = {
+          enabled = true
+          action  = "log"
+        }
+      }
+    }
+  ]
+}
+
+# Test Case 13: Cache settings with cache_reserve and query_string
+resource "cloudflare_ruleset" "cache_with_reserve" {
+  zone_id     = var.cloudflare_zone_id
+  name        = "${local.name_prefix}-cache-reserve"
+  kind        = "zone"
+  phase       = "http_request_cache_settings"
+  description = "Cache settings with cache reserve"
+
+  rules = [
+    {
+      action      = "set_cache_settings"
+      expression  = "(http.request.uri.path contains \"/static\")"
+      description = "Cache static content with reserve"
+      enabled     = true
+      action_parameters = {
+        cache = true
+        cache_key = {
+          cache_by_device_type = true
+          custom_key = {
+            query_string = {
+              include = {
+                list = ["utm_source", "utm_medium", "page"]
+              }
+            }
+          }
+        }
+        cache_reserve = {
+          eligible          = true
+          minimum_file_size = 10485760
+        }
+        edge_ttl = {
+          mode    = "override_origin"
+          default = 86400
+          status_code_ttl = [
+            {
+              status_code = 200
+              value       = 2592000
+            },
+            {
+              value = 300
+              status_code_range = {
+                from = 400
+                to   = 499
+              }
+            }
+          ]
+        }
+        serve_stale = {
+          disable_stale_while_updating = true
+        }
+      }
+    }
+  ]
+}
+
+# Test Case 16: Origin routing with SNI
+resource "cloudflare_ruleset" "origin_with_sni" {
+  zone_id     = var.cloudflare_zone_id
+  name        = "${local.name_prefix}-origin-sni"
+  kind        = "zone"
+  phase       = "http_request_origin"
+  description = "Route to origin with SNI override"
+
+  rules = [
+    {
+      action      = "route"
+      expression  = "(http.host eq \"api.${var.cloudflare_domain}\")"
+      description = "Route API traffic to origin with custom SNI"
+      enabled     = true
+      action_parameters = {
+        origin = {
+          host = var.cloudflare_domain
+          port = 8443
+        }
+        sni = {
+          value = "secure.${var.cloudflare_domain}"
+        }
+      }
+    }
+  ]
+}
+
+# Test Case 17: DDoS with algorithms override
+resource "cloudflare_ruleset" "ddos_algorithms" {
+  account_id  = var.cloudflare_account_id
+  name        = "${local.name_prefix}-ddos-algorithms"
+  kind        = "root"
+  phase       = "ddos_l7"
+  description = "DDoS protection with algorithm override"
+
+  rules = [
+    {
+      action      = "execute"
+      expression  = "true"
+      description = "Execute DDoS rules with sensitivity"
+      enabled     = true
+      action_parameters = {
+        id = "4d21379b4f9f4bb088e0729962c8b3cf"
+        overrides = {
+          sensitivity_level = "medium"
+        }
+      }
+    }
+  ]
+}

--- a/e2e-v5/testdata/snippet/snippet.tf
+++ b/e2e-v5/testdata/snippet/snippet.tf
@@ -1,0 +1,288 @@
+# Comprehensive snippet integration test data
+
+variable "cloudflare_account_id" {
+  description = "Cloudflare account ID"
+  type        = string
+}
+
+variable "cloudflare_zone_id" {
+  description = "Cloudflare zone ID"
+  type        = string
+}
+
+variable "cloudflare_domain" {
+  description = "Cloudflare domain for testing"
+  type        = string
+}
+
+locals {
+  name_prefix = "v5_upgrade_${replace(var.from_version, ".", "_")}"
+  zone_id     = "abc123def456"
+}
+
+variable "snippet_name" {
+  type    = string
+  default = "test_snippet"
+}
+
+variable "main_module_file" {
+  type    = string
+  default = "index.js"
+}
+
+# Test 1: Minimal snippet with single file
+resource "cloudflare_snippet" "minimal" {
+  zone_id = var.cloudflare_zone_id
+
+  snippet_name = "${local.name_prefix}_minimal"
+  files = [{
+    name    = "main.js"
+    content = <<-EOT
+      export default {
+        async fetch(request, env, ctx) {
+          const response = await fetch(request);
+          const newHeaders = new Headers(response.headers);
+          
+          // Your custom logic here
+          newHeaders.set("x-snippet-type", "inline-terraform-string");
+
+          return new Response(response.body, {
+            status: response.status,
+            statusText: response.statusText,
+            headers: newHeaders,
+          });
+        }
+      };
+    EOT
+  }]
+  metadata = {
+    main_module = "main.js"
+  }
+}
+
+# Test 2: Snippet with multiple files
+resource "cloudflare_snippet" "multi_file" {
+  zone_id = var.cloudflare_zone_id
+
+
+
+  snippet_name = "${local.name_prefix}_multi"
+  files = [{
+    name    = "index.js"
+    content = "export default { fetch() { return new Response('Hello'); } }"
+    }, {
+    name    = "utils.js"
+    content = "export function helper() { return 42; }"
+    }, {
+    name    = "config.js"
+    content = "export default {\"key\": \"value\"};"
+  }]
+  metadata = {
+    main_module = "index.js"
+  }
+}
+
+# Test 3: Snippet with special characters in content
+resource "cloudflare_snippet" "special_chars" {
+  zone_id = var.cloudflare_zone_id
+
+  snippet_name = "${local.name_prefix}_special"
+  files = [{
+    name    = "special.js"
+    content = "export default { fetch() { const msg = \"Hello, \\\"World\\\"!\"; return new Response(msg); } }"
+  }]
+  metadata = {
+    main_module = "special.js"
+  }
+}
+
+# Test 4: Snippet using count
+resource "cloudflare_snippet" "with_count" {
+  count   = 3
+  zone_id = var.cloudflare_zone_id
+
+  snippet_name = "${local.name_prefix}_count_${count.index}"
+  files = [{
+    name    = "main.js"
+    content = "export default { fetch(r) { console.log('Index: ${count.index}'); return fetch(r); } }"
+  }]
+  metadata = {
+    main_module = "main.js"
+  }
+}
+
+# Test 5: Snippet using for_each with set
+resource "cloudflare_snippet" "with_for_each_set" {
+  for_each = toset(["api", "web", "worker"])
+
+  zone_id = var.cloudflare_zone_id
+
+  snippet_name = "${local.name_prefix}_${each.value}"
+  files = [{
+    name    = "${each.value}.js"
+    content = "export default { fetch(r) { return fetch(r); } }; // Snippet for ${each.value}"
+  }]
+  metadata = {
+    main_module = "${each.value}.js"
+  }
+}
+
+# Test 6: Snippet using for_each with map
+resource "cloudflare_snippet" "with_for_each_map" {
+  for_each = {
+    prod    = "production.js"
+    staging = "staging.js"
+    dev     = "development.js"
+  }
+
+  zone_id = var.cloudflare_zone_id
+
+  snippet_name = "${local.name_prefix}_${each.key}"
+  files = [{
+    name    = each.value
+    content = "export default { fetch(r) { return fetch(r); } }; // Environment: ${each.key}"
+  }]
+  metadata = {
+    main_module = each.value
+  }
+}
+
+# Test 7: Snippet with conditional (ternary operator)
+resource "cloudflare_snippet" "conditional" {
+  zone_id = var.cloudflare_zone_id
+
+  snippet_name = "${local.name_prefix}_conditional"
+  files = [{
+    name    = var.snippet_name != "" ? "custom.js" : "default.js"
+    content = "export default { fetch(r) { return fetch(r); } }; ${var.snippet_name != "" ? "// Custom" : "// Default"}"
+  }]
+  metadata = {
+    main_module = var.snippet_name != "" ? "custom.js" : "default.js"
+  }
+}
+
+# Test 8: Snippet with multiline content
+resource "cloudflare_snippet" "multiline" {
+  zone_id = var.cloudflare_zone_id
+
+  snippet_name = "${local.name_prefix}_multiline"
+  files = [{
+    name    = "app.js"
+    content = <<-EOT
+      export default {
+        async fetch(request) {
+          return new Response('Hello World!');
+        }
+      }
+    EOT
+  }]
+  metadata = {
+    main_module = "app.js"
+  }
+}
+
+# Test 9: Snippet with jsonencode function
+resource "cloudflare_snippet" "with_jsonencode" {
+  zone_id = var.cloudflare_zone_id
+
+  snippet_name = "${local.name_prefix}_json"
+  files = [{
+    name    = "index.js"
+    content = "const config = ${jsonencode({ key = "value", debug = true })}; export default { fetch(r) { return new Response(JSON.stringify(config)); } }"
+  }]
+  metadata = {
+    main_module = "index.js"
+  }
+}
+
+# Test 10: Snippet with interpolation in all fields
+resource "cloudflare_snippet" "interpolated" {
+  zone_id = "${var.cloudflare_zone_id}"
+
+  snippet_name = "${local.name_prefix}_interpolated"
+  files = [{
+    name    = "${var.main_module_file}"
+    content = "export default { fetch(r) { return fetch(r); } }; // ${var.snippet_name}"
+  }]
+  metadata = {
+    main_module = "${var.main_module_file}"
+  }
+}
+
+# Test 11: Snippet with lifecycle meta-argument
+resource "cloudflare_snippet" "with_lifecycle" {
+  zone_id = var.cloudflare_zone_id
+
+
+  lifecycle {
+    create_before_destroy = true
+    ignore_changes        = [files]
+  }
+  snippet_name = "${local.name_prefix}_lifecycle"
+  files = [{
+    name    = "main.js"
+    content = "export default { fetch(r) { return fetch(r); } }; // Lifecycle test"
+  }]
+  metadata = {
+    main_module = "main.js"
+  }
+}
+
+# Test 12: Snippet with depends_on
+resource "cloudflare_snippet" "with_depends_on" {
+  depends_on = [cloudflare_snippet.minimal]
+
+  zone_id = var.cloudflare_zone_id
+
+  snippet_name = "${local.name_prefix}_depends"
+  files = [{
+    name    = "dependent.js"
+    content = "export default { fetch(r) { return fetch(r); } }; // Depends on minimal snippet"
+  }]
+  metadata = {
+    main_module = "dependent.js"
+  }
+}
+
+# Test 13: Snippet with long content
+resource "cloudflare_snippet" "long_content" {
+  zone_id = var.cloudflare_zone_id
+
+  snippet_name = "${local.name_prefix}_long"
+  files = [{
+    name    = "worker.js"
+    content = <<-EOT
+      // This is a comprehensive worker script
+      export default {
+        async fetch(request, env, ctx) {
+          const url = new URL(request.url);
+
+          // Handle different routes
+          switch (url.pathname) {
+            case '/api':
+              return handleAPI(request);
+            case '/health':
+              return new Response('OK', { status: 200 });
+            default:
+              return new Response('Not Found', { status: 404 });
+          }
+        }
+      }
+
+      async function handleAPI(request) {
+        const data = await request.json();
+        return new Response(JSON.stringify(data), {
+          headers: { 'Content-Type': 'application/json' }
+        });
+      }
+    EOT
+  }]
+  metadata = {
+    main_module = "worker.js"
+  }
+}
+
+variable "from_version" {
+  description = "Provider version under test, used to namespace resource names"
+  type        = string
+}

--- a/e2e-v5/testdata/snippet_rules/snippet_rules.tf
+++ b/e2e-v5/testdata/snippet_rules/snippet_rules.tf
@@ -1,0 +1,447 @@
+# E2E test for snippet_rules migration
+#
+# cloudflare_snippet_rules is a zone-level singleton (one resource per zone),
+# so we use a single resource with multiple rules for e2e testing.
+# for_each, count, and multi-resource patterns are tested in the integration
+# tests (snippet_rules.tf) which only validates config transformation.
+#
+# This file includes cloudflare_snippet resources inline so the module is
+# self-contained. Run with: --resources snippet_rules
+
+variable "cloudflare_account_id" {
+  description = "Cloudflare account ID"
+  type        = string
+}
+
+variable "cloudflare_zone_id" {
+  description = "Cloudflare zone ID"
+  type        = string
+}
+
+variable "cloudflare_domain" {
+  description = "Cloudflare domain for testing"
+  type        = string
+}
+
+variable "enable_snippet" {
+  type    = bool
+  default = true
+}
+
+variable "snippet_name" {
+  type    = string
+  default = "use_special_chars_snippet"
+}
+
+variable "create_conditional" {
+  type    = bool
+  default = true
+}
+
+variable "main_module_file" {
+  type    = string
+  default = "index.js"
+}
+
+locals {
+  name_prefix  = "v5_upgrade_${replace(var.from_version, ".", "_")}"
+  environments = ["dev", "test", "prod"]
+  base_zone_id = var.cloudflare_zone_id
+}
+
+# ========================================
+# Snippet resources (dependencies for rules)
+# ========================================
+
+resource "cloudflare_snippet" "minimal" {
+  zone_id = var.cloudflare_zone_id
+
+  snippet_name = "${local.name_prefix}_sr_minimal"
+  files = [{
+    name    = "main.js"
+    content = <<-EOT
+      export default {
+        async fetch(request, env, ctx) {
+          const response = await fetch(request);
+          const newHeaders = new Headers(response.headers);
+          newHeaders.set("x-snippet-type", "inline-terraform-string");
+          return new Response(response.body, {
+            status: response.status,
+            statusText: response.statusText,
+            headers: newHeaders,
+          });
+        }
+      };
+    EOT
+  }]
+  metadata = {
+    main_module = "main.js"
+  }
+}
+
+resource "cloudflare_snippet" "multi_file" {
+  zone_id = var.cloudflare_zone_id
+
+
+
+  snippet_name = "${local.name_prefix}_sr_multi"
+  files = [{
+    name    = "index.js"
+    content = "export default { fetch() { return new Response('Hello'); } }"
+    }, {
+    name    = "utils.js"
+    content = "export function helper() { return 42; }"
+    }, {
+    name    = "config.js"
+    content = "export default {\"key\": \"value\"};"
+  }]
+  metadata = {
+    main_module = "index.js"
+  }
+}
+
+resource "cloudflare_snippet" "special_chars" {
+  zone_id = var.cloudflare_zone_id
+
+  snippet_name = "${local.name_prefix}_sr_special"
+  files = [{
+    name    = "special.js"
+    content = "export default { fetch() { const msg = \"Hello, \\\"World\\\"!\"; return new Response(msg); } }"
+  }]
+  metadata = {
+    main_module = "special.js"
+  }
+}
+
+resource "cloudflare_snippet" "with_count" {
+  count   = 3
+  zone_id = var.cloudflare_zone_id
+
+  snippet_name = "${local.name_prefix}_sr_count_${count.index}"
+  files = [{
+    name    = "main.js"
+    content = "export default { fetch(r) { console.log('Index: ${count.index}'); return fetch(r); } }"
+  }]
+  metadata = {
+    main_module = "main.js"
+  }
+}
+
+resource "cloudflare_snippet" "with_for_each_set" {
+  for_each = toset(["api", "web", "worker"])
+
+  zone_id = var.cloudflare_zone_id
+
+  snippet_name = "${local.name_prefix}_sr_${each.value}"
+  files = [{
+    name    = "${each.value}.js"
+    content = "export default { fetch(r) { return fetch(r); } }; // Snippet for ${each.value}"
+  }]
+  metadata = {
+    main_module = "${each.value}.js"
+  }
+}
+
+resource "cloudflare_snippet" "with_for_each_map" {
+  for_each = {
+    prod    = "production.js"
+    staging = "staging.js"
+    dev     = "development.js"
+  }
+
+  zone_id = var.cloudflare_zone_id
+
+  snippet_name = "${local.name_prefix}_sr_${each.key}"
+  files = [{
+    name    = each.value
+    content = "export default { fetch(r) { return fetch(r); } }; // Environment: ${each.key}"
+  }]
+  metadata = {
+    main_module = each.value
+  }
+}
+
+resource "cloudflare_snippet" "conditional" {
+  zone_id = var.cloudflare_zone_id
+
+  snippet_name = "${local.name_prefix}_sr_conditional"
+  files = [{
+    name    = var.snippet_name != "" ? "custom.js" : "default.js"
+    content = "export default { fetch(r) { return fetch(r); } }; ${var.snippet_name != "" ? "// Custom" : "// Default"}"
+  }]
+  metadata = {
+    main_module = var.snippet_name != "" ? "custom.js" : "default.js"
+  }
+}
+
+resource "cloudflare_snippet" "multiline" {
+  zone_id = var.cloudflare_zone_id
+
+  snippet_name = "${local.name_prefix}_sr_multiline"
+  files = [{
+    name    = "app.js"
+    content = <<-EOT
+      export default {
+        async fetch(request) {
+          return new Response('Hello World!');
+        }
+      }
+    EOT
+  }]
+  metadata = {
+    main_module = "app.js"
+  }
+}
+
+resource "cloudflare_snippet" "with_jsonencode" {
+  zone_id = var.cloudflare_zone_id
+
+  snippet_name = "${local.name_prefix}_sr_json"
+  files = [{
+    name    = "index.js"
+    content = "const config = ${jsonencode({ key = "value", debug = true })}; export default { fetch(r) { return new Response(JSON.stringify(config)); } }"
+  }]
+  metadata = {
+    main_module = "index.js"
+  }
+}
+
+resource "cloudflare_snippet" "interpolated" {
+  zone_id = var.cloudflare_zone_id
+
+  snippet_name = "${local.name_prefix}_sr_interpolated"
+  files = [{
+    name    = "${var.main_module_file}"
+    content = "export default { fetch(r) { return fetch(r); } }; // ${var.snippet_name}"
+  }]
+  metadata = {
+    main_module = "${var.main_module_file}"
+  }
+}
+
+resource "cloudflare_snippet" "with_lifecycle" {
+  zone_id = var.cloudflare_zone_id
+
+
+  lifecycle {
+    create_before_destroy = true
+    ignore_changes        = [files]
+  }
+  snippet_name = "${local.name_prefix}_sr_lifecycle"
+  files = [{
+    name    = "main.js"
+    content = "export default { fetch(r) { return fetch(r); } }; // Lifecycle test"
+  }]
+  metadata = {
+    main_module = "main.js"
+  }
+}
+
+resource "cloudflare_snippet" "with_depends_on" {
+  depends_on = [cloudflare_snippet.minimal]
+
+  zone_id = var.cloudflare_zone_id
+
+  snippet_name = "${local.name_prefix}_sr_depends"
+  files = [{
+    name    = "dependent.js"
+    content = "export default { fetch(r) { return fetch(r); } }; // Depends on minimal snippet"
+  }]
+  metadata = {
+    main_module = "dependent.js"
+  }
+}
+
+resource "cloudflare_snippet" "long_content" {
+  zone_id = var.cloudflare_zone_id
+
+  snippet_name = "${local.name_prefix}_sr_long"
+  files = [{
+    name    = "worker.js"
+    content = <<-EOT
+      // This is a comprehensive worker script
+      export default {
+        async fetch(request, env, ctx) {
+          const url = new URL(request.url);
+          switch (url.pathname) {
+            case '/api':
+              return handleAPI(request);
+            case '/health':
+              return new Response('OK', { status: 200 });
+            default:
+              return new Response('Not Found', { status: 404 });
+          }
+        }
+      }
+      async function handleAPI(request) {
+        const data = await request.json();
+        return new Response(JSON.stringify(data), {
+          headers: { 'Content-Type': 'application/json' }
+        });
+      }
+    EOT
+  }]
+  metadata = {
+    main_module = "worker.js"
+  }
+}
+
+# ========================================
+# Snippet rules (zone-level singleton)
+# ========================================
+
+resource "cloudflare_snippet_rules" "basic" {
+  depends_on = [
+    cloudflare_snippet.minimal,
+    cloudflare_snippet.multi_file,
+    cloudflare_snippet.special_chars,
+    cloudflare_snippet.with_count,
+    cloudflare_snippet.with_for_each_set,
+    cloudflare_snippet.with_for_each_map,
+    cloudflare_snippet.conditional,
+    cloudflare_snippet.multiline,
+    cloudflare_snippet.with_jsonencode,
+    cloudflare_snippet.interpolated,
+    cloudflare_snippet.with_lifecycle,
+    cloudflare_snippet.with_depends_on,
+    cloudflare_snippet.long_content,
+  ]
+
+  zone_id = local.base_zone_id
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  rules = [
+    {
+      enabled      = true
+      expression   = "http.request.uri.path eq \"/api\""
+      snippet_name = "${local.name_prefix}_sr_minimal"
+      description  = "Basic test rule"
+    },
+    {
+      enabled      = var.enable_snippet
+      expression   = "http.request.uri.path eq \"/v1\""
+      snippet_name = "${local.name_prefix}_sr_multi"
+      description  = "Rule with variable-controlled enabled"
+    },
+    {
+      enabled      = false
+      expression   = "http.request.uri.path eq \"/v2\""
+      snippet_name = "${local.name_prefix}_sr_special"
+      description  = "Rule referencing special_chars snippet"
+    },
+    {
+      expression   = "http.request.uri.path eq \"/v3\""
+      snippet_name = "${local.name_prefix}_sr_count_0"
+      enabled      = true
+    },
+    {
+      enabled      = true
+      expression   = "(http.request.uri.path eq \"/complex\") and (http.request.method eq \"POST\")"
+      snippet_name = "${local.name_prefix}_sr_count_1"
+      description  = "Complex expression with AND"
+    },
+    {
+      enabled      = true
+      expression   = "(http.host eq \"example.com\") or (http.host eq \"www.example.com\")"
+      snippet_name = "${local.name_prefix}_sr_count_2"
+      description  = "Complex expression with OR"
+    },
+    {
+      enabled      = true
+      expression   = "http.request.uri.path matches \"^/api/v[0-9]+/.*$\""
+      snippet_name = "${local.name_prefix}_sr_api"
+      description  = "Rule with regex pattern"
+    },
+    {
+      enabled      = true
+      expression   = "http.request.uri.query contains \"token=\""
+      snippet_name = "${local.name_prefix}_sr_web"
+      description  = "Rule checking query parameters"
+    },
+    {
+      enabled      = true
+      expression   = "http.request.uri.path eq \"/${lower("UPPERCASE")}\""
+      snippet_name = "${local.name_prefix}_${format("%s", "sr_interpolated")}"
+      description  = "${title("function-based description")}"
+    },
+    {
+      enabled      = true
+      expression   = "http.request.uri.path eq \"/local\""
+      snippet_name = "${local.name_prefix}_sr_lifecycle"
+      description  = "Using locals: ${join(", ", local.environments)}"
+    },
+    {
+      expression   = "http.request.uri.path eq \"/minimal\""
+      snippet_name = "${local.name_prefix}_sr_long"
+      enabled      = true
+    },
+    {
+      enabled      = false
+      expression   = "http.request.uri.path eq \"/all\""
+      snippet_name = "${local.name_prefix}_sr_conditional"
+      description  = "Rule with all optional fields set"
+    },
+    {
+      enabled      = true
+      expression   = "http.request.uri.path eq \"/prod\""
+      snippet_name = "${local.name_prefix}_sr_prod"
+      description  = "Rule for prod environment"
+    },
+    {
+      enabled      = true
+      expression   = "http.request.uri.path eq \"/staging\""
+      snippet_name = "${local.name_prefix}_sr_staging"
+      description  = "Rule for staging environment"
+    },
+    {
+      enabled      = true
+      expression   = "http.request.uri.path eq \"/dev\""
+      snippet_name = "${local.name_prefix}_sr_dev"
+      description  = "Rule for dev environment"
+    },
+    {
+      enabled      = true
+      expression   = "http.request.uri.path eq \"/worker\""
+      snippet_name = "${local.name_prefix}_sr_worker"
+    },
+    {
+      enabled      = true
+      expression   = "http.request.uri.path eq \"/multiline\""
+      snippet_name = "${local.name_prefix}_sr_multiline"
+      description  = "Rule referencing multiline snippet"
+    },
+    {
+      enabled      = var.create_conditional ? true : false
+      expression   = "http.request.uri.path eq \"/json\""
+      snippet_name = "${local.name_prefix}_sr_json"
+      description  = "Conditional enabled via ternary"
+    },
+    {
+      enabled      = true
+      expression   = "http.request.uri.path eq \"/depends\""
+      snippet_name = "${local.name_prefix}_sr_depends"
+    }
+  ]
+}
+
+variable "from_version" {
+  description = "Provider version under test, used to namespace resource names"
+  type        = string
+}

--- a/e2e-v5/testdata/spectrum_application/spectrum_application.tf
+++ b/e2e-v5/testdata/spectrum_application/spectrum_application.tf
@@ -1,0 +1,84 @@
+variable "cloudflare_account_id" {
+  description = "Cloudflare account ID"
+  type        = string
+}
+
+variable "cloudflare_zone_id" {
+  description = "Cloudflare zone ID"
+  type        = string
+}
+
+variable "cloudflare_domain" {
+  description = "Cloudflare domain for testing"
+  type        = string
+}
+
+variable "from_version" {
+  description = "Provider version under test, used to namespace resource names"
+  type        = string
+}
+
+variable "spectrum_origin_ip" {
+  description = "Origin IP address for Spectrum applications"
+  type        = string
+  default     = "54.205.230.94" # httpbin.org
+}
+
+data "cloudflare_zone" "this" {
+  zone_id = var.cloudflare_zone_id
+}
+
+locals {
+  name_prefix = "v5-upgrade-${replace(var.from_version, ".", "-")}"
+  zone_name   = data.cloudflare_zone.this.name
+}
+
+# Basic - IPv6 only to avoid exhausting IPv4 quota
+resource "cloudflare_spectrum_application" "basic" {
+  zone_id       = var.cloudflare_zone_id
+  protocol      = "tcp/443"
+  origin_direct = ["tcp://${var.spectrum_origin_ip}:443"]
+  dns = {
+    type = "CNAME"
+    name = "${local.name_prefix}-spectrum-basic.${local.zone_name}"
+  }
+  edge_ips = {
+    type         = "dynamic"
+    connectivity = "ipv6"
+  }
+}
+
+# With all optional fields - IPv6 only
+resource "cloudflare_spectrum_application" "full" {
+  zone_id            = var.cloudflare_zone_id
+  protocol           = "tcp/22"
+  tls                = "flexible"
+  argo_smart_routing = true
+  ip_firewall        = true
+  proxy_protocol     = "v1"
+  traffic_type       = "direct"
+  origin_direct      = ["tcp://${var.spectrum_origin_ip}:22"]
+  dns = {
+    type = "CNAME"
+    name = "${local.name_prefix}-spectrum-full.${local.zone_name}"
+  }
+  edge_ips = {
+    type         = "dynamic"
+    connectivity = "ipv6"
+  }
+}
+
+# Cross-resource reference - IPv6 only
+resource "cloudflare_spectrum_application" "zone_ref" {
+  zone_id       = data.cloudflare_zone.this.id
+  protocol      = "tcp/8443"
+  origin_direct = ["tcp://${var.spectrum_origin_ip}:8443"]
+  dns = {
+    type = "CNAME"
+    name = "${local.name_prefix}-spectrum-ref.${local.zone_name}"
+  }
+  edge_ips = {
+    type         = "dynamic"
+    connectivity = "ipv6"
+  }
+}

--- a/e2e-v5/testdata/tiered_cache/tiered_cache.tf
+++ b/e2e-v5/testdata/tiered_cache/tiered_cache.tf
@@ -1,0 +1,36 @@
+variable "cloudflare_account_id" {
+  description = "Cloudflare account ID"
+  type        = string
+}
+
+variable "cloudflare_zone_id" {
+  description = "Cloudflare zone ID"
+  type        = string
+}
+
+variable "cloudflare_domain" {
+  description = "Cloudflare domain for testing"
+  type        = string
+}
+
+
+resource "cloudflare_tiered_cache" "generic_with_lifecycle" {
+  zone_id = var.cloudflare_zone_id
+  value   = "off"
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "cloudflare_argo_tiered_caching" "generic_with_lifecycle" {
+  zone_id = var.cloudflare_zone_id
+  value   = "on"
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+variable "from_version" {
+  description = "Provider version under test, used to namespace resource names"
+  type        = string
+}

--- a/e2e-v5/testdata/turnstile_widget/turnstile_widget.tf
+++ b/e2e-v5/testdata/turnstile_widget/turnstile_widget.tf
@@ -1,0 +1,300 @@
+# Terraform Provider v4 to v5 Migration Test
+# Resource: cloudflare_turnstile_widget
+# Comprehensive integration test covering all Terraform patterns
+
+# Standard variables (auto-provided by E2E infrastructure)
+variable "cloudflare_account_id" {
+  type = string
+}
+
+variable "cloudflare_zone_id" {
+  type = string
+}
+
+variable "cloudflare_domain" {
+  type = string
+}
+
+# Locals for DRY testing
+locals {
+  name_prefix = "v5-upgrade-${replace(var.from_version, ".", "-")}"
+  account_id  = var.cloudflare_account_id
+
+  # Common domains for testing
+  test_domains = {
+    prod    = "prod.cf-tf-test.com"
+    staging = "staging.cf-tf-test.com"
+    dev     = "dev.cf-tf-test.com"
+  }
+
+  # Widget modes for iteration
+  widget_modes = ["managed", "invisible", "non-interactive"]
+}
+
+# ==================================================
+# Pattern Group 1: Basic Resources (Edge Cases)
+# ==================================================
+
+# Test Case 1: Minimal configuration (required fields only)
+resource "cloudflare_turnstile_widget" "minimal" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-minimal"
+  domains    = ["minimal.cf-tf-test.com"]
+
+  mode = "managed"
+}
+
+# Test Case 2: Maximal configuration (all optional fields)
+resource "cloudflare_turnstile_widget" "maximal" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-maximal"
+  domains    = ["max2.cf-tf-test.com", "maximal.cf-tf-test.com"]
+
+  mode           = "invisible"
+  region         = "world"
+  bot_fight_mode = false
+  offlabel       = true
+}
+
+# Test Case 3: With explicit defaults
+resource "cloudflare_turnstile_widget" "with_defaults" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-defaults"
+  domains    = ["defaults.cf-tf-test.com"]
+
+  mode           = "non-interactive"
+  region         = "world"
+  bot_fight_mode = false
+  offlabel       = false
+}
+
+# ==================================================
+# Pattern Group 2: for_each with Maps
+# ==================================================
+
+# Test Case 4-6: for_each with map (3 instances)
+resource "cloudflare_turnstile_widget" "foreach_map" {
+  for_each = {
+    "prod" = {
+      domain = local.test_domains.prod
+      mode   = "managed"
+    }
+    "staging" = {
+      domain = local.test_domains.staging
+      mode   = "invisible"
+    }
+    "dev" = {
+      domain = local.test_domains.dev
+      mode   = "non-interactive"
+    }
+  }
+
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-map-${each.key}"
+  domains    = [each.value.domain]
+  mode       = each.value.mode
+}
+
+# ==================================================
+# Pattern Group 3: for_each with Sets
+# ==================================================
+
+# Test Case 7-10: for_each with set (4 instances)
+resource "cloudflare_turnstile_widget" "foreach_set" {
+  for_each = toset([
+    "alpha",
+    "beta",
+    "gamma",
+    "delta"
+  ])
+
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-set-${each.value}"
+  domains    = ["${each.value}.cf-tf-test.com"]
+  mode       = "managed"
+}
+
+# ==================================================
+# Pattern Group 4: count-based Resources
+# ==================================================
+
+# Test Case 11-13: count-based (3 instances)
+resource "cloudflare_turnstile_widget" "counted" {
+  count = 3
+
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-count-${count.index}"
+  domains    = ["count${count.index}.cf-tf-test.com"]
+  mode       = local.widget_modes[count.index]
+}
+
+# ==================================================
+# Pattern Group 5: Conditional Creation
+# ==================================================
+
+locals {
+  enable_production  = true
+  enable_development = false
+}
+
+# Test Case 14: Conditional enabled (will be created)
+resource "cloudflare_turnstile_widget" "conditional_enabled" {
+  count = local.enable_production ? 1 : 0
+
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-conditional-enabled"
+  domains    = ["enabled.cf-tf-test.com"]
+
+  mode = "managed"
+}
+
+# Test Case 15: Conditional disabled (will NOT be created - no instance in state)
+resource "cloudflare_turnstile_widget" "conditional_disabled" {
+  count = local.enable_development ? 1 : 0
+
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-conditional-disabled"
+  domains    = ["disabled.cf-tf-test.com"]
+
+  mode = "invisible"
+}
+
+# ==================================================
+# Pattern Group 6: Terraform Functions
+# ==================================================
+
+# Test Case 16: Using join() function
+resource "cloudflare_turnstile_widget" "with_join" {
+  account_id = var.cloudflare_account_id
+  name       = join("-", [local.name_prefix, "join", "test"])
+  domains    = ["join.cf-tf-test.com"]
+
+  mode = "managed"
+}
+
+# Test Case 17: String interpolation
+resource "cloudflare_turnstile_widget" "with_interpolation" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-interp"
+  domains    = ["interp.cf-tf-test.com"]
+
+  mode = "invisible"
+}
+
+# ==================================================
+# Pattern Group 7: Lifecycle Meta-Arguments
+# ==================================================
+
+# Test Case 18: Lifecycle with create_before_destroy
+resource "cloudflare_turnstile_widget" "with_lifecycle_cbd" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-lifecycle-cbd"
+  domains    = ["lifecycle-cbd.cf-tf-test.com"]
+
+  mode = "managed"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+# Test Case 19: Lifecycle with ignore_changes
+resource "cloudflare_turnstile_widget" "with_lifecycle_ignore" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-lifecycle-ignore"
+  domains    = ["lifecycle-ignore.cf-tf-test.com"]
+
+  mode = "invisible"
+
+  lifecycle {
+    ignore_changes = [name]
+  }
+}
+
+# Test Case 20: Lifecycle with prevent_destroy
+resource "cloudflare_turnstile_widget" "with_lifecycle_prevent" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-lifecycle-prevent"
+  domains    = ["lifecycle-prevent.cf-tf-test.com"]
+
+  mode = "non-interactive"
+
+  lifecycle {
+    prevent_destroy = false # Set to false for testing purposes
+  }
+}
+
+# ==================================================
+# Pattern Group 8: Multiple Domains
+# ==================================================
+
+# Test Case 21: Multiple domains (2)
+resource "cloudflare_turnstile_widget" "multi_domain_2" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-multi-2"
+  domains    = ["multi1.cf-tf-test.com", "multi2.cf-tf-test.com"]
+
+  mode = "managed"
+}
+
+# Test Case 22: Multiple domains (5)
+resource "cloudflare_turnstile_widget" "multi_domain_5" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-multi-5"
+  domains    = ["md1.cf-tf-test.com", "md2.cf-tf-test.com", "md3.cf-tf-test.com", "md4.cf-tf-test.com", "md5.cf-tf-test.com"]
+
+  mode = "invisible"
+}
+
+# ==================================================
+# Pattern Group 9: Variable References
+# ==================================================
+
+# Test Case 23: Variable reference (toset with variable - should preserve)
+resource "cloudflare_turnstile_widget" "with_var_domains" {
+  account_id = local.account_id
+  name       = "${local.name_prefix}-var-domains"
+  domains    = [local.test_domains.prod]
+  mode       = "managed"
+}
+
+# ==================================================
+# Pattern Group 10: All Widget Modes
+# ==================================================
+
+# Test Case 24: managed mode
+resource "cloudflare_turnstile_widget" "mode_managed" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-mode-managed"
+  domains    = ["managed.cf-tf-test.com"]
+
+  mode = "managed"
+}
+
+# Test Case 25: invisible mode
+resource "cloudflare_turnstile_widget" "mode_invisible" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-mode-invisible"
+  domains    = ["invisible.cf-tf-test.com"]
+
+  mode = "invisible"
+}
+
+# Test Case 26: non-interactive mode
+resource "cloudflare_turnstile_widget" "mode_noninteractive" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-mode-noninteractive"
+  domains    = ["noninteractive.cf-tf-test.com"]
+
+  mode = "non-interactive"
+}
+
+# ==================================================
+# Summary: Total 26 resource declarations
+# Actual instances: 23 (conditional_disabled won't be created)
+# ==================================================
+
+variable "from_version" {
+  description = "Provider version under test, used to namespace resource names"
+  type        = string
+}

--- a/e2e-v5/testdata/url_normalization_settings/url_normalization_settings.tf
+++ b/e2e-v5/testdata/url_normalization_settings/url_normalization_settings.tf
@@ -1,0 +1,30 @@
+# E2E test for url_normalization_settings migration
+# This is a simplified version for actual API testing (singleton resource)
+
+variable "cloudflare_account_id" {
+  description = "Cloudflare account ID"
+  type        = string
+}
+
+variable "cloudflare_zone_id" {
+  description = "Cloudflare zone ID"
+  type        = string
+}
+
+variable "cloudflare_domain" {
+  description = "Cloudflare domain for testing"
+  type        = string
+}
+
+# Test: Single instance (singleton resource - only one per zone)
+# Note: This is a SINGLETON resource - only ONE instance per zone
+resource "cloudflare_url_normalization_settings" "test" {
+  zone_id = var.cloudflare_zone_id
+  type    = "cloudflare"
+  scope   = "incoming"
+}
+
+variable "from_version" {
+  description = "Provider version under test, used to namespace resource names"
+  type        = string
+}

--- a/e2e-v5/testdata/worker_route/worker_route.tf
+++ b/e2e-v5/testdata/worker_route/worker_route.tf
@@ -1,0 +1,220 @@
+# Comprehensive integration test for worker_route migration
+# This file tests ALL Terraform patterns and edge cases
+# Note: Testing routes without script_name to avoid requiring actual worker scripts
+
+# ========================================
+# Variables
+# ========================================
+variable "cloudflare_account_id" {
+  description = "Cloudflare account ID"
+  type        = string
+}
+
+variable "cloudflare_zone_id" {
+  description = "Cloudflare zone ID"
+  type        = string
+}
+
+variable "cloudflare_domain" {
+  description = "Cloudflare domain for testing"
+  type        = string
+}
+
+locals {
+  name_prefix = "v5-upgrade-${replace(var.from_version, ".", "-")}"
+  zone_id     = var.cloudflare_zone_id
+
+  # Test data for routes
+  api_routes = {
+    api     = "${local.name_prefix}-api.cf-tf-test.com/*"
+    graphql = "${local.name_prefix}-graphql.cf-tf-test.com/*"
+  }
+
+  admin_patterns = [
+    "${local.name_prefix}-admin.cf-tf-test.com/*",
+    "${local.name_prefix}-manage.cf-tf-test.com/*",
+  ]
+}
+
+###############################################################################
+# Pattern 1: Basic Resources - Minimal and Full Configurations
+###############################################################################
+
+# Minimal route - only required fields
+resource "cloudflare_workers_route" "minimal" {
+  zone_id = local.zone_id
+  pattern = "${local.name_prefix}.cf-tf-test.com/*"
+}
+
+# Full route - with additional fields
+resource "cloudflare_workers_route" "full" {
+  zone_id = local.zone_id
+  pattern = "${local.name_prefix}-full.cf-tf-test.com/*"
+}
+
+# Route with wildcard subdomain pattern
+resource "cloudflare_workers_route" "wildcard_subdomain" {
+  zone_id = local.zone_id
+  pattern = "*.${local.name_prefix}.cf-tf-test.com/*"
+}
+
+# Route with specific path pattern
+resource "cloudflare_workers_route" "specific_path" {
+  zone_id = local.zone_id
+  pattern = "${local.name_prefix}.cf-tf-test.com/api/*"
+}
+
+# Route with exact path (no wildcard)
+resource "cloudflare_workers_route" "exact_path" {
+  zone_id = local.zone_id
+  pattern = "${local.name_prefix}.cf-tf-test.com/health"
+}
+
+###############################################################################
+# Pattern 2: for_each with Maps
+###############################################################################
+
+resource "cloudflare_workers_route" "api_routes" {
+  for_each = local.api_routes
+
+  zone_id = local.zone_id
+  pattern = each.value
+}
+
+###############################################################################
+# Pattern 3: for_each with Sets (toset)
+###############################################################################
+
+resource "cloudflare_workers_route" "admin_routes" {
+  for_each = toset(local.admin_patterns)
+
+  zone_id = local.zone_id
+  pattern = each.value
+}
+
+###############################################################################
+# Pattern 4: count-based Resources
+###############################################################################
+
+resource "cloudflare_workers_route" "numbered" {
+  count = 3
+
+  zone_id = local.zone_id
+  pattern = "${local.name_prefix}-${count.index}.cf-tf-test.com/*"
+}
+
+###############################################################################
+# Pattern 5: Conditional Creation
+###############################################################################
+
+resource "cloudflare_workers_route" "conditional" {
+  count = 1 # Simulate conditional: count = var.enable_route ? 1 : 0
+
+  zone_id = local.zone_id
+  pattern = "${local.name_prefix}-conditional.cf-tf-test.com/*"
+}
+
+###############################################################################
+# Pattern 6: Variable References and Interpolation
+###############################################################################
+
+resource "cloudflare_workers_route" "with_variables" {
+  zone_id = var.cloudflare_zone_id
+  pattern = "${local.name_prefix}-var.cf-tf-test.com/*"
+}
+
+###############################################################################
+# Pattern 7: Route without script (catch-all/fallback route)
+###############################################################################
+
+resource "cloudflare_workers_route" "no_script_catchall" {
+  zone_id = local.zone_id
+  pattern = "${local.name_prefix}-fallback.cf-tf-test.com/*"
+}
+
+###############################################################################
+# Pattern 8: Multiple Routes for Same Domain (different paths)
+###############################################################################
+
+resource "cloudflare_workers_route" "multi_path_1" {
+  zone_id = local.zone_id
+  pattern = "${local.name_prefix}-multi.cf-tf-test.com/api/*"
+}
+
+resource "cloudflare_workers_route" "multi_path_2" {
+  zone_id = local.zone_id
+  pattern = "${local.name_prefix}-multi.cf-tf-test.com/static/*"
+}
+
+resource "cloudflare_workers_route" "multi_path_3" {
+  zone_id = local.zone_id
+  pattern = "${local.name_prefix}-multi.cf-tf-test.com/*"
+}
+
+###############################################################################
+# Pattern 9: Special Characters in Patterns
+###############################################################################
+
+resource "cloudflare_workers_route" "query_params" {
+  zone_id = local.zone_id
+  pattern = "${local.name_prefix}-query.cf-tf-test.com/*"
+}
+
+resource "cloudflare_workers_route" "dashes_underscores" {
+  zone_id = local.zone_id
+  pattern = "${local.name_prefix}-test_route.cf-tf-test.com/*"
+}
+
+###############################################################################
+# Pattern 10: Dynamic Block Pattern (using for_each in a different way)
+###############################################################################
+
+locals {
+  route_configs = {
+    prod = {
+      pattern = "${local.name_prefix}-prod.cf-tf-test.com/*"
+    }
+    staging = {
+      pattern = "${local.name_prefix}-staging.cf-tf-test.com/*"
+    }
+    dev = {
+      pattern = "${local.name_prefix}-dev.cf-tf-test.com/*"
+    }
+  }
+}
+
+resource "cloudflare_workers_route" "environments" {
+  for_each = local.route_configs
+
+  zone_id = local.zone_id
+  pattern = each.value.pattern
+}
+
+###############################################################################
+# Pattern 11: Cross-Pattern Testing
+###############################################################################
+
+# Combination of locals, variables, and string interpolation
+resource "cloudflare_workers_route" "complex_interpolation" {
+  zone_id = var.cloudflare_zone_id
+  pattern = "${local.name_prefix}-${replace("test.domain", ".", "-")}.cf-tf-test.com/*"
+}
+
+###############################################################################
+# Summary: Test Coverage
+###############################################################################
+# Total resources: 25+ instances across all patterns
+# - Routes without script_name (catch-all/fallback): 25+ instances
+# - for_each with maps: 2 instances (api_routes)
+# - for_each with sets: 2 instances (admin_routes)
+# - count-based: 3 instances (numbered)
+# - Conditional: 1 instance
+# - Variable references: multiple
+# - Special patterns: wildcard, exact paths, query params, special chars
+# - Environment configs: 3 instances (prod/staging/dev)
+###############################################################################
+
+variable "from_version" {
+  description = "Provider version under test, used to namespace resource names"
+  type        = string
+}

--- a/e2e-v5/testdata/workers_custom_domain/workers_custom_domain.tf
+++ b/e2e-v5/testdata/workers_custom_domain/workers_custom_domain.tf
@@ -1,0 +1,45 @@
+variable "cloudflare_account_id" {
+  description = "Cloudflare account ID"
+  type        = string
+}
+
+variable "cloudflare_zone_id" {
+  description = "Cloudflare zone ID"
+  type        = string
+}
+
+variable "cloudflare_domain" {
+  description = "Cloudflare domain for testing"
+  type        = string
+}
+
+locals {
+  name_prefix          = "v5-upgrade-${replace(var.from_version, ".", "-")}"
+  workers_service_name = "${local.name_prefix}-workers-custom-domain-${substr(var.cloudflare_account_id, 0, 8)}"
+  workers_hostname     = "${local.name_prefix}-workers-custom-domain-${substr(var.cloudflare_account_id, 0, 8)}.${var.cloudflare_domain}"
+  workers_content      = "addEventListener('fetch', event => { event.respondWith(new Response('ok')); });"
+}
+
+# Prerequisite Worker service for domain attachment.
+resource "cloudflare_workers_script" "service" {
+  account_id  = var.cloudflare_account_id
+  content     = local.workers_content
+  script_name = local.workers_service_name
+}
+
+
+resource "cloudflare_workers_custom_domain" "example" {
+  account_id  = var.cloudflare_account_id
+  hostname    = local.workers_hostname
+  service     = local.workers_service_name
+  zone_id     = var.cloudflare_zone_id
+  environment = "production"
+
+  depends_on = [cloudflare_workers_script.service]
+}
+
+
+variable "from_version" {
+  description = "Provider version under test, used to namespace resource names"
+  type        = string
+}

--- a/e2e-v5/testdata/workers_for_platforms_dispatch_namespace/workers_for_platforms_dispatch_namespace.tf
+++ b/e2e-v5/testdata/workers_for_platforms_dispatch_namespace/workers_for_platforms_dispatch_namespace.tf
@@ -1,0 +1,308 @@
+# Comprehensive Integration Tests for workers_for_platforms_dispatch_namespace
+# Target: 15-30+ resource instances covering all Terraform patterns
+
+# Variables (no defaults - must be provided by test framework or user)
+variable "cloudflare_account_id" {
+  description = "Cloudflare account ID"
+  type        = string
+}
+
+variable "cloudflare_zone_id" {
+  description = "Cloudflare zone ID"
+  type        = string
+}
+
+variable "cloudflare_domain" {
+  description = "Cloudflare domain for testing"
+  type        = string
+}
+
+# Locals for test resource naming
+locals {
+  name_prefix = "v5-upgrade-${replace(var.from_version, ".", "-")}"
+}
+
+# ==============================================================================
+# Pattern 1: Basic Resources (minimal and full configurations)
+# ==============================================================================
+
+# Test 1: Minimal configuration (required fields only)
+resource "cloudflare_workers_for_platforms_dispatch_namespace" "minimal" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-full-namespace"
+}
+
+# Test 3: With special characters in name
+resource "cloudflare_workers_for_platforms_dispatch_namespace" "special_chars" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-namespace-2024"
+}
+
+# Test 4: With hyphens and underscores
+resource "cloudflare_workers_for_platforms_dispatch_namespace" "naming_variations" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-my_test-namespace"
+}
+
+# ==============================================================================
+# Pattern 2-3: for_each with maps and sets
+# ==============================================================================
+
+# Test 5-9: for_each with map (5 instances)
+locals {
+  namespace_map = {
+    production  = "${local.name_prefix}-prod-namespace"
+    staging     = "${local.name_prefix}-staging-namespace"
+    development = "${local.name_prefix}-dev-namespace"
+    testing     = "${local.name_prefix}-test-namespace"
+    demo        = "${local.name_prefix}-demo-namespace"
+  }
+}
+
+resource "cloudflare_workers_for_platforms_dispatch_namespace" "for_each_map" {
+  for_each   = local.namespace_map
+  account_id = var.cloudflare_account_id
+  name       = each.value
+}
+
+# Test 10-14: for_each with set (5 instances)
+locals {
+  namespace_set = toset([
+    "${local.name_prefix}-api-namespace",
+    "${local.name_prefix}-web-namespace",
+    "${local.name_prefix}-mobile-namespace",
+    "${local.name_prefix}-backend-namespace",
+    "${local.name_prefix}-frontend-namespace",
+  ])
+}
+
+resource "cloudflare_workers_for_platforms_dispatch_namespace" "for_each_set" {
+  for_each   = local.namespace_set
+  account_id = var.cloudflare_account_id
+  name       = each.value
+}
+
+# ==============================================================================
+# Pattern 4: count-based resources
+# ==============================================================================
+
+# Test 15-19: count with index (5 instances)
+resource "cloudflare_workers_for_platforms_dispatch_namespace" "count_basic" {
+  count      = 5
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-namespace-${count.index}"
+}
+
+# ==============================================================================
+# Pattern 5: Conditional resource creation
+# ==============================================================================
+
+# Test 20: Conditional with count (1 instance when true)
+variable "create_optional_namespace" {
+  type    = bool
+  default = true
+}
+
+resource "cloudflare_workers_for_platforms_dispatch_namespace" "conditional" {
+  count      = var.create_optional_namespace ? 1 : 0
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-conditional-namespace"
+}
+
+# ==============================================================================
+# Pattern 6: Cross-resource references
+# ==============================================================================
+
+# Test 21: Reference to another resource's attribute
+resource "cloudflare_workers_for_platforms_dispatch_namespace" "primary" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-primary-namespace"
+}
+
+# Test 22: Uses primary's account_id (cross-reference)
+resource "cloudflare_workers_for_platforms_dispatch_namespace" "secondary" {
+  account_id = cloudflare_workers_for_platforms_dispatch_namespace.primary.account_id
+  name       = "${local.name_prefix}-secondary-namespace"
+}
+
+# ==============================================================================
+# Pattern 7: Lifecycle meta-arguments
+# ==============================================================================
+
+# Test 23: With create_before_destroy
+resource "cloudflare_workers_for_platforms_dispatch_namespace" "lifecycle_cbd" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-cbd-namespace"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+# Test 24: With ignore_changes
+resource "cloudflare_workers_for_platforms_dispatch_namespace" "lifecycle_ignore" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-ignore-namespace"
+
+  lifecycle {
+    ignore_changes = [name]
+  }
+}
+
+# Test 25: With prevent_destroy
+resource "cloudflare_workers_for_platforms_dispatch_namespace" "lifecycle_prevent" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-prevent-namespace"
+
+  lifecycle {
+    prevent_destroy = false # Must be false for tests to clean up
+  }
+}
+
+# ==============================================================================
+# Pattern 8: Terraform functions
+# ==============================================================================
+
+# Test 26: Using join() function
+locals {
+  namespace_parts = ["${local.name_prefix}", "joined", "namespace"]
+}
+
+resource "cloudflare_workers_for_platforms_dispatch_namespace" "func_join" {
+  account_id = var.cloudflare_account_id
+  name       = join("-", local.namespace_parts)
+}
+
+# Test 27: Using format() function
+resource "cloudflare_workers_for_platforms_dispatch_namespace" "func_format" {
+  account_id = var.cloudflare_account_id
+  name       = format("%s-formatted-%02d", local.name_prefix, 1)
+}
+
+# Test 28: Using lower() function
+resource "cloudflare_workers_for_platforms_dispatch_namespace" "func_lower" {
+  account_id = var.cloudflare_account_id
+  name       = lower("${local.name_prefix}-LOWERCASE-namespace")
+}
+
+# Test 29: Using replace() function
+resource "cloudflare_workers_for_platforms_dispatch_namespace" "func_replace" {
+  account_id = var.cloudflare_account_id
+  name       = replace("${local.name_prefix}_underscore_namespace", "_", "-")
+}
+
+# ==============================================================================
+# Pattern 9: String interpolation and expressions
+# ==============================================================================
+
+# Test 30: Complex string interpolation
+locals {
+  environment = "production"
+  region      = "us-east"
+}
+
+resource "cloudflare_workers_for_platforms_dispatch_namespace" "interpolation" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-${local.environment}-${local.region}-namespace"
+}
+
+# ==============================================================================
+# Edge Cases and Special Scenarios
+# ==============================================================================
+
+# Test 31: Very long name (test length limits)
+resource "cloudflare_workers_for_platforms_dispatch_namespace" "long_name" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-very-long-namespace-name-to-test-limits"
+}
+
+# Test 32: Name with numbers
+resource "cloudflare_workers_for_platforms_dispatch_namespace" "with_numbers" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-namespace-12345"
+}
+
+# Test 33: Depends_on meta-argument
+resource "cloudflare_workers_for_platforms_dispatch_namespace" "depends_base" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-depends-base"
+}
+
+resource "cloudflare_workers_for_platforms_dispatch_namespace" "depends_derived" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-depends-derived"
+
+  depends_on = [cloudflare_workers_for_platforms_dispatch_namespace.depends_base]
+}
+
+# ==============================================================================
+# Pattern 10: Deprecated Resource Name (cloudflare_workers_for_platforms_namespace)
+# These resources use the deprecated v4 name and should be renamed during migration
+# ==============================================================================
+
+
+# Test 36-38: Deprecated resource with for_each (3 instances)
+locals {
+  deprecated_map = {
+    alpha = "${local.name_prefix}-deprecated-alpha"
+    beta  = "${local.name_prefix}-deprecated-beta"
+    gamma = "${local.name_prefix}-deprecated-gamma"
+  }
+}
+
+
+
+
+# ==============================================================================
+# Summary: 42 total resource instances
+# ==============================================================================
+# - Pattern 1 (Basic): 4 instances
+# - Pattern 2 (for_each map): 5 instances
+# - Pattern 3 (for_each set): 5 instances
+# - Pattern 4 (count): 5 instances
+# - Pattern 5 (conditional): 1 instance
+# - Pattern 6 (cross-reference): 2 instances
+# - Pattern 7 (lifecycle): 3 instances
+# - Pattern 8 (functions): 4 instances
+# - Pattern 9 (interpolation): 1 instance
+# - Edge cases: 4 instances
+# - Pattern 10 (deprecated name): 8 instances
+# Total: 42 instances (exceeds 15-30 target)
+
+# Test 35: Basic deprecated resource name
+resource "cloudflare_workers_for_platforms_dispatch_namespace" "deprecated_basic" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-deprecated-basic"
+}
+
+
+resource "cloudflare_workers_for_platforms_dispatch_namespace" "deprecated_for_each" {
+  for_each   = local.deprecated_map
+  account_id = var.cloudflare_account_id
+  name       = each.value
+}
+
+
+# Test 39-41: Deprecated resource with count (3 instances)
+resource "cloudflare_workers_for_platforms_dispatch_namespace" "deprecated_count" {
+  count      = 3
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-deprecated-count-${count.index}"
+}
+
+
+# Test 42: Deprecated resource with lifecycle
+resource "cloudflare_workers_for_platforms_dispatch_namespace" "deprecated_lifecycle" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-deprecated-lifecycle"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+
+variable "from_version" {
+  description = "Provider version under test, used to namespace resource names"
+  type        = string
+}

--- a/e2e-v5/testdata/workers_kv/workers_kv.tf
+++ b/e2e-v5/testdata/workers_kv/workers_kv.tf
@@ -1,0 +1,265 @@
+locals {
+  name_prefix = "v5-upgrade-${replace(var.from_version, ".", "-")}"
+}
+
+variable "cloudflare_account_id" {
+  description = "Cloudflare account ID"
+  type        = string
+}
+
+variable "cloudflare_zone_id" {
+  description = "Cloudflare zone ID"
+  type        = string
+}
+
+variable "cloudflare_domain" {
+  description = "Cloudflare domain for testing"
+  type        = string
+}
+
+# Locals for reusable values
+locals {
+  common_account   = var.cloudflare_account_id
+  namespace_prefix = "${local.name_prefix}-kv"
+  test_keys = [
+    "config_key_1",
+    "config_key_2",
+    "config_key_3"
+  ]
+  enable_optional = true
+  disable_test    = false
+}
+
+# Parent resource: KV Namespace for dependency testing
+resource "cloudflare_workers_kv_namespace" "test_namespace" {
+  account_id = local.common_account
+  title      = "${local.namespace_prefix}-namespace-primary"
+}
+
+# Pattern Group 1: Basic Resources
+# Test Case 1: Minimal resource (only required fields)
+resource "cloudflare_workers_kv" "minimal" {
+  account_id   = var.cloudflare_account_id
+  namespace_id = cloudflare_workers_kv_namespace.test_namespace.id
+  value        = "minimal_value"
+  key_name     = "minimal_key"
+}
+
+# Test Case 2: Basic resource with cross-resource reference
+resource "cloudflare_workers_kv" "basic" {
+  account_id   = var.cloudflare_account_id
+  namespace_id = cloudflare_workers_kv_namespace.test_namespace.id
+  value        = "config_value"
+  key_name     = "config_key"
+}
+
+# Test Case 3: KV with special characters in key
+resource "cloudflare_workers_kv" "special_chars" {
+  account_id   = var.cloudflare_account_id
+  namespace_id = cloudflare_workers_kv_namespace.test_namespace.id
+  value        = "{\"api_key\": \"test123\", \"endpoint\": \"https://api.cf-tf-test.com\"}"
+  key_name     = "api/token"
+}
+
+# Test Case 4: KV with empty value
+resource "cloudflare_workers_kv" "empty_value" {
+  account_id   = var.cloudflare_account_id
+  namespace_id = cloudflare_workers_kv_namespace.test_namespace.id
+  value        = ""
+  key_name     = "placeholder"
+}
+
+# Test Case 5: KV with special characters in value
+resource "cloudflare_workers_kv" "special_value" {
+  account_id   = var.cloudflare_account_id
+  namespace_id = cloudflare_workers_kv_namespace.test_namespace.id
+  value        = "Line 1\nLine 2\tTabbed\r\nWindows line"
+  key_name     = "special_value_key"
+}
+
+# Pattern Group 2: for_each with Maps (3-5 resources)
+resource "cloudflare_workers_kv" "map_example" {
+  for_each = {
+    "config1" = {
+      key   = "map_config_1"
+      value = "Config value 1"
+    }
+    "config2" = {
+      key   = "map_config_2"
+      value = "Config value 2"
+    }
+    "config3" = {
+      key   = "map_config_3"
+      value = "Config value 3"
+    }
+    "config4" = {
+      key   = "map_config_4"
+      value = "Config value 4"
+    }
+  }
+
+  account_id   = var.cloudflare_account_id
+  namespace_id = cloudflare_workers_kv_namespace.test_namespace.id
+  value        = each.value.value
+  key_name     = each.value.key
+}
+
+# Pattern Group 3: for_each with Sets (3-5 items)
+resource "cloudflare_workers_kv" "set_example" {
+  for_each = toset([
+    "alpha",
+    "beta",
+    "gamma",
+    "delta"
+  ])
+
+  account_id   = var.cloudflare_account_id
+  namespace_id = cloudflare_workers_kv_namespace.test_namespace.id
+  value        = "Value for ${each.value}"
+  key_name     = "set-${each.value}"
+}
+
+# Pattern Group 4: count-based Resources (at least 3)
+resource "cloudflare_workers_kv" "counted" {
+  count = 3
+
+  account_id   = var.cloudflare_account_id
+  namespace_id = cloudflare_workers_kv_namespace.test_namespace.id
+  value        = "This is count resource number ${count.index}"
+  key_name     = "counted-${count.index}"
+}
+
+# Pattern Group 5: Conditional Creation
+resource "cloudflare_workers_kv" "conditional_enabled" {
+  count = local.enable_optional ? 1 : 0
+
+  account_id   = var.cloudflare_account_id
+  namespace_id = cloudflare_workers_kv_namespace.test_namespace.id
+  value        = "This resource is conditionally created"
+  key_name     = "conditional_enabled_key"
+}
+
+resource "cloudflare_workers_kv" "conditional_disabled" {
+  count = local.disable_test ? 1 : 0
+
+  account_id   = var.cloudflare_account_id
+  namespace_id = cloudflare_workers_kv_namespace.test_namespace.id
+  value        = "This resource should NOT be created"
+  key_name     = "conditional_disabled_key"
+}
+
+# Pattern Group 6: Terraform Functions
+resource "cloudflare_workers_kv" "with_functions" {
+  account_id   = var.cloudflare_account_id
+  namespace_id = cloudflare_workers_kv_namespace.test_namespace.id
+
+
+  # String interpolation with account ID
+  value    = "Resource for account ${var.cloudflare_account_id}"
+  key_name = join("-", ["test", "function", "key"])
+}
+
+resource "cloudflare_workers_kv" "with_base64" {
+  account_id   = var.cloudflare_account_id
+  namespace_id = cloudflare_workers_kv_namespace.test_namespace.id
+
+  # base64encode() function
+  value    = base64encode("This is a base64 encoded value for testing")
+  key_name = "encoded_key"
+}
+
+# Pattern Group 7: Lifecycle Meta-Arguments
+resource "cloudflare_workers_kv" "with_lifecycle" {
+  account_id   = var.cloudflare_account_id
+  namespace_id = cloudflare_workers_kv_namespace.test_namespace.id
+  value        = "Testing lifecycle rules"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+  key_name = "lifecycle_test_key"
+}
+
+resource "cloudflare_workers_kv" "with_ignore_changes" {
+  account_id   = var.cloudflare_account_id
+  namespace_id = cloudflare_workers_kv_namespace.test_namespace.id
+  value        = "Value that might change"
+
+  lifecycle {
+    ignore_changes = [value]
+  }
+  key_name = "ignore_changes_key"
+}
+
+# Pattern Group 8: Edge Cases
+# Large value (approaching 25 MiB limit - using a smaller 1KB sample)
+resource "cloudflare_workers_kv" "large_value" {
+  account_id   = var.cloudflare_account_id
+  namespace_id = cloudflare_workers_kv_namespace.test_namespace.id
+  value        = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt."
+  key_name     = "large_value_key"
+}
+
+# Key with URL encoding special cases
+#resource "cloudflare_workers_kv" "url_encoded_key" {
+#  account_id   = var.cloudflare_account_id
+#  namespace_id = cloudflare_workers_kv_namespace.test_namespace.id
+#  key          = "path/to/resource?query=value&param=test"
+#  value        = "Value for URL-like key"
+#}
+
+# Key with Unicode characters
+resource "cloudflare_workers_kv" "unicode_key" {
+  account_id   = var.cloudflare_account_id
+  namespace_id = cloudflare_workers_kv_namespace.test_namespace.id
+  value        = "Unicode test value: 你好世界"
+  key_name     = "unicode_测试_key"
+}
+
+# Value with JSON
+resource "cloudflare_workers_kv" "json_value" {
+  account_id   = var.cloudflare_account_id
+  namespace_id = cloudflare_workers_kv_namespace.test_namespace.id
+  value = jsonencode({
+    name    = "test"
+    enabled = true
+    count   = 42
+    tags    = ["tag1", "tag2", "tag3"]
+  })
+  key_name = "json_data"
+}
+
+# Pattern Group 9: Multiple Resources with Dependencies
+resource "cloudflare_workers_kv_namespace" "secondary_namespace" {
+  account_id = var.cloudflare_account_id
+  title      = "${local.namespace_prefix}-secondary"
+}
+
+resource "cloudflare_workers_kv" "secondary_ns_kv1" {
+  account_id   = var.cloudflare_account_id
+  namespace_id = cloudflare_workers_kv_namespace.secondary_namespace.id
+  value        = "Value in secondary namespace 1"
+  key_name     = "secondary_key_1"
+}
+
+resource "cloudflare_workers_kv" "secondary_ns_kv2" {
+  account_id   = var.cloudflare_account_id
+  namespace_id = cloudflare_workers_kv_namespace.secondary_namespace.id
+  value        = "Value in secondary namespace 2"
+  key_name     = "secondary_key_2"
+}
+
+# Using local values in keys
+resource "cloudflare_workers_kv" "with_locals" {
+  count = length(local.test_keys)
+
+  account_id   = var.cloudflare_account_id
+  namespace_id = cloudflare_workers_kv_namespace.test_namespace.id
+  value        = "Value for ${local.test_keys[count.index]}"
+  key_name     = local.test_keys[count.index]
+}
+
+variable "from_version" {
+  description = "Provider version under test, used to namespace resource names"
+  type        = string
+}

--- a/e2e-v5/testdata/workers_kv_namespace/workers_kv_namespace.tf
+++ b/e2e-v5/testdata/workers_kv_namespace/workers_kv_namespace.tf
@@ -1,0 +1,191 @@
+# Comprehensive Integration Tests for workers_kv_namespace v4 to v5 Migration
+# Covers all mandatory patterns from subtask 08
+
+# Pattern Group 1: Variables & Locals (Lines 1-25)
+variable "cloudflare_account_id" {
+  description = "Cloudflare account ID"
+  type        = string
+}
+
+variable "cloudflare_zone_id" {
+  description = "Cloudflare zone ID"
+  type        = string
+}
+
+variable "cloudflare_domain" {
+  description = "Cloudflare domain for testing"
+  type        = string
+}
+
+locals {
+  common_account = var.cloudflare_account_id
+  name_prefix    = "v5-upgrade-${replace(var.from_version, ".", "-")}"
+  tags           = ["test", "migration", "v4_to_v5"]
+  environments   = ["dev", "staging", "prod"]
+}
+
+# Pattern Group 2: for_each with Maps (3 instances)
+resource "cloudflare_workers_kv_namespace" "map_example" {
+  for_each = {
+    "cache" = {
+      title = "Cache Store"
+    }
+    "session" = {
+      title = "Session Store"
+    }
+    "config" = {
+      title = "Configuration Store"
+    }
+  }
+
+  account_id = local.common_account
+  title      = "${local.name_prefix}-${each.value.title}"
+}
+
+# Pattern Group 3: for_each with Sets (4 instances)
+resource "cloudflare_workers_kv_namespace" "set_example" {
+  for_each = toset([
+    "alpha",
+    "beta",
+    "gamma",
+    "delta"
+  ])
+
+  account_id = var.cloudflare_account_id
+  title      = "${local.name_prefix}-set-${each.value}-namespace"
+}
+
+# Pattern Group 4: count-based Resources (3 instances)
+resource "cloudflare_workers_kv_namespace" "counted" {
+  count = 3
+
+  account_id = var.cloudflare_account_id
+  title      = "${local.name_prefix}-counted-namespace-${count.index}"
+}
+
+# Pattern Group 5: Conditional Creation (1 instance created, 1 not created)
+locals {
+  enable_feature = true
+  enable_test    = false
+}
+
+resource "cloudflare_workers_kv_namespace" "conditional_enabled" {
+  count = local.enable_feature ? 1 : 0
+
+  account_id = var.cloudflare_account_id
+  title      = "${local.name_prefix}-conditional-enabled-namespace"
+}
+
+resource "cloudflare_workers_kv_namespace" "conditional_disabled" {
+  count = local.enable_test ? 1 : 0
+
+  account_id = var.cloudflare_account_id
+  title      = "${local.name_prefix}-conditional-disabled-namespace"
+}
+
+# Pattern Group 6: Terraform Functions (3 instances)
+resource "cloudflare_workers_kv_namespace" "with_join" {
+  account_id = var.cloudflare_account_id
+  title      = join("-", [local.name_prefix, "workers", "kv", "joined"])
+}
+
+resource "cloudflare_workers_kv_namespace" "with_format" {
+  account_id = var.cloudflare_account_id
+  title      = "${local.name_prefix}-formatted-namespace-001"
+}
+
+resource "cloudflare_workers_kv_namespace" "with_interpolation" {
+  account_id = var.cloudflare_account_id
+  title      = "${local.name_prefix}-namespace-for-account-${var.cloudflare_account_id}"
+}
+
+# Pattern Group 7: Lifecycle Meta-Arguments (2 instances)
+resource "cloudflare_workers_kv_namespace" "with_lifecycle" {
+  account_id = var.cloudflare_account_id
+  title      = "${local.name_prefix}-lifecycle-test-namespace"
+
+  lifecycle {
+    create_before_destroy = true
+    ignore_changes        = [title]
+  }
+}
+
+resource "cloudflare_workers_kv_namespace" "with_prevent_destroy" {
+  account_id = var.cloudflare_account_id
+  title      = "${local.name_prefix}-prevent-destroy-namespace"
+
+  lifecycle {
+    prevent_destroy = false
+  }
+}
+
+# Pattern Group 8: Edge Cases
+
+# Minimal resource (only required fields)
+resource "cloudflare_workers_kv_namespace" "minimal" {
+  account_id = var.cloudflare_account_id
+  title      = "${local.name_prefix}-minimal"
+}
+
+# Resource with special characters in title
+resource "cloudflare_workers_kv_namespace" "special_chars" {
+  account_id = var.cloudflare_account_id
+  title      = "${local.name_prefix}_namespace-with.special-chars!2024"
+}
+
+# Resource with spaces in title
+resource "cloudflare_workers_kv_namespace" "with_spaces" {
+  account_id = var.cloudflare_account_id
+  title      = "${local.name_prefix} My Workers KV Namespace With Spaces"
+}
+
+# Resource with very long title
+resource "cloudflare_workers_kv_namespace" "long_title" {
+  account_id = var.cloudflare_account_id
+  title      = "${local.name_prefix}-very-long-namespace-title-that-tests-maximum-length-handling"
+}
+
+# Resource with unicode characters
+resource "cloudflare_workers_kv_namespace" "unicode" {
+  account_id = var.cloudflare_account_id
+  title      = "${local.name_prefix}-namespace-with-émojis-🚀-and-spëcial-chàrs"
+}
+
+# Pattern Group 9: Production-like Patterns
+
+# Using locals for common values
+resource "cloudflare_workers_kv_namespace" "from_locals" {
+  account_id = local.common_account
+  title      = "${local.name_prefix}-from-locals"
+}
+
+# Variable-driven configuration
+resource "cloudflare_workers_kv_namespace" "variable_driven" {
+  account_id = var.cloudflare_account_id
+  title      = "${local.name_prefix}-namespace-${var.cloudflare_zone_id}"
+}
+
+# Total instances: 23
+# - map_example: 3 instances (cache, session, config)
+# - set_example: 4 instances (alpha, beta, gamma, delta)
+# - counted: 3 instances (0, 1, 2)
+# - conditional_enabled: 1 instance
+# - conditional_disabled: 0 instances (not created)
+# - with_join: 1 instance
+# - with_format: 1 instance
+# - with_interpolation: 1 instance
+# - with_lifecycle: 1 instance
+# - with_prevent_destroy: 1 instance
+# - minimal: 1 instance
+# - special_chars: 1 instance
+# - with_spaces: 1 instance
+# - long_title: 1 instance
+# - unicode: 1 instance
+# - from_locals: 1 instance
+# - variable_driven: 1 instance
+# Total: 23 instances (excluding conditional_disabled which has count = 0)
+
+variable "from_version" {
+  description = "Provider version under test, used to namespace resource names"
+  type        = string
+}

--- a/e2e-v5/testdata/workers_script/workers_script.tf
+++ b/e2e-v5/testdata/workers_script/workers_script.tf
@@ -1,3 +1,4 @@
+
 variable "cloudflare_account_id" {
   description = "Cloudflare account ID"
   type        = string
@@ -51,10 +52,12 @@ resource "cloudflare_r2_bucket" "test_r2" {
 # ========================================
 
 locals {
-  name_prefix    = "v5-upgrade-${replace(var.from_version, ".", "-")}"
-  worker_prefix  = local.name_prefix
-  common_content = "addEventListener('fetch', event => { event.respondWith(new Response('Hello World')); });"
-  script_names   = ["worker-1", "worker-2", "worker-3"]
+  name_prefix                   = "v5-upgrade-${replace(var.from_version, ".", "-")}"
+  worker_prefix                 = local.name_prefix
+  common_content                = "addEventListener('fetch', event => { event.respondWith(new Response('Hello World')); });"
+  script_names                  = ["worker-1", "worker-2", "worker-3"]
+  legacy_module_upload_versions = ["5.17.0", "5.18.0"]
+  use_legacy_worker_upload      = contains(local.legacy_module_upload_versions, var.from_version)
 
   # Complex expression
   full_worker_name = "${local.worker_prefix}-main"
@@ -227,12 +230,12 @@ resource "cloudflare_workers_script" "module_false" {
 
 resource "cloudflare_workers_script" "placement" {
   account_id = var.cloudflare_account_id
-  content    = "export default { fetch(request) { return new Response('Hello World'); } }"
+  content    = local.use_legacy_worker_upload ? local.common_content : "export default { fetch(request) { return new Response('Hello World'); } }"
 
   script_name        = "${local.name_prefix}-placement-worker"
-  main_module        = "worker.js"
+  main_module        = local.use_legacy_worker_upload ? null : "worker.js"
   compatibility_date = "2025-01-01"
-  placement = var.from_version == "5.18.0" ? null : {
+  placement = local.use_legacy_worker_upload ? null : {
     mode = "smart"
   }
 }
@@ -261,7 +264,7 @@ resource "cloudflare_workers_script" "tags" {
 
 resource "cloudflare_workers_script" "comprehensive" {
   account_id = var.cloudflare_account_id
-  content    = "export default { fetch(request) { return new Response('Hello World'); } }"
+  content    = local.use_legacy_worker_upload ? local.common_content : "export default { fetch(request) { return new Response('Hello World'); } }"
 
 
 
@@ -282,9 +285,9 @@ resource "cloudflare_workers_script" "comprehensive" {
       namespace_id = cloudflare_workers_kv_namespace.test_kv.id
     }
   ]
-  main_module        = "worker.js"
+  main_module        = local.use_legacy_worker_upload ? null : "worker.js"
   compatibility_date = "2025-01-01"
-  placement = var.from_version == "5.18.0" ? null : {
+  placement = local.use_legacy_worker_upload ? null : {
     mode = "smart"
   }
 }

--- a/e2e-v5/testdata/workers_script/workers_script.tf
+++ b/e2e-v5/testdata/workers_script/workers_script.tf
@@ -1,0 +1,642 @@
+variable "cloudflare_account_id" {
+  description = "Cloudflare account ID"
+  type        = string
+}
+
+variable "cloudflare_zone_id" {
+  description = "Cloudflare zone ID"
+  type        = string
+}
+
+variable "cloudflare_domain" {
+  description = "Cloudflare domain for testing"
+  type        = string
+}
+
+# ========================================
+# Dependencies - KV Namespaces
+# ========================================
+
+resource "cloudflare_workers_kv_namespace" "test_kv" {
+  account_id = var.cloudflare_account_id
+  title      = "${local.name_prefix}-kv-namespace-for-workers-script"
+}
+
+resource "cloudflare_workers_kv_namespace" "test_kv_multiple" {
+  count      = 2
+  account_id = var.cloudflare_account_id
+  title      = "${local.name_prefix}-kv-${count.index}"
+}
+
+# ========================================
+# Dependencies - Queues
+# ========================================
+
+resource "cloudflare_queue" "test_queue" {
+  account_id = var.cloudflare_account_id
+  queue_name = "${local.name_prefix}-queue"
+}
+
+# ========================================
+# Dependencies - R2 Buckets
+# ========================================
+
+resource "cloudflare_r2_bucket" "test_r2" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-workers-script-r2-bucket"
+}
+
+# ========================================
+# Local Values
+# ========================================
+
+locals {
+  name_prefix    = "v5-upgrade-${replace(var.from_version, ".", "-")}"
+  worker_prefix  = local.name_prefix
+  common_content = "addEventListener('fetch', event => { event.respondWith(new Response('Hello World')); });"
+  script_names   = ["worker-1", "worker-2", "worker-3"]
+
+  # Complex expression
+  full_worker_name = "${local.worker_prefix}-main"
+}
+
+# ========================================
+# Variables for Testing
+# ========================================
+
+variable "worker_content" {
+  type    = string
+  default = "addEventListener('fetch', event => { event.respondWith(new Response('Test')); });"
+}
+
+variable "enable_analytics" {
+  type    = bool
+  default = true
+}
+
+# ========================================
+# Pattern 1: Simple worker with plain_text_binding
+# ========================================
+
+resource "cloudflare_workers_script" "plain_text" {
+  account_id = var.cloudflare_account_id
+  content    = local.common_content
+
+  script_name = "${local.name_prefix}-plain-text-worker"
+  bindings = [
+    {
+      type = "plain_text"
+      name = "MY_VAR"
+      text = "my-value"
+    }
+  ]
+}
+
+# ========================================
+# Pattern 2: Worker with secret_text_binding
+# ========================================
+
+resource "cloudflare_workers_script" "secret_text" {
+  account_id = var.cloudflare_account_id
+  content    = local.common_content
+
+  script_name = "${local.name_prefix}-secret-text-worker"
+  bindings = [
+    {
+      type = "secret_text"
+      name = "API_KEY"
+      text = "secret-api-key-value"
+    }
+  ]
+}
+
+# ========================================
+# Pattern 3: Worker with kv_namespace_binding
+# ========================================
+
+resource "cloudflare_workers_script" "kv_namespace" {
+  account_id = var.cloudflare_account_id
+  content    = local.common_content
+
+  script_name = "${local.name_prefix}-kv-worker"
+  bindings = [
+    {
+      type         = "kv_namespace"
+      name         = "MY_KV"
+      namespace_id = cloudflare_workers_kv_namespace.test_kv.id
+    }
+  ]
+}
+
+# ========================================
+# Pattern 5: Worker with r2_bucket_binding
+# ========================================
+
+resource "cloudflare_workers_script" "r2_bucket" {
+  account_id = var.cloudflare_account_id
+  content    = local.common_content
+
+  script_name = "${local.name_prefix}-r2-worker"
+  bindings = [
+    {
+      type        = "r2_bucket"
+      name        = "MY_BUCKET"
+      bucket_name = cloudflare_r2_bucket.test_r2.name
+    }
+  ]
+}
+
+# ========================================
+# Pattern 7: Worker with analytics_engine_binding
+# ========================================
+
+resource "cloudflare_workers_script" "analytics_engine" {
+  account_id = var.cloudflare_account_id
+  content    = local.common_content
+
+  script_name = "${local.name_prefix}-analytics-worker"
+  bindings = [
+    {
+      type    = "analytics_engine"
+      name    = "MY_ANALYTICS"
+      dataset = "analytics_dataset"
+    }
+  ]
+}
+
+# ========================================
+# Pattern 8: Worker with queue_binding (binding → name, queue → queue_name)
+# ========================================
+
+resource "cloudflare_workers_script" "queue" {
+  account_id = var.cloudflare_account_id
+  content    = local.common_content
+
+  script_name = "${local.name_prefix}-queue-worker"
+  bindings = [
+    {
+      type       = "queue"
+      name       = "MY_QUEUE"
+      queue_name = cloudflare_queue.test_queue.queue_name
+    }
+  ]
+}
+
+# ========================================
+# Pattern 9: Worker with multiple bindings (order preservation test)
+# ========================================
+
+resource "cloudflare_workers_script" "multiple_bindings" {
+  account_id = var.cloudflare_account_id
+  content    = local.common_content
+
+
+
+  script_name = "${local.name_prefix}-multiple-bindings-worker"
+  bindings = [
+    {
+      type = "plain_text"
+      name = "VAR_ONE"
+      text = "value-one"
+      }, {
+      type = "secret_text"
+      name = "SECRET_ONE"
+      text = "secret-value-one"
+      }, {
+      type         = "kv_namespace"
+      name         = "KV_ONE"
+      namespace_id = cloudflare_workers_kv_namespace.test_kv.id
+    }
+  ]
+}
+
+# ========================================
+# Pattern 10: Worker with module = false (becomes body_part)
+# ========================================
+
+resource "cloudflare_workers_script" "module_false" {
+  account_id  = var.cloudflare_account_id
+  content     = local.common_content
+  script_name = "${local.name_prefix}-module-false-worker"
+  body_part   = "worker.js"
+}
+
+# ========================================
+# Pattern 15: Worker with placement block (becomes object)
+# ========================================
+
+resource "cloudflare_workers_script" "placement" {
+  account_id = var.cloudflare_account_id
+  content    = "export default { fetch(request) { return new Response('Hello World'); } }"
+
+  script_name        = "${local.name_prefix}-placement-worker"
+  main_module        = "worker.js"
+  compatibility_date = "2025-01-01"
+  placement = var.from_version == "5.18.0" ? null : {
+    mode = "smart"
+  }
+}
+
+# ========================================
+# Pattern 16: Worker with tags (should be removed)
+# ========================================
+
+resource "cloudflare_workers_script" "tags" {
+  account_id = var.cloudflare_account_id
+  content    = local.common_content
+
+  script_name = "${local.name_prefix}-tags-worker"
+  bindings = [
+    {
+      type = "plain_text"
+      name = "VAR"
+      text = "value"
+    }
+  ]
+}
+
+# ========================================
+# Pattern 17: Comprehensive worker with all transformations
+# ========================================
+
+resource "cloudflare_workers_script" "comprehensive" {
+  account_id = var.cloudflare_account_id
+  content    = "export default { fetch(request) { return new Response('Hello World'); } }"
+
+
+
+
+  script_name = "${local.name_prefix}-comprehensive-worker"
+  bindings = [
+    {
+      type = "plain_text"
+      name = "PLAIN_VAR"
+      text = "plain-value"
+      }, {
+      type = "secret_text"
+      name = "SECRET_VAR"
+      text = "secret-value"
+      }, {
+      type         = "kv_namespace"
+      name         = "KV_NS"
+      namespace_id = cloudflare_workers_kv_namespace.test_kv.id
+    }
+  ]
+  main_module        = "worker.js"
+  compatibility_date = "2025-01-01"
+  placement = var.from_version == "5.18.0" ? null : {
+    mode = "smart"
+  }
+}
+
+# ========================================
+# Pattern 18: for_each with map
+# ========================================
+
+variable "worker_configs" {
+  type = map(object({
+    content   = string
+    var_value = string
+  }))
+  default = {
+    "worker-a" = {
+      content   = "addEventListener('fetch', e => { e.respondWith(new Response('A')); });"
+      var_value = "value-a"
+    }
+    "worker-b" = {
+      content   = "addEventListener('fetch', e => { e.respondWith(new Response('B')); });"
+      var_value = "value-b"
+    }
+    "worker-c" = {
+      content   = "addEventListener('fetch', e => { e.respondWith(new Response('C')); });"
+      var_value = "value-c"
+    }
+  }
+}
+
+resource "cloudflare_workers_script" "for_each_map" {
+  for_each = var.worker_configs
+
+  account_id = var.cloudflare_account_id
+  content    = each.value.content
+
+  script_name = "${local.name_prefix}-${each.key}"
+  bindings = [
+    {
+      type = "plain_text"
+      name = "CONFIG_VAR"
+      text = each.value.var_value
+    }
+  ]
+}
+
+# ========================================
+# Pattern 19: for_each with set
+# ========================================
+
+variable "simple_workers" {
+  type    = set(string)
+  default = ["simple-1", "simple-2", "simple-3"]
+}
+
+resource "cloudflare_workers_script" "for_each_set" {
+  for_each = var.simple_workers
+
+  account_id = var.cloudflare_account_id
+  content    = "addEventListener('fetch', e => { e.respondWith(new Response('${each.value}')); });"
+
+  script_name = "${local.name_prefix}-${each.value}"
+  bindings = [
+    {
+      type = "plain_text"
+      name = "WORKER_NAME"
+      text = each.value
+    }
+  ]
+}
+
+# ========================================
+# Pattern 20: Count-based resources
+# ========================================
+
+variable "replica_count" {
+  type    = number
+  default = 3
+}
+
+resource "cloudflare_workers_script" "count_based" {
+  count = var.replica_count
+
+  account_id = var.cloudflare_account_id
+  content    = local.common_content
+
+
+  script_name = "${local.name_prefix}-replica-${count.index}"
+  bindings = [
+    {
+      type = "plain_text"
+      name = "REPLICA_ID"
+      text = tostring(count.index)
+      }, {
+      type         = "kv_namespace"
+      name         = "KV"
+      namespace_id = cloudflare_workers_kv_namespace.test_kv_multiple[count.index % 2].id
+    }
+  ]
+}
+
+# ========================================
+# Pattern 21: Conditional resource creation
+# ========================================
+
+resource "cloudflare_workers_script" "conditional" {
+  count = var.enable_analytics ? 1 : 0
+
+  account_id = var.cloudflare_account_id
+  content    = local.common_content
+
+  script_name = "${local.name_prefix}-conditional-worker"
+  bindings = [
+    {
+      type    = "analytics_engine"
+      name    = "ANALYTICS"
+      dataset = "conditional_dataset"
+    }
+  ]
+}
+
+# ========================================
+# Pattern 22: Resource with lifecycle meta-arguments
+# ========================================
+
+resource "cloudflare_workers_script" "lifecycle" {
+  account_id = var.cloudflare_account_id
+  content    = local.common_content
+
+
+  lifecycle {
+    prevent_destroy       = false
+    create_before_destroy = true
+  }
+  script_name = "${local.name_prefix}-lifecycle-worker"
+  bindings = [
+    {
+      type = "plain_text"
+      name = "LIFECYCLE_VAR"
+      text = "protected"
+    }
+  ]
+}
+
+# ========================================
+# Pattern 23: Using terraform expressions in bindings
+# ========================================
+
+resource "cloudflare_workers_script" "conditional_binding" {
+  account_id = var.cloudflare_account_id
+  content    = var.enable_analytics ? local.common_content : var.worker_content
+
+
+  script_name = "${local.name_prefix}-conditional-binding-worker"
+  bindings = [
+    {
+      type = "plain_text"
+      name = "ENABLED"
+      text = var.enable_analytics ? "true" : "false"
+      }, {
+      type         = "kv_namespace"
+      name         = "KV"
+      namespace_id = cloudflare_workers_kv_namespace.test_kv.id
+    }
+  ]
+}
+
+# ========================================
+# Pattern 24: Cross-resource references with dependencies
+# ========================================
+
+resource "cloudflare_workers_script" "dependent" {
+  account_id = var.cloudflare_account_id
+  content    = local.common_content
+
+
+
+
+  script_name = "${local.name_prefix}-dependent-worker"
+  bindings = [
+    {
+      type         = "kv_namespace"
+      name         = "PRIMARY_KV"
+      namespace_id = cloudflare_workers_kv_namespace.test_kv.id
+      }, {
+      type         = "kv_namespace"
+      name         = "SECONDARY_KV"
+      namespace_id = cloudflare_workers_kv_namespace.test_kv_multiple[0].id
+      }, {
+      type        = "r2_bucket"
+      name        = "STORAGE"
+      bucket_name = cloudflare_r2_bucket.test_r2.name
+      }, {
+      type       = "queue"
+      name       = "JOBS"
+      queue_name = cloudflare_queue.test_queue.queue_name
+    }
+  ]
+}
+
+# ========================================
+# Pattern 25: Worker referencing local values extensively
+# ========================================
+
+resource "cloudflare_workers_script" "local_refs" {
+  account_id = var.cloudflare_account_id
+  content    = local.common_content
+
+  script_name = local.full_worker_name
+  bindings = [
+    {
+      type = "plain_text"
+      name = "PREFIX"
+      text = local.worker_prefix
+    }
+  ]
+}
+
+# ========================================
+# Pattern 26: Singular resource name (cloudflare_worker_script)
+# Tests resource rename: cloudflare_worker_script → cloudflare_workers_script
+# ========================================
+
+
+# ========================================
+# Pattern 27: Complex for_each with list transformation
+# ========================================
+
+variable "environment_configs" {
+  type = list(object({
+    env       = string
+    kv_index  = number
+    use_queue = bool
+  }))
+  default = [
+    {
+      env       = "dev"
+      kv_index  = 0
+      use_queue = true
+    },
+    {
+      env       = "staging"
+      kv_index  = 1
+      use_queue = true
+    },
+    {
+      env       = "prod"
+      kv_index  = 0
+      use_queue = false
+    }
+  ]
+}
+
+resource "cloudflare_workers_script" "environment" {
+  for_each = { for cfg in var.environment_configs : cfg.env => cfg }
+
+  account_id = var.cloudflare_account_id
+  content    = local.common_content
+
+
+
+  script_name = "${local.name_prefix}-${each.key}-worker"
+  bindings = concat([
+    {
+      type = "plain_text"
+      name = "ENVIRONMENT"
+      text = each.value.env
+      }, {
+      type         = "kv_namespace"
+      name         = "ENV_KV"
+      namespace_id = cloudflare_workers_kv_namespace.test_kv_multiple[each.value.kv_index].id
+    }
+    ], each.value.use_queue ? [{
+      type       = "queue"
+      name       = "ENV_QUEUE"
+      queue_name = cloudflare_queue.test_queue.queue_name
+  }] : [])
+}
+
+# ========================================
+# Pattern 28: Dynamic plain_text_binding
+# Tests dynamic block transformation with plain_text binding type
+# ========================================
+
+variable "enable_debug_mode" {
+  type    = bool
+  default = false
+}
+
+resource "cloudflare_workers_script" "dynamic_plain_text" {
+  account_id = var.cloudflare_account_id
+  content    = local.common_content
+
+
+  script_name = "${local.name_prefix}-dynamic-plain-text-worker"
+  bindings = concat([
+    {
+      type = "plain_text"
+      name = "STATIC_VAR"
+      text = "always-present"
+    }
+    ], var.enable_debug_mode ? [{
+      type = "plain_text"
+      name = "DEBUG_MODE"
+      text = "enabled"
+  }] : [])
+}
+
+# ========================================
+# Pattern 29: Dynamic kv_namespace_binding with conditional
+# Tests dynamic block transformation with kv_namespace binding type
+# ========================================
+
+variable "enable_kv_cache" {
+  type    = bool
+  default = true
+}
+
+resource "cloudflare_workers_script" "dynamic_kv" {
+  account_id = var.cloudflare_account_id
+  content    = local.common_content
+
+
+  script_name = "${local.name_prefix}-dynamic-kv-worker"
+  bindings = concat([
+    {
+      type = "plain_text"
+      name = "ALWAYS_PRESENT"
+      text = "yes"
+    }
+    ], var.enable_kv_cache ? [{
+      type         = "kv_namespace"
+      name         = "KV_CACHE"
+      namespace_id = cloudflare_workers_kv_namespace.test_kv.id
+  }] : [])
+}
+
+resource "cloudflare_workers_script" "singular_name" {
+  account_id = var.cloudflare_account_id
+  content    = local.common_content
+
+  script_name = "${local.name_prefix}-singular-resource"
+  bindings = [
+    {
+      type = "plain_text"
+      name = "SINGULAR"
+      text = "true"
+    }
+  ]
+}
+
+
+variable "from_version" {
+  description = "Provider version under test, used to namespace resource names"
+  type        = string
+}

--- a/e2e-v5/testdata/zero_trust_access_application/zero_trust_access_application.tf
+++ b/e2e-v5/testdata/zero_trust_access_application/zero_trust_access_application.tf
@@ -1,0 +1,459 @@
+variable "cloudflare_account_id" {
+  description = "Cloudflare account ID"
+  type        = string
+}
+
+variable "cloudflare_zone_id" {
+  description = "Cloudflare zone ID"
+  type        = string
+}
+
+variable "cloudflare_domain" {
+  description = "Cloudflare Domain"
+  type        = string
+}
+
+# Resource-specific variables with defaults
+variable "app_prefix" {
+  type    = string
+  default = "test"
+}
+
+variable "enable_saas_apps" {
+  type    = bool
+  default = true
+}
+
+variable "policy_ids" {
+  type    = list(string)
+  default = ["policy-1", "policy-2", "policy-3"]
+}
+
+# Locals with common values
+locals {
+  name_prefix       = "v5-upgrade-${replace(var.from_version, ".", "-")}-zta"
+  common_account_id = var.cloudflare_account_id
+  app_domain_suffix = var.cloudflare_domain
+  common_policies   = ["default-policy-id"]
+}
+
+# ============================================================================
+# Pattern Group 1: Basic Resources (Edge Cases)
+# ============================================================================
+
+# 1. Minimal resource - only required fields
+resource "cloudflare_zero_trust_access_application" "minimal" {
+  account_id                 = local.common_account_id
+  name                       = "${local.name_prefix} Minimal App"
+  domain                     = "${local.name_prefix}-minimal.${local.app_domain_suffix}"
+  type                       = "self_hosted"
+  http_only_cookie_attribute = "false"
+}
+
+# 2. Minimal with type specification
+resource "cloudflare_zero_trust_access_application" "minimal_self_hosted" {
+  account_id                 = local.common_account_id
+  name                       = "${local.name_prefix} Self Hosted"
+  domain                     = "${local.name_prefix}-self-hosted.${local.app_domain_suffix}"
+  type                       = "self_hosted"
+  http_only_cookie_attribute = "false"
+}
+
+# 3. Maximal self-hosted app - all common fields
+resource "cloudflare_zero_trust_access_application" "maximal_self_hosted" {
+  account_id                   = local.common_account_id
+  name                         = "${local.name_prefix} Maximal Self Hosted"
+  domain                       = "${local.name_prefix}-maximal.${local.app_domain_suffix}"
+  type                         = "self_hosted"
+  session_duration             = "24h"
+  enable_binding_cookie        = true
+  http_only_cookie_attribute   = true
+  same_site_cookie_attribute   = "strict"
+  custom_deny_url              = "https://${local.name_prefix}-deny.${local.app_domain_suffix}"
+  custom_deny_message          = "Access denied - contact admin"
+  custom_non_identity_deny_url = "https://${local.name_prefix}-login.${local.app_domain_suffix}"
+  skip_interstitial            = true
+  app_launcher_visible         = true
+  service_auth_401_redirect    = true
+
+  cors_headers = {
+    allowed_methods   = ["GET", "POST", "PUT", "DELETE"]
+    allowed_origins   = ["https://${local.name_prefix}-app.${local.app_domain_suffix}"]
+    allowed_headers   = ["Content-Type", "Authorization"]
+    allow_credentials = true
+    max_age           = 3600
+  }
+}
+
+# ============================================================================
+# Pattern Group 2: SAAS Applications
+# ============================================================================
+
+# 4. SAML SAAS app with full configuration
+resource "cloudflare_zero_trust_access_application" "saas_saml" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix} SAML SAAS"
+  type       = "saas"
+
+  saas_app = {
+    consumer_service_url = "https://${local.name_prefix}-saml.${local.app_domain_suffix}/sso/saml"
+    sp_entity_id         = "saml-app-${local.name_prefix}"
+    name_id_format       = "email"
+    custom_attributes = [
+      {
+        name = "email"
+        source = {
+          name = "user_email"
+        }
+      },
+      {
+        name          = "department"
+        friendly_name = "Department"
+        source = {
+          name = "department"
+        }
+      }
+    ]
+  }
+}
+
+# 5. OIDC SAAS app
+resource "cloudflare_zero_trust_access_application" "saas_oidc" {
+  account_id = local.common_account_id
+  name       = "${local.name_prefix} OIDC SAAS"
+  type       = "saas"
+
+  saas_app = {
+    auth_type        = "oidc"
+    app_launcher_url = "https://${local.name_prefix}-oidc.${local.app_domain_suffix}/launch"
+    grant_types      = ["authorization_code"]
+    scopes           = ["openid", "profile", "email"]
+    redirect_uris    = ["https://${local.name_prefix}-oidc.${local.app_domain_suffix}/callback"]
+    custom_claims = [
+      {
+        name  = "groups"
+        scope = "groups"
+        source = {
+          name = "user_groups"
+        }
+      }
+    ]
+    hybrid_and_implicit_options = {
+      return_access_token_from_authorization_endpoint = true
+      return_id_token_from_authorization_endpoint     = true
+    }
+    refresh_token_options = {
+      lifetime = "2160h"
+    }
+  }
+}
+
+# ============================================================================
+# Pattern Group 3: WARP Applications with Destinations
+# ============================================================================
+
+# NOTE: WARP applications have special API behavior - they're forced to be
+# named "Warp Login App" and don't respect custom configurations. Skipped for e2e tests.
+# # 6. WARP app with multiple destinations
+# resource "cloudflare_access_application" "warp_multi" {
+#   account_id = local.common_account_id
+#   name       = "${local.name_prefix} WARP Multi"
+#   type       = "warp"
+#
+#   destinations {
+#     uri  = "https://app1.internal"
+#     type = "public"
+#   }
+#
+#   destinations {
+#     uri  = "tcp://10.0.0.0/24:22"
+#     type = "private"
+#   }
+#
+#   destinations {
+#     uri  = "udp://192.168.1.0/24:53"
+#     type = "private"
+#   }
+# }
+
+# ============================================================================
+# Pattern Group 4: SSH Applications with Target Criteria
+# ============================================================================
+
+# 9. SSH app (basic)
+resource "cloudflare_zero_trust_access_application" "ssh_basic" {
+  account_id                 = local.common_account_id
+  name                       = "${local.name_prefix} SSH Basic"
+  type                       = "ssh"
+  domain                     = "${local.name_prefix}-ssh-basic.${local.app_domain_suffix}"
+  http_only_cookie_attribute = "false"
+}
+
+# 10. SSH app (multi)
+resource "cloudflare_zero_trust_access_application" "ssh_multi_criteria" {
+  account_id                 = var.cloudflare_account_id
+  name                       = "${local.name_prefix} SSH Multi"
+  type                       = "ssh"
+  domain                     = "${local.name_prefix}-ssh-multi.${local.app_domain_suffix}"
+  http_only_cookie_attribute = "false"
+}
+
+# ============================================================================
+# Pattern Group 5: Apps with Landing Page Design
+# ============================================================================
+
+# NOTE: landing_page_design is not supported in v4 provider
+# # 11. App with custom landing page
+# resource "cloudflare_access_application" "with_landing_page" {
+#   account_id = local.common_account_id
+#   name       = "${local.name_prefix} Landing Page"
+#   domain     = "landing.${local.app_domain_suffix}"
+#   policies   = ["landing-policy"]
+#
+#   landing_page_design {
+#     title            = "Welcome to ${local.name_prefix}"
+#     message          = "Please sign in to continue"
+#     logo_url         = "https://logo.${local.app_domain_suffix}/logo.png"
+#     header_bg_color  = "#0051C3"
+#     body_bg_color    = "#FFFFFF"
+#     footer_links {
+#       name = "Help Center"
+#       url  = "https://help.${local.app_domain_suffix}"
+#     }
+#     footer_links {
+#       name = "Privacy Policy"
+#       url  = "https://privacy.${local.app_domain_suffix}"
+#     }
+#   }
+# }
+#
+# # 12. App with minimal landing page
+# resource "cloudflare_access_application" "minimal_landing" {
+#   account_id = var.cloudflare_account_id
+#   name       = "${local.name_prefix} Minimal Landing"
+#   domain     = "minimal-landing.${local.app_domain_suffix}"
+#
+#   landing_page_design {
+#     message = "Sign in required"
+#   }
+# }
+
+# ============================================================================
+# Pattern Group 6: Apps with SCIM Configuration
+# ============================================================================
+
+# 13. App with SCIM config
+# NOTE: Commented out - SCIM requires special account permissions
+# resource "cloudflare_access_application" "with_scim" {
+#   account_id = local.common_account_id
+#   name       = "${local.name_prefix} SCIM"
+#   domain     = "scim.${local.app_domain_suffix}"
+#
+#   scim_config {
+#     enabled                = true
+#     remote_uri             = "https://scim.${local.app_domain_suffix}/v2"
+#     idp_uid                = "email"
+#     deactivate_on_delete   = true
+#
+#     authentication {
+#       scheme   = "httpbasic"
+#       user     = "scim_user"
+#       password = "scim_password"
+#     }
+#
+#     mappings {
+#       schema = "urn:ietf:params:scim:schemas:core:2.0:User"
+#       enabled = true
+#
+#       operations {
+#         create = true
+#         update = true
+#         delete = true
+#       }
+#     }
+#   }
+# }
+
+# ============================================================================
+# Pattern Group 7: Apps with Custom Pages
+# ============================================================================
+
+# 14. App with custom pages
+# NOTE: Commented out - custom_pages requires real page IDs
+# resource "cloudflare_access_application" "with_custom_pages" {
+#   account_id   = var.cloudflare_account_id
+#   name         = "${local.name_prefix} Custom Pages"
+#   domain       = "custom-pages.${local.app_domain_suffix}"
+#   custom_pages = toset(["custom-forbidden-id", "custom-identity-denied-id"])
+# }
+
+# ============================================================================
+# Pattern Group 8: Apps with Self Hosted Domains (Deprecated)
+# ============================================================================
+
+# 15. App with self_hosted_domains (deprecated field)
+resource "cloudflare_zero_trust_access_application" "with_self_hosted_domains" {
+  account_id                 = local.common_account_id
+  name                       = "${local.name_prefix} Self Hosted Domains"
+  type                       = "self_hosted"
+  self_hosted_domains        = ["${local.name_prefix}-legacy1.${local.app_domain_suffix}", "${local.name_prefix}-legacy2.${local.app_domain_suffix}"]
+  http_only_cookie_attribute = "false"
+}
+
+# ============================================================================
+# Pattern Group 9: Apps with Domain Type (Removed Field)
+# ============================================================================
+
+# 16. App with domain_type field (to be removed in v5)
+# NOTE: v4 only supports domain_type = "public"
+resource "cloudflare_zero_trust_access_application" "with_domain_type" {
+  account_id                 = var.cloudflare_account_id
+  name                       = "${local.name_prefix} Domain Type"
+  domain                     = "${local.name_prefix}-domain-type.${local.app_domain_suffix}"
+  type                       = "self_hosted"
+  http_only_cookie_attribute = "false"
+}
+
+# ============================================================================
+# Pattern Group 10: Meta-Arguments (Count)
+# ============================================================================
+
+# 17-19. Apps created with count
+resource "cloudflare_zero_trust_access_application" "with_count" {
+  count = 3
+
+  account_id                 = local.common_account_id
+  name                       = "${local.name_prefix} Count ${count.index}"
+  domain                     = "${local.name_prefix}-count-${count.index}.${local.app_domain_suffix}"
+  type                       = "self_hosted"
+  http_only_cookie_attribute = "false"
+}
+
+# ============================================================================
+# Pattern Group 11: Apps with For Each
+# ============================================================================
+
+# 20-22. Apps created with for_each
+resource "cloudflare_zero_trust_access_application" "with_for_each" {
+  for_each = toset(["dev", "staging", "prod"])
+
+  account_id                 = var.cloudflare_account_id
+  name                       = "${local.name_prefix} ${each.key}"
+  domain                     = "${local.name_prefix}-${each.key}.${local.app_domain_suffix}"
+  session_duration           = each.key == "prod" ? "8h" : "24h"
+  type                       = "self_hosted"
+  http_only_cookie_attribute = "false"
+}
+
+# ============================================================================
+# Pattern Group 12: Complex Nested Structures
+# ============================================================================
+
+# 23. App with session_duration and cors_headers (compatible with type=self_hosted)
+resource "cloudflare_zero_trust_access_application" "complex_nested" {
+  account_id       = local.common_account_id
+  name             = "${local.name_prefix} Complex"
+  domain           = "${local.name_prefix}-complex.${local.app_domain_suffix}"
+  session_duration = "12h"
+
+  type                       = "self_hosted"
+  http_only_cookie_attribute = "false"
+  cors_headers = {
+    allowed_methods   = ["GET", "POST"]
+    allowed_origins   = ["*"]
+    allow_credentials = false
+    max_age           = 7200
+  }
+}
+
+# 24. App with variable references
+resource "cloudflare_zero_trust_access_application" "with_var_refs" {
+  account_id                 = var.cloudflare_account_id
+  name                       = "${local.name_prefix} Variable Refs"
+  domain                     = "${local.name_prefix}-var-refs.${local.app_domain_suffix}"
+  type                       = "self_hosted"
+  http_only_cookie_attribute = "false"
+}
+
+# ============================================================================
+# Pattern Group 13: Edge Cases
+# ============================================================================
+
+# 25. App with empty policies array
+resource "cloudflare_zero_trust_access_application" "empty_policies" {
+  account_id                 = local.common_account_id
+  name                       = "${local.name_prefix} Empty Policies"
+  domain                     = "${local.name_prefix}-empty-policies.${local.app_domain_suffix}"
+  type                       = "self_hosted"
+  http_only_cookie_attribute = "false"
+}
+
+# 26. App with only required fields and null optionals
+resource "cloudflare_zero_trust_access_application" "sparse" {
+  account_id                 = var.cloudflare_account_id
+  name                       = "${local.name_prefix} Sparse"
+  domain                     = "${local.name_prefix}-sparse.${local.app_domain_suffix}"
+  type                       = "self_hosted"
+  http_only_cookie_attribute = "false"
+}
+
+# 27. Conditional app
+resource "cloudflare_zero_trust_access_application" "conditional" {
+  count = var.enable_saas_apps ? 1 : 0
+
+  account_id                 = local.common_account_id
+  name                       = "${local.name_prefix} Conditional"
+  domain                     = "${local.name_prefix}-conditional.${local.app_domain_suffix}"
+  type                       = "self_hosted"
+  http_only_cookie_attribute = "false"
+}
+
+# ============================================================================
+# Pattern Group 14: Special Characters and Escaping
+# ============================================================================
+
+# 28. App with special characters (API restricts: ,.!:@?-)
+resource "cloudflare_zero_trust_access_application" "special_chars" {
+  account_id                 = var.cloudflare_account_id
+  name                       = "${local.name_prefix} Special \"Chars\" & 'Quotes'"
+  domain                     = "${local.name_prefix}-special.${local.app_domain_suffix}"
+  custom_deny_message        = "Access denied - contact support"
+  type                       = "self_hosted"
+  http_only_cookie_attribute = "false"
+}
+
+# ============================================================================
+# Pattern 9: Cross-resource reference using both v4 names
+# ============================================================================
+# This validates that GetResourceRename() returns ALL v4 names for cross-file reference updates
+# v4 name option 1: cloudflare_access_application
+# v4 name option 2: cloudflare_zero_trust_access_application
+# v5 name: cloudflare_zero_trust_access_application
+
+
+# Resource using v4 name option 2
+resource "cloudflare_zero_trust_access_application" "resourcename_opt2" {
+  account_id                 = var.cloudflare_account_id
+  name                       = "${local.name_prefix} Pattern9 Option2"
+  domain                     = "${local.name_prefix}-pattern9-opt2.${local.app_domain_suffix}"
+  type                       = "self_hosted"
+  http_only_cookie_attribute = "false"
+}
+
+# NOTE: cloudflare_access_policy with application_id CANNOT be migrated to v5.
+# See access_policy.md in the repo root for details.
+
+# Resource using v4 name option 1
+resource "cloudflare_zero_trust_access_application" "resourcename_opt1" {
+  account_id                 = var.cloudflare_account_id
+  name                       = "${local.name_prefix} Pattern9 Option1"
+  domain                     = "${local.name_prefix}-pattern9-opt1.${local.app_domain_suffix}"
+  type                       = "self_hosted"
+  http_only_cookie_attribute = "false"
+}
+
+
+variable "from_version" {
+  description = "Provider version under test, used to namespace resource names"
+  type        = string
+}

--- a/e2e-v5/testdata/zero_trust_access_group/zero_trust_access_group.tf
+++ b/e2e-v5/testdata/zero_trust_access_group/zero_trust_access_group.tf
@@ -1,0 +1,476 @@
+# Variables (no defaults for account_id and zone_id per testing guide)
+variable "cloudflare_account_id" {
+  type = string
+}
+
+variable "cloudflare_zone_id" {
+  type = string
+}
+
+variable "cloudflare_domain" {
+  description = "Cloudflare domain for testing"
+  type        = string
+}
+
+locals {
+  name_prefix = "v5-upgrade-${replace(var.from_version, ".", "-")}-ztg"
+}
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+# Pattern 1: Simple email selector
+resource "cloudflare_zero_trust_access_group" "simple_email" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix} Simple Email Group"
+
+  include = [
+    {
+      email = {
+        email = "user1@example.com"
+      }
+    },
+  ]
+}
+
+
+# Pattern 2: Multiple selector types
+resource "cloudflare_zero_trust_access_group" "multiple_selectors" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix} Multiple Selectors Group"
+
+  include = [
+    {
+      email = {
+        email = "admin@example.com"
+      }
+    },
+    {
+      email = {
+        email = "manager@example.com"
+      }
+    },
+    {
+      ip = {
+        ip = "192.168.1.0/24"
+      }
+    },
+    {
+      ip = {
+        ip = "10.0.0.0/8"
+      }
+    },
+  ]
+}
+
+
+# Pattern 3: for_each with map
+resource "cloudflare_zero_trust_access_group" "foreach_map" {
+  for_each = {
+    team1 = "Engineering Team"
+    team2 = "Product Team"
+    team3 = "Design Team"
+  }
+
+  account_id = var.cloudflare_account_id
+  name       = format("%s %s", local.name_prefix, each.value)
+
+  include = [
+    {
+      email_domain = {
+        domain = "example.com"
+      }
+    },
+  ]
+}
+
+
+# Pattern 4: for_each with set
+resource "cloudflare_zero_trust_access_group" "foreach_set" {
+  for_each = toset(["contractors", "vendors", "partners"])
+
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-${each.value}-group"
+
+  include = [
+    {
+      ip = {
+        ip = "192.0.2.1/32"
+      }
+    },
+  ]
+}
+
+
+# Pattern 5: count-based resources
+resource "cloudflare_zero_trust_access_group" "count_based" {
+  count = 3
+
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix} Count Group ${count.index}"
+
+  include = [
+    {
+      ip = {
+        ip = "10.${count.index}.0.0/16"
+      }
+    },
+  ]
+}
+
+
+# Pattern 6: Conditional resource
+resource "cloudflare_zero_trust_access_group" "conditional" {
+  count = var.cloudflare_account_id != "" ? 1 : 0
+
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix} Conditional Group"
+
+  include = [
+    {
+      everyone = {}
+    },
+  ]
+}
+
+
+# Pattern 7: Boolean selectors
+resource "cloudflare_zero_trust_access_group" "booleans" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix} Boolean Selectors Group"
+
+
+  include = [
+    {
+      everyone = {}
+    },
+  ]
+  exclude = [
+    {
+      certificate = {}
+    },
+  ]
+}
+
+
+# Pattern 8: Email domain selector
+resource "cloudflare_zero_trust_access_group" "email_domains" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix} Email Domain Group"
+
+  include = [
+    {
+      email_domain = {
+        domain = "company.com"
+      }
+    },
+    {
+      email_domain = {
+        domain = "partner.com"
+      }
+    },
+    {
+      email_domain = {
+        domain = "vendor.com"
+      }
+    },
+  ]
+}
+
+
+# Pattern 9: Geo selector
+resource "cloudflare_zero_trust_access_group" "geo" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix} Geo Group"
+
+  include = [
+    {
+      geo = {
+        country_code = "US"
+      }
+    },
+    {
+      geo = {
+        country_code = "CA"
+      }
+    },
+    {
+      geo = {
+        country_code = "GB"
+      }
+    },
+  ]
+}
+
+
+# Pattern 10: All three rule types
+resource "cloudflare_zero_trust_access_group" "all_rules" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix} All Rules Group"
+
+
+
+  include = [
+    {
+      email = {
+        email = "user@example.com"
+      }
+    },
+  ]
+  exclude = [
+    {
+      ip = {
+        ip = "192.168.0.0/16"
+      }
+    },
+  ]
+  require = [
+    {
+      email_domain = {
+        domain = "example.com"
+      }
+    },
+  ]
+}
+
+
+# Pattern 11: Multiple selectors in each rule
+resource "cloudflare_zero_trust_access_group" "complex" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix} Complex Group"
+
+
+  include = [
+    {
+      email = {
+        email = "admin@example.com"
+      }
+    },
+    {
+      email = {
+        email = "manager@example.com"
+      }
+    },
+    {
+      email_domain = {
+        domain = "example.com"
+      }
+    },
+    {
+      ip = {
+        ip = "10.0.0.0/8"
+      }
+    },
+  ]
+  exclude = [
+    {
+      ip = {
+        ip = "10.0.1.0/24"
+      }
+    },
+    {
+      geo = {
+        country_code = "CN"
+      }
+    },
+    {
+      geo = {
+        country_code = "RU"
+      }
+    },
+  ]
+}
+
+
+# Pattern 12: Service token selector
+resource "cloudflare_zero_trust_access_group" "service_tokens" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix} Service Token Group"
+
+  include = [
+    {
+      any_valid_service_token = {}
+    },
+  ]
+}
+
+
+# Pattern 13: Group and email list selectors
+resource "cloudflare_zero_trust_access_group" "lists" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix} Lists Group"
+
+  include = [
+    {
+      ip = {
+        ip = "192.0.2.10/32"
+      }
+    },
+    {
+      ip = {
+        ip = "192.0.2.11/32"
+      }
+    },
+    {
+      ip = {
+        ip = "198.51.100.1/32"
+      }
+    },
+    {
+      email_list = {
+        id = "list-id-1"
+      }
+    },
+    {
+      ip_list = {
+        id = "iplist-id-1"
+      }
+    },
+    {
+      ip_list = {
+        id = "iplist-id-2"
+      }
+    },
+  ]
+}
+
+
+# Pattern 14: Login method and device posture
+resource "cloudflare_zero_trust_access_group" "auth_methods" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix} Auth Methods Group"
+
+  include = [
+    {
+      login_method = {
+        id = "method-id-1"
+      }
+    },
+    {
+      login_method = {
+        id = "method-id-2"
+      }
+    },
+    {
+      device_posture = {
+        integration_uid = "posture-id-1"
+      }
+    },
+  ]
+}
+
+
+# Pattern 15: Common name selector
+resource "cloudflare_zero_trust_access_group" "common_name" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix} Common Name Group"
+
+  include = [
+    {
+      common_name = {
+        common_name = "client.example.com"
+      }
+    },
+  ]
+}
+
+
+# Pattern 16: Auth method selector
+resource "cloudflare_zero_trust_access_group" "auth_method_selector" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix} Auth Method Selector Group"
+
+  include = [
+    {
+      auth_method = {
+        auth_method = "email"
+      }
+    },
+  ]
+}
+
+
+# Pattern 17: Lifecycle meta-arguments
+resource "cloudflare_zero_trust_access_group" "lifecycle_test" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix} Lifecycle Test Group"
+
+
+  lifecycle {
+    create_before_destroy = true
+  }
+  include = [
+    {
+      email = {
+        email = "lifecycle@example.com"
+      }
+    },
+  ]
+}
+
+
+# Pattern 18: Terraform functions
+resource "cloudflare_zero_trust_access_group" "functions" {
+  account_id = var.cloudflare_account_id
+  name       = join("-", [local.name_prefix, "Function", "Test", "Group"])
+
+  include = [for i in range(2) : {
+    email = {
+      email = "user${i}@example.com"
+    }
+  }]
+}
+
+
+# Pattern 20: Cross-resource references
+resource "cloudflare_zero_trust_access_group" "parent" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix} Parent Group"
+
+  include = [
+    {
+      email = {
+        email = "parent@example.com"
+      }
+    },
+  ]
+}
+
+
+resource "cloudflare_zero_trust_access_group" "child" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix} Child Group - References ${cloudflare_zero_trust_access_group.parent.name}"
+
+
+  depends_on = [cloudflare_zero_trust_access_group.parent]
+  include = [
+    {
+      email = {
+        email = "child@example.com"
+      }
+    },
+  ]
+}
+
+
+variable "from_version" {
+  description = "Provider version under test, used to namespace resource names"
+  type        = string
+}

--- a/e2e-v5/testdata/zero_trust_access_identity_provider/zero_trust_access_identity_provider.tf
+++ b/e2e-v5/testdata/zero_trust_access_identity_provider/zero_trust_access_identity_provider.tf
@@ -1,0 +1,277 @@
+# Integration test for zero_trust_access_identity_provider v4 to v5 migration
+
+variable "cloudflare_account_id" {
+  type = string
+}
+
+variable "cloudflare_zone_id" {
+  type        = string
+  description = "Not used by this resource (account-level only), but required by e2e framework"
+  default     = ""
+}
+
+variable "cloudflare_domain" {
+  description = "Cloudflare domain for testing"
+  type        = string
+}
+
+variable "enable_conditional_provider" {
+  type    = bool
+  default = true
+}
+
+# Locals for reusable values
+locals {
+  base_scopes     = ["openid", "profile", "email"]
+  extended_scopes = concat(local.base_scopes, ["groups"])
+  name_prefix     = "v5-upgrade-${replace(var.from_version, ".", "-")}"
+  encoded_value   = base64encode("test-value")
+
+  # Map for for_each with maps pattern
+  google_providers = {
+    "prod" = {
+      name      = "${local.name_prefix} Google OAuth Production"
+      client_id = "google-prod-client-id"
+    }
+    "staging" = {
+      name      = "${local.name_prefix} Google OAuth Staging"
+      client_id = "google-staging-client-id"
+    }
+    "dev" = {
+      name      = "${local.name_prefix} Google OAuth Development"
+      client_id = "google-dev-client-id"
+    }
+    "qa" = {
+      name      = "${local.name_prefix} Google OAuth QA"
+      client_id = "google-qa-client-id"
+    }
+  }
+
+  # Set for for_each with sets pattern
+  github_environments = toset(["production", "staging", "development"])
+}
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+# Test 1: onetimepin (no config block in v4, but will be required in v5)
+resource "cloudflare_zero_trust_access_identity_provider" "otp" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix} One-Time PIN"
+  type       = "onetimepin"
+  config     = {}
+}
+
+
+# Test 2: GitHub OAuth (basic config)
+resource "cloudflare_zero_trust_access_identity_provider" "github" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix} GitHub OAuth"
+  type       = "github"
+
+  config = {
+    client_id     = "github-client-id"
+    client_secret = "github-client-secret"
+  }
+}
+
+
+# Test 3: Azure AD with SCIM (complex config)
+resource "cloudflare_zero_trust_access_identity_provider" "azure" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix} Azure AD SSO"
+  type       = "azureAD"
+
+
+  config = {
+    client_id                  = "azure-client-id"
+    client_secret              = "azure-client-secret"
+    directory_id               = "azure-directory-uuid"
+    conditional_access_enabled = false
+    support_groups             = true
+  }
+  scim_config = {
+    enabled          = true
+    user_deprovision = true
+    seat_deprovision = false
+  }
+}
+
+
+# Test 4: SAML with idp_public_cert (single string in v4, array in v5)
+resource "cloudflare_zero_trust_access_identity_provider" "saml" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix} SAML Provider"
+  type       = "saml"
+
+  config = {
+    issuer_url       = "https://saml.example.com/issuer"
+    sso_target_url   = "https://saml.example.com/sso"
+    sign_request     = true
+    attributes       = ["email", "username"]
+    idp_public_certs = ["MIIDpDCCAoygAwIBAgIGAV2ka+55MA0GCSqGSIb3DQEBCwUAMIGSMQswCQYDVQQGEwJVUzETMBEG"]
+  }
+}
+
+
+# Test 5: OIDC with PKCE
+resource "cloudflare_zero_trust_access_identity_provider" "oidc" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix} Generic OIDC"
+  type       = "oidc"
+
+  config = {
+    client_id     = "oidc-client-id"
+    client_secret = "oidc-client-secret"
+    auth_url      = "https://oidc.example.com/authorize"
+    token_url     = "https://oidc.example.com/token"
+    certs_url     = "https://oidc.example.com/.well-known/jwks.json"
+    scopes        = ["openid", "profile", "email"]
+    pkce_enabled  = true
+  }
+}
+
+
+# Test 6-9: for_each with map (4 Google OAuth providers)
+resource "cloudflare_zero_trust_access_identity_provider" "google_map" {
+  for_each = local.google_providers
+
+  account_id = var.cloudflare_account_id
+  name       = each.value.name
+  type       = "google"
+
+  config = {
+    client_id     = each.value.client_id
+    client_secret = format("google-%s-secret", each.key)
+  }
+}
+
+
+# Test 10-12: for_each with set (3 GitHub providers)
+resource "cloudflare_zero_trust_access_identity_provider" "github_set" {
+  for_each = local.github_environments
+
+  account_id = var.cloudflare_account_id
+  name       = format("%s GitHub %s", local.name_prefix, title(each.key))
+  type       = "github"
+
+  config = {
+    client_id     = join("-", ["github", each.key, "client"])
+    client_secret = join("-", ["github", each.key, "secret"])
+  }
+}
+
+
+# Test 13-15: count-based resources (3 GitHub Enterprise providers)
+resource "cloudflare_zero_trust_access_identity_provider" "github_enterprise" {
+  count = 3
+
+  account_id = var.cloudflare_account_id
+  name       = format("%s GitHub Enterprise %d", local.name_prefix, count.index + 1)
+  type       = "github"
+
+  config = {
+    client_id     = format("ghe-client-%d", count.index)
+    client_secret = format("ghe-secret-%d", count.index)
+  }
+}
+
+
+# Test 16: conditional resource creation (count with ternary)
+resource "cloudflare_zero_trust_access_identity_provider" "conditional" {
+  count = var.enable_conditional_provider ? 1 : 0
+
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix} Conditional Provider"
+  type       = "github"
+
+  config = {
+    client_id     = "conditional-client-id"
+    client_secret = "conditional-secret"
+  }
+}
+
+
+# Test 17: cross-resource reference (references the otp provider)
+resource "cloudflare_zero_trust_access_identity_provider" "with_reference" {
+  account_id = var.cloudflare_account_id
+  name       = format("%s Referenced Provider - %s", local.name_prefix, cloudflare_zero_trust_access_identity_provider.otp.id)
+  type       = "github"
+  config = {
+    client_id     = "ref-client-id"
+    client_secret = "ref-client-secret"
+  }
+}
+
+
+# Test 18: using Terraform functions (base64encode, concat)
+resource "cloudflare_zero_trust_access_identity_provider" "with_functions" {
+  account_id = var.cloudflare_account_id
+  name       = format("%s Provider with Functions", local.name_prefix)
+  type       = "oidc"
+
+  config = {
+    client_id     = format("client-%s", local.encoded_value)
+    client_secret = base64encode("secret-value")
+    auth_url      = "https://auth.example.com/authorize"
+    token_url     = "https://auth.example.com/token"
+    certs_url     = "https://auth.example.com/.well-known/jwks.json"
+    scopes        = local.extended_scopes
+  }
+}
+
+
+# Test 19: with lifecycle meta-arguments
+resource "cloudflare_zero_trust_access_identity_provider" "with_lifecycle" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix} Provider with Lifecycle"
+  type       = "github"
+
+
+  lifecycle {
+    create_before_destroy = true
+    ignore_changes        = [name]
+  }
+  config = {
+    client_id     = "lifecycle-client-id"
+    client_secret = "lifecycle-secret"
+  }
+}
+
+
+# Test 20: Azure AD with all optional fields
+resource "cloudflare_zero_trust_access_identity_provider" "azure_full" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix} Azure AD Full Configuration"
+  type       = "azureAD"
+
+
+  config = {
+    client_id                  = "azure-full-client-id"
+    client_secret              = "azure-full-client-secret"
+    directory_id               = "azure-full-directory-uuid"
+    conditional_access_enabled = false
+    support_groups             = false
+  }
+  scim_config = {
+    enabled          = true
+    user_deprovision = true
+    seat_deprovision = true
+  }
+}
+
+
+variable "from_version" {
+  description = "Provider version under test, used to namespace resource names"
+  type        = string
+}

--- a/e2e-v5/testdata/zero_trust_access_mtls_certificate/zero_trust_access_mtls_certificate.tf
+++ b/e2e-v5/testdata/zero_trust_access_mtls_certificate/zero_trust_access_mtls_certificate.tf
@@ -1,0 +1,140 @@
+# E2E Test Configuration for zero_trust_access_mtls_certificate
+# This file is used for end-to-end testing against the real Cloudflare API
+# It contains minimal resources with unique certificates
+
+variable "cloudflare_account_id" {
+  type = string
+}
+
+variable "cloudflare_zone_id" {
+  type = string
+}
+
+variable "cloudflare_domain" {
+  type        = string
+  description = "Domain for testing (not used by this module but accepted for consistency)"
+}
+
+# Use static prefix for E2E tests to avoid timestamp-related plan drift
+locals {
+  name_prefix = "v5-upgrade-${replace(var.from_version, ".", "-")}"
+
+  # Three unique certificates for testing
+  cert1 = <<EOT
+-----BEGIN CERTIFICATE-----
+MIIDvTCCAqWgAwIBAgIEaUWyljANBgkqhkiG9w0BAQsFADB0MQswCQYDVQQGEwJV
+UzELMAkGA1UECBMCQ0ExFjAUBgNVBAcTDVNhbiBGcmFuY2lzY28xGTAXBgNVBAoT
+EFRlc3QtSW50ZWdyYXRpb24xJTAjBgNVBAMTHGludGVncmF0aW9uLXRlc3QuZXhh
+bXBsZS5jb20wHhcNMjUxMjE5MjAxNjIyWhcNMjYxMjE5MjAxNjIyWjB0MQswCQYD
+VQQGEwJVUzELMAkGA1UECBMCQ0ExFjAUBgNVBAcTDVNhbiBGcmFuY2lzY28xGTAX
+BgNVBAoTEFRlc3QtSW50ZWdyYXRpb24xJTAjBgNVBAMTHGludGVncmF0aW9uLXRl
+c3QuZXhhbXBsZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDF
+MxiaTyz/XpDiUdF07ObHkTQIlYjAW7phHnSzznvEWl2Tn3J77lNl7XQVeoPyIXDn
+s1j93wj4Tf7UrgarBWxmDWD2nfgE6hROVhuYWhmNnNFqPIAV31KJZt4scE3sq1M+
+dVttBTu5ItShdntt7QrE2E51lQobJME6yHIlaOQLiAaJTmsTR3ziNnSlR3y+/MDY
+SqvLKEQYkLx5Y3GE2D34knWkgjDy7TL6N1bXutu/7clLRGUXsIpqVgv8VT2tkYzD
+KsmRTO3S4tZlAXNjY40j4Y1zVfjDN9soiS5u0wLbNQq0hJF4p8FEZqiQTUR7gwDf
+XwKjc3c2j9DoWdAOAK+HAgMBAAGjVzBVMA4GA1UdDwEB/wQEAwICpDATBgNVHSUE
+DDAKBggrBgEFBQcDATAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBRo5vWci6AQ
+stsJGT/PyNfUglwsrzANBgkqhkiG9w0BAQsFAAOCAQEAfRid4vB6DhxkAdNMGn0I
+aVpe1IP0cnsfrI4f8yShbwa7syEfpGbsdPmePmUnoTnXW/SZZ86ndT7uzYa2WIyE
+PTQkcyScRVTGyU+Ze0T4S+tFm10QvjL7NmQrlKX/fDqho5RX+yP5li+adgBClowo
+jIYvMgrg2SBKuLCR/JEragdGNBZTOkXT7vxA4ldzH70iBZLr/ODHVCFfCI+7mlaV
+9jlPBN58LSZypTWBNraO1849fuYKVEGMafDVuFUGWwQQXE0zzUHyd1mNBQ/aRBmI
+ULHVVSsA1PCbJ0Iq+Cnserb2j6EgZQqSlGo1D5mMPflWffjQQpgpbaq9xfNRt7gI
+Ag==
+-----END CERTIFICATE-----
+EOT
+
+  cert2 = <<EOT
+-----BEGIN CERTIFICATE-----
+MIIDvTCCAqWgAwIBAgIEaUWylzANBgkqhkiG9w0BAQsFADB0MQswCQYDVQQGEwJV
+UzELMAkGA1UECBMCQ0ExFjAUBgNVBAcTDVNhbiBGcmFuY2lzY28xGTAXBgNVBAoT
+EFRlc3QtSW50ZWdyYXRpb24xJTAjBgNVBAMTHGludGVncmF0aW9uLXRlc3QuZXhh
+bXBsZS5jb20wHhcNMjUxMjE5MjAxNjIzWhcNMjYxMjE5MjAxNjIzWjB0MQswCQYD
+VQQGEwJVUzELMAkGA1UECBMCQ0ExFjAUBgNVBAcTDVNhbiBGcmFuY2lzY28xGTAX
+BgNVBAoTEFRlc3QtSW50ZWdyYXRpb24xJTAjBgNVBAMTHGludGVncmF0aW9uLXRl
+c3QuZXhhbXBsZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCs
+7VjWTxDB3qTrgAUFZ9lkI4jueQs4rO/spuRYrDqWjNXregux24YI6q4AbAG6m92Y
+IIX7JzjHebHjX9RrxvkF6crhu0X5QrCgTgpZtfywBmURSPFq8VCGH0mQmsQFQW9K
+XPX7056uoVsFCmXR8raF8pqg1XHtnmDKq5Dzj6HLwBzZR+oD3PG9tsQCITRloIGK
+6cf5ndqv9AjdrqDOqWcIcAg9eD/G6eMzYqLNi/U8bY1BCqugqy8zlxyh9vVhGew1
+0DxejH53QiHgdsRwJXo9Z2NO2laCLz+Pnoz+bGUY2UuwCL3e0poJ6+GHabEAhbYB
+Uj+dgQIjbJLUFJXy5sSDAgMBAAGjVzBVMA4GA1UdDwEB/wQEAwICpDATBgNVHSUE
+DDAKBggrBgEFBQcDATAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBS8QTh7p+OK
+0nz36FgxG1kjP2EKiDANBgkqhkiG9w0BAQsFAAOCAQEARAYVxpQtovXiptpEjaV3
+F+lzdXCqV5lwZbkpdbdlys/KhKiBT9uVIJR1RUFdqB2jXPfeQy+MQkqvQyc0veM1
+Sa4lyiN7vmRwnqMN9A0ZZnlN6JHZ93pFZ4ZvyBr4v4mkmHQLemYXHzaTohBPdE12
+p/8Ck/T8mtcIYFxFjZC6xTdzt1EECllGYB0vZ1EFvceY+0Gevqy3ha8iB0c5KR1X
+/llZVVCZN5vtOSwxnmxlct0OE7FNLuliijooXHqzVjCXxX7qpts5a6qJ8gg0RNoh
+IIh3Hm55M4F2vvDlzAlOGxv6i2l1RvCXnlB7Jps2uphkfsO2xFv5YFKkaChYELLq
+lg==
+-----END CERTIFICATE-----
+EOT
+
+  cert3 = <<EOT
+-----BEGIN CERTIFICATE-----
+MIIDvTCCAqWgAwIBAgIEaUWymDANBgkqhkiG9w0BAQsFADB0MQswCQYDVQQGEwJV
+UzELMAkGA1UECBMCQ0ExFjAUBgNVBAcTDVNhbiBGcmFuY2lzY28xGTAXBgNVBAoT
+EFRlc3QtSW50ZWdyYXRpb24xJTAjBgNVBAMTHGludGVncmF0aW9uLXRlc3QuZXhh
+bXBsZS5jb20wHhcNMjUxMjE5MjAxNjI0WhcNMjYxMjE5MjAxNjI0WjB0MQswCQYD
+VQQGEwJVUzELMAkGA1UECBMCQ0ExFjAUBgNVBAcTDVNhbiBGcmFuY2lzY28xGTAX
+BgNVBAoTEFRlc3QtSW50ZWdyYXRpb24xJTAjBgNVBAMTHGludGVncmF0aW9uLXRl
+c3QuZXhhbXBsZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDG
+3n+ATbARsi34DniDSKyX+UyqE8SaaSvbhAjdtzpzkbLMmWnKXtAGQsJUj+sXr+qq
+vlirL1BX5Wl1TCnV3+M5LJbFSdspfs0xjGmduNmHiXw+BGq1Kn5Q3RUpgrH0j08M
+WWBon2r+R5wLYEFWh7H2/+diSbGGRSGcayop8Dx4YpddaIHN91b+nbU9UUvOVKwH
+hJr+uDrupQW9GqcXfQNJcq4Hj3THtH8Gmlo9UT8lDLCd0ZNK/8UsF1OTBvHd4u6a
+0L2jVRyxP9UVW2lxd6K19Lp5VOdQAMiBGcB6kKZQLMizLxgCZ3fR7m6VJrivjBBr
+PIyeZcw0UzftCZyBQFmDAgMBAAGjVzBVMA4GA1UdDwEB/wQEAwICpDATBgNVHSUE
+DDAKBggrBgEFBQcDATAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBREqIZCU4NC
+rf6JGwrVlJS5AJLBZTANBgkqhkiG9w0BAQsFAAOCAQEAe4pT7qla+kcKnHT4DYyd
+v0ifzQJhtTxNgS8Y7kFrC0/OAWIeYt/9lplwCZzl+X9ep7iIfZ3t+PlypBktb7gu
+qnQaQxbi7UdgY0sJpepvilV08tA59o2pXMVWm0VIpGFYbDC5oTeSnp4riaQAPlUl
+2FOVWGgpvG54KrEwrb6ha6gWuHpNESpsOR4iIj2LgSStGUbxZ2tYz4lkk5ZdOrlX
+IGK2ayvoffXWLvSvFt6TAwhh8fjtp4QGtk3uPf2VoLO3PWjre3lP0MvsGrK32tYO
+rvi1xUmOwefZCE4cEt9jFR2n/5Z7Ml7Q3upuAdfcJoKN2v2ZnxujiiWVE/Irz//T
+Ew==
+-----END CERTIFICATE-----
+EOT
+}
+
+##########################
+# MINIMAL E2E TEST RESOURCES
+##########################
+
+
+
+
+# 1. Basic account-scoped certificate
+resource "cloudflare_zero_trust_access_mtls_certificate" "e2e_basic" {
+  account_id  = var.cloudflare_account_id
+  name        = "${local.name_prefix}-basic"
+  certificate = local.cert1
+}
+
+
+# 2. Zone-scoped certificate
+resource "cloudflare_zero_trust_access_mtls_certificate" "e2e_zone" {
+  zone_id     = var.cloudflare_zone_id
+  name        = "${local.name_prefix}-zone"
+  certificate = local.cert2
+}
+
+
+# 3. for_each pattern with unique certificates
+resource "cloudflare_zero_trust_access_mtls_certificate" "e2e_foreach" {
+  for_each = {
+    env1 = local.cert3
+  }
+
+  account_id  = var.cloudflare_account_id
+  name        = "${local.name_prefix}-foreach-${each.key}"
+  certificate = each.value
+}
+
+
+variable "from_version" {
+  description = "Provider version under test, used to namespace resource names"
+  type        = string
+}

--- a/e2e-v5/testdata/zero_trust_access_mtls_hostname_settings/zero_trust_access_mtls_hostname_settings.tf
+++ b/e2e-v5/testdata/zero_trust_access_mtls_hostname_settings/zero_trust_access_mtls_hostname_settings.tf
@@ -1,0 +1,50 @@
+variable "cloudflare_account_id" {
+  description = "Cloudflare account ID"
+  type        = string
+}
+
+variable "cloudflare_zone_id" {
+  description = "Cloudflare zone ID"
+  type        = string
+}
+
+variable "cloudflare_domain" {
+  description = "Cloudflare domain for testing"
+  type        = string
+}
+
+locals {
+  name_prefix      = "v5-upgrade-${replace(var.from_version, ".", "-")}-mtls-host"
+  account_hostname = "${local.name_prefix}-account.${var.cloudflare_domain}"
+  zone_hostname    = "${local.name_prefix}-zone.${var.cloudflare_domain}"
+}
+
+# NOTE: These resources are commented out because they require mTLS certificates
+# to be uploaded to Cloudflare first. Uncomment and configure certificates if needed.
+
+# # Minimal E2E test - account-level with single settings block
+resource "cloudflare_zero_trust_access_mtls_hostname_settings" "e2e_account" {
+  account_id = var.cloudflare_account_id
+
+  settings = [{
+    hostname                      = local.account_hostname
+    china_network                 = false
+    client_certificate_forwarding = false
+  }]
+}
+
+# Minimal E2E test - zone-level with single settings block
+resource "cloudflare_zero_trust_access_mtls_hostname_settings" "e2e_zone" {
+  zone_id = var.cloudflare_zone_id
+
+  settings = [{
+    hostname                      = local.zone_hostname
+    china_network                 = false
+    client_certificate_forwarding = true
+  }]
+}
+
+variable "from_version" {
+  description = "Provider version under test, used to namespace resource names"
+  type        = string
+}

--- a/e2e-v5/testdata/zero_trust_access_policy/zero_trust_access_policy.tf
+++ b/e2e-v5/testdata/zero_trust_access_policy/zero_trust_access_policy.tf
@@ -1,0 +1,294 @@
+# Integration Test: zero_trust_access_policy
+# Comprehensive test covering all Terraform patterns (V4 format)
+
+# Pattern Group 1: Variables & Locals
+variable "cloudflare_account_id" {
+  description = "Cloudflare account ID"
+  type        = string
+}
+
+variable "cloudflare_zone_id" {
+  description = "Cloudflare zone ID"
+  type        = string
+}
+
+variable "cloudflare_domain" {
+  description = "Cloudflare Domain"
+  type        = string
+}
+
+locals {
+  name_prefix    = "v5-upgrade-${replace(var.from_version, ".", "-")}-ztp"
+  common_account = var.cloudflare_account_id
+  policy_names   = ["dev", "staging", "prod"]
+  enable_test    = true
+  enable_demo    = false
+}
+
+# NOTE: In v5, cloudflare_zero_trust_access_policy are account-level policies.
+# The migration removes zone_id and application_id fields from v4 policies.
+# Application-specific policies (with application_id in v4) cannot be migrated
+# as they use different API endpoints and are fundamentally different resources.
+
+
+
+
+
+
+
+
+
+
+
+# Pattern Group 8: Edge Cases
+
+
+
+
+
+
+
+
+
+# Basic test cases
+resource "cloudflare_zero_trust_access_policy" "example" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-example-policy"
+  decision   = "allow"
+
+
+  approval_groups = [{
+    approvals_needed = 1
+    email_addresses  = ["approver@example.com"]
+  }]
+  include = [{ everyone = {} }]
+}
+
+
+resource "cloudflare_zero_trust_access_policy" "complex" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-complex-policy"
+  decision   = "allow"
+
+
+
+  include = [{ email = { email = "user@example.com" } },
+    { email = { email = "admin@example.com" } },
+  { email_domain = { domain = "example.com" } }]
+  exclude = [{ ip = { ip = "192.168.1.1/32" } },
+  { ip = { ip = "10.0.0.0/8" } }]
+  require = [{ email = { email = "required@example.com" } }]
+}
+
+
+# Pattern Group 2: for_each with Maps (3-5 resources)
+resource "cloudflare_zero_trust_access_policy" "map_example" {
+  for_each = {
+    "api" = {
+      decision = "allow"
+    }
+    "web" = {
+      decision = "allow"
+    }
+    "admin" = {
+      decision = "allow"
+    }
+    "readonly" = {
+      decision = "allow"
+    }
+  }
+
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-map-${each.key}-policy"
+  decision   = each.value.decision
+
+  include = [{ email = { email = "@example.com" } }]
+}
+
+
+# Pattern Group 3: for_each with Sets (3-5 items)
+resource "cloudflare_zero_trust_access_policy" "set_example" {
+  for_each = toset(["alpha", "beta", "gamma", "delta", "epsilon"])
+
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-set-${each.key}"
+  decision   = "allow"
+
+  include = [{ email = { email = "@example.com" } }]
+}
+
+
+# Pattern Group 4: count-based Resources (at least 3)
+resource "cloudflare_zero_trust_access_policy" "counted" {
+  count = 3
+
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-counted-${count.index}"
+  decision   = "allow"
+
+  include = [{ ip = { ip = "10.0.${count.index}.0/24" } }]
+}
+
+
+# Pattern Group 5: Conditional Creation
+resource "cloudflare_zero_trust_access_policy" "conditional_enabled" {
+  count = local.enable_test ? 1 : 0
+
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-conditional-enabled"
+  decision   = "allow"
+
+  include = [{ everyone = {} }]
+}
+
+
+resource "cloudflare_zero_trust_access_policy" "conditional_disabled" {
+  count = local.enable_demo ? 1 : 0
+
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-conditional-disabled"
+  decision   = "deny"
+
+  include = [{ everyone = {} }]
+}
+
+
+# Pattern Group 6: Terraform Functions
+resource "cloudflare_zero_trust_access_policy" "with_functions" {
+  account_id = var.cloudflare_account_id
+  name       = join("-", [local.name_prefix, "functions", "test"])
+  decision   = "allow"
+
+  include = [{ email = { email = "function1@example.com" } },
+  { email = { email = "function2@example.com" } }]
+}
+
+
+# Pattern Group 7: Lifecycle Meta-Arguments
+resource "cloudflare_zero_trust_access_policy" "with_lifecycle" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-lifecycle-test"
+  decision   = "allow"
+
+  lifecycle {
+    create_before_destroy = true
+    ignore_changes        = [name]
+  }
+
+  include = [{ everyone = {} }]
+}
+
+
+resource "cloudflare_zero_trust_access_policy" "with_prevent_destroy" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-prevent-destroy"
+  decision   = "allow"
+
+  lifecycle {
+    prevent_destroy = false
+  }
+
+  include = [{ email = { email = "protected@example.com" } }]
+}
+
+
+# Minimal resource (only required fields)
+resource "cloudflare_zero_trust_access_policy" "minimal" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-minimal"
+  decision   = "allow"
+
+  include = [{ everyone = {} }]
+}
+
+
+# Maximal resource (all optional fields populated)
+resource "cloudflare_zero_trust_access_policy" "maximal" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-maximal"
+  decision   = "allow"
+
+
+
+
+  approval_groups = [{
+    approvals_needed = 2
+    email_addresses  = ["approver1@example.com", "approver2@example.com"]
+  }]
+  include = [{ email = { email = "maximal1@example.com" } },
+    { email = { email = "maximal2@example.com" } },
+    { email_domain = { domain = "maximal.example.com" } },
+    { geo = { country_code = "US" } },
+    { geo = { country_code = "CA" } },
+  { ip = { ip = "203.0.113.0/24" } }]
+  exclude = [{ email = { email = "blocked@example.com" } },
+  { ip = { ip = "203.0.113.100/32" } }]
+  require = [{ email = { email = "required@example.com" } }]
+}
+
+
+# Policy with common_name
+resource "cloudflare_zero_trust_access_policy" "with_common_name" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-common-name"
+  decision   = "allow"
+
+  include = [{ common_name = { common_name = "device1.example.com" } }]
+}
+
+
+# Policy with auth_method
+resource "cloudflare_zero_trust_access_policy" "with_auth_method" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-auth-method"
+  decision   = "allow"
+
+  include = [{ auth_method = { auth_method = "swk" } }]
+}
+
+
+# Policy with login_method
+resource "cloudflare_zero_trust_access_policy" "with_login_method" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-login-method"
+  decision   = "allow"
+
+  include = [{ login_method = { id = "otp" } },
+  { login_method = { id = "warp" } }]
+}
+
+
+# Policy with any_valid_service_token
+resource "cloudflare_zero_trust_access_policy" "with_service_token" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-service-token"
+  decision   = "allow"
+
+  include = [{ any_valid_service_token = {} }]
+}
+
+
+# Deny policy
+resource "cloudflare_zero_trust_access_policy" "deny_policy" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-deny"
+  decision   = "deny"
+
+  include = [{ ip = { ip = "198.51.100.0/24" } }]
+}
+
+
+# Bypass policy
+resource "cloudflare_zero_trust_access_policy" "bypass_policy" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-bypass"
+  decision   = "bypass"
+
+  include = [{ ip = { ip = "192.0.2.0/24" } }]
+}
+
+
+variable "from_version" {
+  description = "Provider version under test, used to namespace resource names"
+  type        = string
+}

--- a/e2e-v5/testdata/zero_trust_access_service_token/zero_trust_access_service_token.tf
+++ b/e2e-v5/testdata/zero_trust_access_service_token/zero_trust_access_service_token.tf
@@ -1,0 +1,290 @@
+variable "cloudflare_account_id" {
+  description = "Cloudflare account ID"
+  type        = string
+}
+
+variable "cloudflare_zone_id" {
+  description = "Cloudflare zone ID"
+  type        = string
+}
+
+variable "cloudflare_domain" {
+  description = "Cloudflare domain for testing"
+  type        = string
+}
+
+# ============================================================================
+# Pattern Group 1: Variables & Locals
+# ============================================================================
+
+locals {
+  common_account        = var.cloudflare_account_id
+  name_prefix           = "v5-upgrade-${replace(var.from_version, ".", "-")}-zts"
+  tags                  = ["test", "migration", "v4_to_v5"]
+  token_duration        = "8760h"
+  enable_long_duration  = true
+  enable_short_duration = false
+}
+
+# ============================================================================
+# Pattern Group 2: for_each with Maps (5 resources)
+# ============================================================================
+
+resource "cloudflare_zero_trust_access_service_token" "map_example" {
+  for_each = {
+    "prod" = {
+      account_id           = var.cloudflare_account_id
+      name                 = "${local.name_prefix}-prod-service-token"
+      duration             = "8760h"
+      min_days_for_renewal = 30
+    }
+    "staging" = {
+      account_id           = var.cloudflare_account_id
+      name                 = "${local.name_prefix}-staging-service-token"
+      duration             = "8760h"
+      min_days_for_renewal = 15
+    }
+    "dev" = {
+      account_id           = var.cloudflare_account_id
+      name                 = "${local.name_prefix}-dev-service-token"
+      duration             = "8760h"
+      min_days_for_renewal = 7
+    }
+    "qa" = {
+      account_id           = var.cloudflare_account_id
+      name                 = "${local.name_prefix}-qa-service-token"
+      duration             = "8760h"
+      min_days_for_renewal = 10
+    }
+    "perf" = {
+      account_id           = var.cloudflare_account_id
+      name                 = "${local.name_prefix}-perf-service-token"
+      duration             = "8760h"
+      min_days_for_renewal = 5
+    }
+  }
+
+  account_id = each.value.account_id
+  name       = each.value.name
+  duration   = each.value.duration
+}
+
+# ============================================================================
+# Pattern Group 3: for_each with Sets (4 items)
+# ============================================================================
+
+resource "cloudflare_zero_trust_access_service_token" "set_example" {
+  for_each = toset([
+    "alpha",
+    "beta",
+    "gamma",
+    "delta"
+  ])
+
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-set-${each.value}-token"
+  duration   = local.token_duration
+}
+
+# ============================================================================
+# Pattern Group 4: count-based Resources (3 instances)
+# ============================================================================
+
+resource "cloudflare_zero_trust_access_service_token" "counted" {
+  count = 3
+
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-counted-token-${count.index}"
+  duration   = "8760h"
+}
+
+# ============================================================================
+# Pattern Group 5: Conditional Creation
+# ============================================================================
+
+resource "cloudflare_zero_trust_access_service_token" "conditional_enabled" {
+  count = local.enable_long_duration ? 1 : 0
+
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-conditional-long-duration"
+  duration   = "17520h" # 2 years
+}
+
+resource "cloudflare_zero_trust_access_service_token" "conditional_disabled" {
+  count = local.enable_short_duration ? 1 : 0
+
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-conditional-short-duration"
+  duration   = "8760h" # Changed from 720h to valid value
+}
+
+# ============================================================================
+# Pattern Group 7: Terraform Functions
+# ============================================================================
+
+resource "cloudflare_zero_trust_access_service_token" "with_functions" {
+  account_id = local.common_account
+
+  # join() function
+  name = join("-", [local.name_prefix, "function", "example"])
+
+  # String interpolation
+  duration = local.token_duration
+
+}
+
+resource "cloudflare_zero_trust_access_service_token" "with_interpolation" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-token-for-account-${var.cloudflare_account_id}"
+  duration   = "8760h"
+}
+
+# ============================================================================
+# Pattern Group 8: Lifecycle Meta-Arguments
+# ============================================================================
+
+resource "cloudflare_zero_trust_access_service_token" "with_lifecycle" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-lifecycle-test-token"
+  duration   = "8760h"
+
+  lifecycle {
+    create_before_destroy = true
+    ignore_changes        = [duration]
+  }
+}
+
+resource "cloudflare_zero_trust_access_service_token" "with_prevent_destroy" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-prevent-destroy-token"
+  duration   = "8760h"
+
+  lifecycle {
+    prevent_destroy = false # Set to false for testing
+  }
+}
+
+# ============================================================================
+# Pattern Group 9: Edge Cases
+# ============================================================================
+
+# Minimal resource (only required fields)
+resource "cloudflare_zero_trust_access_service_token" "minimal" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-minimal-token"
+}
+
+# Maximal resource (all fields populated)
+resource "cloudflare_zero_trust_access_service_token" "maximal" {
+  account_id                        = var.cloudflare_account_id
+  name                              = "${local.name_prefix}-maximal-token"
+  duration                          = "8760h"
+  client_secret_version             = 5
+  previous_client_secret_expires_at = "2025-12-31T23:59:59Z"
+}
+
+# Zero values
+resource "cloudflare_zero_trust_access_service_token" "zero_values" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-zero-values-token"
+  duration   = "8760h"
+}
+
+
+# Resource without min_days_for_renewal (deprecated field)
+resource "cloudflare_zero_trust_access_service_token" "without_deprecated" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-no-deprecated-field"
+  duration   = "8760h"
+}
+
+# Resource with very large client_secret_version
+resource "cloudflare_zero_trust_access_service_token" "large_version" {
+  account_id                        = var.cloudflare_account_id
+  name                              = "${local.name_prefix}-large-version-token"
+  duration                          = "8760h"
+  client_secret_version             = 999
+  previous_client_secret_expires_at = "2025-12-31T23:59:59Z"
+}
+
+# Resource with special characters in name
+resource "cloudflare_zero_trust_access_service_token" "special_chars" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-token-with-special_chars-123"
+  duration   = "8760h"
+}
+
+# Resource with minimum duration
+resource "cloudflare_zero_trust_access_service_token" "min_duration" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-min-duration-token"
+  duration   = "8760h" # Changed from 30m to valid minimum value
+}
+
+# Resource with maximum duration
+resource "cloudflare_zero_trust_access_service_token" "max_duration" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-max-duration-token"
+  duration   = "87600h" # 10 years
+}
+
+# ============================================================================
+# Pattern 9: Cross-resource reference using both v4 names
+# ============================================================================
+# This validates that GetResourceRename() returns ALL v4 names for cross-file reference updates
+# v4 name option 1: cloudflare_access_service_token
+# v4 name option 2: cloudflare_zero_trust_access_service_token
+# v5 name: cloudflare_zero_trust_access_service_token
+
+
+# Resource using v4 name option 2
+resource "cloudflare_zero_trust_access_service_token" "resourcename_opt2" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-pattern9-opt2-token"
+  duration   = "8760h"
+}
+
+# Dependent resource that references option 1 via depends_on
+resource "cloudflare_zero_trust_access_application" "ref_opt1" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix} App depends on token opt1"
+  domain     = "${local.name_prefix}-token-opt1.${var.cloudflare_domain}"
+  type       = "self_hosted"
+
+  depends_on                 = [cloudflare_zero_trust_access_service_token.resourcename_opt1]
+  http_only_cookie_attribute = "false"
+}
+
+# Dependent resource that references option 2 via depends_on
+resource "cloudflare_zero_trust_access_application" "ref_opt2" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix} App depends on token opt2"
+  domain     = "${local.name_prefix}-token-opt2.${var.cloudflare_domain}"
+  type       = "self_hosted"
+
+  depends_on                 = [cloudflare_zero_trust_access_service_token.resourcename_opt2]
+  http_only_cookie_attribute = "false"
+}
+
+# Legacy resource name (cloudflare_access_service_token - deprecated)
+resource "cloudflare_zero_trust_access_service_token" "legacy_name" {
+  account_id                        = var.cloudflare_account_id
+  name                              = "${local.name_prefix}-legacy-name-token"
+  duration                          = "8760h"
+  client_secret_version             = 2
+  previous_client_secret_expires_at = "2024-12-31T23:59:59Z"
+}
+
+
+# Resource using v4 name option 1
+resource "cloudflare_zero_trust_access_service_token" "resourcename_opt1" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-pattern9-opt1-token"
+  duration   = "8760h"
+}
+
+
+variable "from_version" {
+  description = "Provider version under test, used to namespace resource names"
+  type        = string
+}

--- a/e2e-v5/testdata/zero_trust_device_managed_networks/zero_trust_device_managed_networks.tf
+++ b/e2e-v5/testdata/zero_trust_device_managed_networks/zero_trust_device_managed_networks.tf
@@ -1,0 +1,285 @@
+# Integration tests for zero_trust_device_managed_networks v4→v5 migration
+# Tests comprehensive patterns: for_each, count, conditionals, variables
+
+variable "cloudflare_account_id" {
+  description = "Cloudflare account ID"
+  type        = string
+}
+
+variable "cloudflare_zone_id" {
+  description = "Cloudflare zone ID (not used by this resource)"
+  type        = string
+}
+
+variable "cloudflare_domain" {
+  description = "Cloudflare domain (not used by this resource)"
+  type        = string
+}
+
+locals {
+  name_prefix = "v5-upgrade-${replace(var.from_version, ".", "-")}"
+
+  networks_map = {
+    "corporate" = {
+      host = "corporate.cf-tf-test.com"
+      port = "443"
+      hash = "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+    }
+    "staging" = {
+      host = "staging.cf-tf-test.com"
+      port = "8443"
+      hash = "fedcba0987654321fedcba0987654321fedcba0987654321fedcba0987654321"
+    }
+    "production" = {
+      host = "prod.cf-tf-test.com"
+      port = "443"
+      hash = "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
+    }
+  }
+}
+
+
+
+
+
+locals {
+  enable_test_network = true
+  enable_dev_network  = false
+  profile_precedence  = 400000 + tonumber(split(".", var.from_version)[1]) * 1000
+}
+
+
+
+
+
+
+
+
+variable "custom_network_name" {
+  type    = string
+  default = "custom"
+}
+
+
+# ============================================================================
+# Pattern 9: Cross-resource reference using both v4 names
+# ============================================================================
+# This validates that GetResourceRename() returns ALL v4 names for cross-file reference updates
+# v4 name option 1: cloudflare_device_managed_networks
+# v4 name option 2: cloudflare_zero_trust_device_managed_networks
+# v5 name: cloudflare_zero_trust_device_managed_networks
+
+
+# Resource using v4 name option 2
+resource "cloudflare_zero_trust_device_managed_networks" "resourcename_opt2" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-pattern9-opt2"
+  type       = "tls"
+
+  config = {
+    tls_sockaddr = "pattern9-opt2.cf-tf-test.com:443"
+    sha256       = "bb22222222222222222222222222222222222222222222222222222222222222"
+  }
+}
+
+
+
+resource "cloudflare_zero_trust_device_managed_networks" "basic" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-basic-network"
+  type       = "tls"
+
+  config = {
+    tls_sockaddr = "basic.cf-tf-test.com:443"
+    sha256       = "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+  }
+}
+
+
+resource "cloudflare_zero_trust_device_managed_networks" "map_foreach" {
+  for_each = local.networks_map
+
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-${each.key}"
+  type       = "tls"
+
+  config = {
+    tls_sockaddr = "${each.value.host}:${each.value.port}"
+    sha256       = each.value.hash
+  }
+}
+
+
+resource "cloudflare_zero_trust_device_managed_networks" "set_foreach" {
+  for_each = toset(["alpha", "beta", "gamma", "delta"])
+
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-set-${each.value}"
+  type       = "tls"
+
+  config = {
+    tls_sockaddr = "${each.value}.cf-tf-test.com:443"
+    sha256       = "1111111111111111111111111111111111111111111111111111111111111111"
+  }
+}
+
+
+resource "cloudflare_zero_trust_device_managed_networks" "counted" {
+  count = 3
+
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-counted-${count.index}"
+  type       = "tls"
+
+  config = {
+    tls_sockaddr = "counted-${count.index}.cf-tf-test.com:443"
+    sha256       = "2222222222222222222222222222222222222222222222222222222222222222"
+  }
+}
+
+
+resource "cloudflare_zero_trust_device_managed_networks" "conditional_enabled" {
+  count = local.enable_test_network ? 1 : 0
+
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-conditional-enabled"
+  type       = "tls"
+
+  config = {
+    tls_sockaddr = "conditional.cf-tf-test.com:443"
+    sha256       = "3333333333333333333333333333333333333333333333333333333333333333"
+  }
+}
+
+
+resource "cloudflare_zero_trust_device_managed_networks" "conditional_disabled" {
+  count = local.enable_dev_network ? 1 : 0
+
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-conditional-disabled"
+  type       = "tls"
+
+  config = {
+    tls_sockaddr = "disabled.cf-tf-test.com:443"
+    sha256       = "4444444444444444444444444444444444444444444444444444444444444444"
+  }
+}
+
+
+resource "cloudflare_zero_trust_device_managed_networks" "with_functions" {
+  account_id = var.cloudflare_account_id
+  name       = join("-", [local.name_prefix, "functions", "test"])
+  type       = "tls"
+
+  config = {
+    tls_sockaddr = "functions.cf-tf-test.com:443"
+    sha256       = "functions1234567890abcdef1234567890abcdef1234567890abcdef1234567"
+  }
+}
+
+
+resource "cloudflare_zero_trust_device_managed_networks" "ipv6" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-ipv6-network"
+  type       = "tls"
+
+  config = {
+    tls_sockaddr = "[2001:db8::1]:443"
+    sha256       = "ipv61234567890abcdef1234567890abcdef1234567890abcdef1234567890ab"
+  }
+}
+
+
+resource "cloudflare_zero_trust_device_managed_networks" "custom_port" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-custom-port"
+  type       = "tls"
+
+  config = {
+    tls_sockaddr = "custom-port.cf-tf-test.com:8443"
+    sha256       = "5555555555555555555555555555555555555555555555555555555555555555"
+  }
+}
+
+
+resource "cloudflare_zero_trust_device_managed_networks" "with_lifecycle" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-lifecycle-test"
+  type       = "tls"
+
+
+  lifecycle {
+    create_before_destroy = true
+  }
+  config = {
+    tls_sockaddr = "lifecycle.cf-tf-test.com:443"
+    sha256       = "6666666666666666666666666666666666666666666666666666666666666666"
+  }
+}
+
+
+resource "cloudflare_zero_trust_device_managed_networks" "special_hash" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-special-hash"
+  type       = "tls"
+
+  config = {
+    tls_sockaddr = "special.cf-tf-test.com:443"
+    sha256       = "ABCDEF1234567890abcdef1234567890ABCDEF1234567890abcdef1234567890"
+  }
+}
+
+
+resource "cloudflare_zero_trust_device_managed_networks" "with_variables" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-${var.custom_network_name}"
+  type       = "tls"
+
+  config = {
+    tls_sockaddr = "${var.custom_network_name}.cf-tf-test.com:443"
+    sha256       = "7777777777777777777777777777777777777777777777777777777777777777"
+  }
+}
+
+
+# Resource using v4 name option 1
+resource "cloudflare_zero_trust_device_managed_networks" "resourcename_opt1" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-pattern9-opt1"
+  type       = "tls"
+
+  config = {
+    tls_sockaddr = "pattern9-opt1.cf-tf-test.com:443"
+    sha256       = "aa11111111111111111111111111111111111111111111111111111111111111"
+  }
+}
+
+
+# Dependent resource that references option 1
+resource "cloudflare_zero_trust_device_custom_profile" "ref_opt1" {
+  account_id  = var.cloudflare_account_id
+  name        = "${local.name_prefix}-profile-opt1"
+  description = "Profile depending on managed network opt1"
+  match       = "identity.email == \"test-opt1@example.com\""
+  precedence  = local.profile_precedence
+
+  depends_on = [cloudflare_zero_trust_device_managed_networks.resourcename_opt1]
+}
+
+
+# Dependent resource that references option 2
+resource "cloudflare_zero_trust_device_custom_profile" "ref_opt2" {
+  account_id  = var.cloudflare_account_id
+  name        = "${local.name_prefix}-profile-opt2"
+  description = "Profile depending on managed network opt2"
+  match       = "identity.email == \"test-opt2@example.com\""
+  precedence  = local.profile_precedence + 1
+
+  depends_on = [cloudflare_zero_trust_device_managed_networks.resourcename_opt2]
+}
+
+
+variable "from_version" {
+  description = "Provider version under test, used to namespace resource names"
+  type        = string
+}

--- a/e2e-v5/testdata/zero_trust_device_posture_integration/zero_trust_device_posture_integration.tf
+++ b/e2e-v5/testdata/zero_trust_device_posture_integration/zero_trust_device_posture_integration.tf
@@ -1,0 +1,255 @@
+# E2E Test Configuration for Device Posture Integration Migration
+# This file uses CrowdStrike S2S integration type with real credentials from environment variables
+# Required environment variables:
+# - CLOUDFLARE_CROWDSTRIKE_CLIENT_ID
+# - CLOUDFLARE_CROWDSTRIKE_CLIENT_SECRET
+# - CLOUDFLARE_CROWDSTRIKE_API_URL
+# - CLOUDFLARE_CROWDSTRIKE_CUSTOMER_ID
+
+variable "cloudflare_account_id" {
+  type = string
+}
+
+# These variables are provided by the e2e runner but not used by device_posture_integration
+variable "cloudflare_zone_id" {
+  type    = string
+  default = ""
+}
+
+variable "cloudflare_domain" {
+  type    = string
+  default = ""
+}
+
+variable "crowdstrike_client_id" {
+  type = string
+}
+
+variable "crowdstrike_client_secret" {
+  type      = string
+  sensitive = true
+}
+
+variable "crowdstrike_api_url" {
+  type = string
+}
+
+variable "crowdstrike_customer_id" {
+  type = string
+}
+
+variable "from_version" {
+  description = "Provider version under test, used to namespace resource names"
+  type        = string
+}
+
+
+locals {
+  e2e_prefix = "v5-upgrade-${replace(var.from_version, ".", "-")}-ztpi"
+}
+
+
+# Test Case 2: Current resource name with all fields
+# Tests: No resource name change (already using current name)
+# Tests: config block → attribute transformation
+resource "cloudflare_zero_trust_device_posture_integration" "current_name" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.e2e_prefix}-current"
+  type       = "crowdstrike_s2s"
+  interval   = "12h"
+
+  config = {
+    api_url       = var.crowdstrike_api_url
+    client_id     = var.crowdstrike_client_id
+    client_secret = var.crowdstrike_client_secret
+    customer_id   = var.crowdstrike_customer_id
+  }
+}
+
+# Test Case 3: Non-standard interval value
+# Tests: Various interval formats (not just 24h)
+# Tests: config block → attribute transformation
+resource "cloudflare_zero_trust_device_posture_integration" "no_interval" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.e2e_prefix}-nointerval"
+  type       = "crowdstrike_s2s"
+  interval   = "168h"
+
+  config = {
+    api_url       = var.crowdstrike_api_url
+    client_id     = var.crowdstrike_client_id
+    client_secret = var.crowdstrike_client_secret
+    customer_id   = var.crowdstrike_customer_id
+  }
+}
+
+
+# Test Case 5: Count-based resources
+# Tests: Multiple resources with count
+# Tests: Different interval values
+# Tests: config block → attribute transformation
+resource "cloudflare_zero_trust_device_posture_integration" "count_test" {
+  count = 2
+
+  account_id = var.cloudflare_account_id
+  name       = "${local.e2e_prefix}-count-${count.index}"
+  type       = "crowdstrike_s2s"
+  interval   = count.index == 0 ? "1h" : "2h"
+
+  config = {
+    api_url       = var.crowdstrike_api_url
+    client_id     = var.crowdstrike_client_id
+    client_secret = var.crowdstrike_client_secret
+    customer_id   = var.crowdstrike_customer_id
+  }
+}
+
+
+
+resource "cloudflare_zero_trust_device_posture_integration" "secondary" {
+  account_id = var.cloudflare_account_id
+  name       = "${cloudflare_zero_trust_device_posture_integration.primary.name}-secondary"
+  type       = "crowdstrike_s2s"
+  interval   = cloudflare_zero_trust_device_posture_integration.primary.interval
+
+  config = {
+    api_url       = var.crowdstrike_api_url
+    client_id     = var.crowdstrike_client_id
+    client_secret = var.crowdstrike_client_secret
+    customer_id   = var.crowdstrike_customer_id
+  }
+}
+
+# Test Case 8: Lifecycle meta-arguments
+# Tests: Lifecycle blocks are preserved during migration
+# Tests: config block → attribute transformation with lifecycle
+resource "cloudflare_zero_trust_device_posture_integration" "lifecycle_test" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.e2e_prefix}-lifecycle"
+  type       = "crowdstrike_s2s"
+  interval   = "24h"
+
+
+  lifecycle {
+    create_before_destroy = true
+  }
+  config = {
+    api_url       = var.crowdstrike_api_url
+    client_id     = var.crowdstrike_client_id
+    client_secret = var.crowdstrike_client_secret
+    customer_id   = var.crowdstrike_customer_id
+  }
+}
+
+
+# Summary of E2E Test Cases:
+# Total: 13 resource instances (1 + 1 + 1 + 1 + 2 + 2 + 2 + 1 + 1 + 1)
+#
+# Coverage:
+# - Deprecated resource name rename: 6 instances (deprecated_name, with_identifier, foreach_deprecated x2, primary, with_comments)
+# - Current resource name (no rename): 7 instances (current_name, no_interval, count_test x2, secondary, lifecycle_test)
+# - Identifier field removal: 1 instance (with_identifier)
+# - Different interval values: All instances (1h, 2h, 6h, 12h, 24h, 168h)
+# - Config block → attribute: All instances
+# - Count-based: 2 instances (count_test[0], count_test[1])
+# - for_each with map: 2 instances (foreach_deprecated["hourly"], foreach_deprecated["daily"])
+# - Cross-resource references: 2 instances (primary, secondary)
+# - Lifecycle meta-arguments: 1 instance (lifecycle_test)
+# - Comments preservation: 1 instance (with_comments)
+
+# Test Case 1: Deprecated resource name with all fields
+# Tests: cloudflare_device_posture_integration → cloudflare_zero_trust_device_posture_integration rename
+# Tests: config block → attribute transformation
+resource "cloudflare_zero_trust_device_posture_integration" "deprecated_name" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.e2e_prefix}-deprecated"
+  type       = "crowdstrike_s2s"
+  interval   = "24h"
+
+  config = {
+    api_url       = var.crowdstrike_api_url
+    client_id     = var.crowdstrike_client_id
+    client_secret = var.crowdstrike_client_secret
+    customer_id   = var.crowdstrike_customer_id
+  }
+}
+
+
+# Test Case 4: With deprecated identifier field
+# Tests: identifier field is removed during migration
+# Tests: Deprecated resource name → current name
+# Tests: config block → attribute transformation
+resource "cloudflare_zero_trust_device_posture_integration" "with_identifier" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.e2e_prefix}-identifier"
+  type       = "crowdstrike_s2s"
+  interval   = "6h"
+
+  config = {
+    api_url       = var.crowdstrike_api_url
+    client_id     = var.crowdstrike_client_id
+    client_secret = var.crowdstrike_client_secret
+    customer_id   = var.crowdstrike_customer_id
+  }
+}
+
+
+# Test Case 6: for_each with map
+# Tests: for_each with map iteration
+# Tests: Variable interval values
+# Tests: Deprecated resource name with for_each
+resource "cloudflare_zero_trust_device_posture_integration" "foreach_deprecated" {
+  for_each = {
+    hourly = "1h"
+    daily  = "24h"
+  }
+
+  account_id = var.cloudflare_account_id
+  name       = "${local.e2e_prefix}-foreach-dep-${each.key}"
+  type       = "crowdstrike_s2s"
+  interval   = each.value
+
+  config = {
+    api_url       = var.crowdstrike_api_url
+    client_id     = var.crowdstrike_client_id
+    client_secret = var.crowdstrike_client_secret
+    customer_id   = var.crowdstrike_customer_id
+  }
+}
+
+
+# Test Case 7: Cross-resource reference
+# Tests: References between resources work after migration
+# Tests: Deprecated name → current name for referenced resource
+resource "cloudflare_zero_trust_device_posture_integration" "primary" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.e2e_prefix}-primary"
+  type       = "crowdstrike_s2s"
+  interval   = "24h"
+
+  config = {
+    api_url       = var.crowdstrike_api_url
+    client_id     = var.crowdstrike_client_id
+    client_secret = var.crowdstrike_client_secret
+    customer_id   = var.crowdstrike_customer_id
+  }
+}
+
+
+# Test Case 9: Comments preservation
+# Tests: Comments are preserved during migration
+resource "cloudflare_zero_trust_device_posture_integration" "with_comments" {
+  # This is a comment before the resource
+  account_id = var.cloudflare_account_id # inline comment
+  name       = "${local.e2e_prefix}-comments"
+  type       = "crowdstrike_s2s"
+  interval   = "24h"
+
+  # Comment after config block
+  config = {
+    api_url       = var.crowdstrike_api_url
+    client_id     = var.crowdstrike_client_id
+    client_secret = var.crowdstrike_client_secret
+    customer_id   = var.crowdstrike_customer_id
+  }
+}

--- a/e2e-v5/testdata/zero_trust_device_posture_rule/zero_trust_device_posture_rule.tf
+++ b/e2e-v5/testdata/zero_trust_device_posture_rule/zero_trust_device_posture_rule.tf
@@ -1,0 +1,563 @@
+variable "cloudflare_account_id" {
+  description = "Cloudflare account ID"
+  type        = string
+}
+
+variable "cloudflare_zone_id" {
+  description = "Cloudflare zone ID"
+  type        = string
+}
+
+variable "cloudflare_domain" {
+  description = "Cloudflare domain for testing"
+  type        = string
+}
+
+# ============================================================================
+# Pattern Group 1: Variables & Locals
+# ============================================================================
+
+locals {
+  common_account        = var.cloudflare_account_id
+  name_prefix           = "v5-upgrade-${replace(var.from_version, ".", "-")}-ztpr"
+  default_schedule      = "24h"
+  enable_firewall_rules = true
+  enable_test_rules     = false
+  gateway_precedence    = 200000 + tonumber(split(".", var.from_version)[1]) * 1000
+}
+
+# ============================================================================
+# Pattern Group 2: for_each with Maps (5 resources)
+# ============================================================================
+
+
+# ============================================================================
+# Pattern Group 3: for_each with Sets (4 items)
+# ============================================================================
+
+
+# ============================================================================
+# Pattern Group 4: count-based Resources (3 instances)
+# ============================================================================
+
+
+# ============================================================================
+# Pattern Group 5: Conditional Creation
+# ============================================================================
+
+
+
+# ============================================================================
+# Pattern Group 7: Terraform Functions
+# ============================================================================
+
+
+
+# ============================================================================
+# Pattern Group 8: Lifecycle Meta-Arguments
+# ============================================================================
+
+
+
+# ============================================================================
+# Pattern Group 9: Edge Cases
+# ============================================================================
+
+
+
+
+# ============================================================================
+# Original Test Cases (Comprehensive Coverage)
+# ============================================================================
+
+
+
+
+
+
+
+# ============================================================================
+# Pattern Group 9: Cross-File References (Resource Rename Test)
+# ============================================================================
+
+# Pattern 9 tests that cross-file references are updated when resource names change.
+# The migrator renames:
+#   cloudflare_device_posture_rule -> cloudflare_zero_trust_device_posture_rule
+#   cloudflare_zero_trust_device_posture_rule -> cloudflare_zero_trust_device_posture_rule (no-op)
+# We create dependent resources (gateway policies) that reference these posture rules via depends_on.
+# After migration, the references must be updated to use the new resource names.
+
+
+
+# Dependent resources that reference the above posture rules
+# Using realistic resources that would depend on posture rules
+
+# Gateway policy depending on old-name posture rule
+# Note: Using high precedence values (100000+) to avoid conflicts with zero_trust_gateway_policy tests
+resource "cloudflare_zero_trust_gateway_policy" "depends_on_old_posture" {
+  account_id  = var.cloudflare_account_id
+  name        = "${local.name_prefix} Gateway Policy - Old Posture Rule"
+  description = "Policy depending on old-name posture rule"
+  action      = "block"
+  precedence  = local.gateway_precedence
+  enabled     = true
+  traffic     = "any(dns.domains[*] == \"example-old.com\")"
+
+  depends_on = [cloudflare_zero_trust_device_posture_rule.ref_source_old_name]
+}
+
+# Gateway policy depending on new-name posture rule
+# Note: Using high precedence values (100000+) to avoid conflicts with zero_trust_gateway_policy tests
+resource "cloudflare_zero_trust_gateway_policy" "depends_on_new_posture" {
+  account_id  = var.cloudflare_account_id
+  name        = "${local.name_prefix} Gateway Policy - New Posture Rule"
+  description = "Policy depending on new-name posture rule"
+  action      = "allow"
+  precedence  = local.gateway_precedence + 1
+  enabled     = true
+  traffic     = "any(dns.domains[*] == \"example-new.com\")"
+
+  depends_on = [cloudflare_zero_trust_device_posture_rule.ref_source_new_name]
+}
+
+resource "cloudflare_zero_trust_device_posture_rule" "map_example" {
+  for_each = {
+    "prod" = {
+      account_id = var.cloudflare_account_id
+      name       = "${local.name_prefix}-prod-posture-rule"
+      type       = "os_version"
+      schedule   = "24h"
+      platform   = "linux"
+      version    = "20.4.0"
+    }
+    "staging" = {
+      account_id = var.cloudflare_account_id
+      name       = "${local.name_prefix}-staging-posture-rule"
+      type       = "os_version"
+      schedule   = "12h"
+      platform   = "windows"
+      version    = "10.0.0"
+    }
+    "dev" = {
+      account_id = var.cloudflare_account_id
+      name       = "${local.name_prefix}-dev-posture-rule"
+      type       = "os_version"
+      schedule   = "6h"
+      platform   = "mac"
+      version    = "12.0.0"
+    }
+    "qa" = {
+      account_id = var.cloudflare_account_id
+      name       = "${local.name_prefix}-qa-posture-rule"
+      type       = "os_version"
+      schedule   = "12h"
+      platform   = "linux"
+      version    = "1.0.0"
+    }
+    "perf" = {
+      account_id = var.cloudflare_account_id
+      name       = "${local.name_prefix}-perf-posture-rule"
+      type       = "os_version"
+      schedule   = "24h"
+      platform   = "windows"
+      version    = "11.0.0"
+    }
+  }
+
+  account_id = each.value.account_id
+  name       = each.value.name
+  type       = each.value.type
+  schedule   = each.value.schedule
+
+
+  input = {
+    version  = each.value.version
+    operator = ">="
+  }
+  match = [
+    {
+      platform = each.value.platform
+    }
+  ]
+}
+
+
+resource "cloudflare_zero_trust_device_posture_rule" "set_example" {
+  for_each = toset([
+    "alpha",
+    "beta",
+    "gamma",
+    "delta"
+  ])
+
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-set-${each.value}-rule"
+  type       = "firewall"
+  schedule   = "5m"
+
+
+  input = {
+    enabled = true
+  }
+  match = [{
+    platform = "linux"
+  }]
+}
+
+
+resource "cloudflare_zero_trust_device_posture_rule" "counted" {
+  count = 3
+
+  account_id  = var.cloudflare_account_id
+  name        = "${local.name_prefix}-counted-rule-${count.index}"
+  type        = "os_version"
+  schedule    = "24h"
+  description = "This is posture rule number ${count.index}"
+
+
+  input = {
+    version  = "1.${count.index}.0"
+    operator = "=="
+  }
+  match = [{
+    platform = "linux"
+  }]
+}
+
+
+resource "cloudflare_zero_trust_device_posture_rule" "conditional_enabled" {
+  count = local.enable_firewall_rules ? 1 : 0
+
+  account_id  = var.cloudflare_account_id
+  name        = "${local.name_prefix}-conditional-firewall-enabled"
+  type        = "firewall"
+  schedule    = "12h"
+  description = "Conditionally enabled firewall rule"
+
+
+  input = {
+    enabled = true
+  }
+  match = [{
+    platform = "windows"
+  }]
+}
+
+
+resource "cloudflare_zero_trust_device_posture_rule" "conditional_disabled" {
+  count = local.enable_test_rules ? 1 : 0
+
+  account_id  = var.cloudflare_account_id
+  name        = "${local.name_prefix}-conditional-test-disabled"
+  type        = "os_version"
+  schedule    = "6h"
+  description = "Conditionally disabled test rule"
+
+
+  input = {
+    version  = "1.0.0"
+    operator = ">"
+  }
+  match = [{
+    platform = "linux"
+  }]
+}
+
+
+resource "cloudflare_zero_trust_device_posture_rule" "with_functions" {
+  account_id = local.common_account
+
+  # join() function
+  name = join("-", [local.name_prefix, "function", "example"])
+
+  type        = "os_version"
+  schedule    = local.default_schedule
+  description = "Rule for account ${var.cloudflare_account_id}"
+
+
+  input = {
+    version  = "22.4.0"
+    operator = ">="
+  }
+  match = [{
+    platform = "linux"
+  }]
+}
+
+
+resource "cloudflare_zero_trust_device_posture_rule" "with_interpolation" {
+  account_id  = var.cloudflare_account_id
+  name        = "${local.name_prefix}-rule-for-account-${var.cloudflare_account_id}"
+  type        = "firewall"
+  schedule    = "5m"
+  description = "Interpolated rule name"
+
+
+  input = {
+    enabled = true
+  }
+  match = [{
+    platform = "windows"
+  }]
+}
+
+
+resource "cloudflare_zero_trust_device_posture_rule" "with_lifecycle" {
+  account_id  = var.cloudflare_account_id
+  name        = "${local.name_prefix}-lifecycle-test-rule"
+  type        = "os_version"
+  schedule    = "24h"
+  description = "Rule with lifecycle arguments"
+
+
+
+  lifecycle {
+    create_before_destroy = true
+    ignore_changes        = [description]
+  }
+  input = {
+    version  = "20.4.0"
+    operator = ">="
+  }
+  match = [{
+    platform = "linux"
+  }]
+}
+
+
+resource "cloudflare_zero_trust_device_posture_rule" "with_prevent_destroy" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-prevent-destroy-rule"
+  type       = "firewall"
+  schedule   = "12h"
+
+
+
+  lifecycle {
+    prevent_destroy = false # Set to false for testing
+  }
+  input = {
+    enabled = true
+  }
+  match = [{
+    platform = "windows"
+  }]
+}
+
+
+# Minimal resource (only required fields)
+resource "cloudflare_zero_trust_device_posture_rule" "minimal" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-minimal-rule"
+  type       = "firewall"
+  schedule   = "5m"
+
+
+  input = {
+    enabled = true
+  }
+  match = [{
+    platform = "linux"
+  }]
+}
+
+
+# Maximal resource (all fields populated)
+resource "cloudflare_zero_trust_device_posture_rule" "maximal" {
+  account_id  = var.cloudflare_account_id
+  name        = "${local.name_prefix}-maximal-rule"
+  type        = "os_version"
+  description = "All fields populated"
+  schedule    = "24h"
+  expiration  = "25h"
+
+
+  input = {
+    version            = "22.4.0"
+    operator           = ">="
+    os_distro_name     = "ubuntu"
+    os_distro_revision = "22.4.0"
+    os_version_extra   = "(LTS)"
+  }
+  match = [{
+    platform = "linux"
+  }]
+}
+
+
+# Resource with empty/null optional fields
+resource "cloudflare_zero_trust_device_posture_rule" "with_nulls" {
+  account_id  = var.cloudflare_account_id
+  name        = "${local.name_prefix}-with-nulls"
+  type        = "firewall"
+  description = null
+  expiration  = null
+  schedule    = "5m"
+
+
+  input = {
+    enabled = true
+  }
+  match = [{
+    platform = "windows"
+  }]
+}
+
+
+# Test case 1: Basic os_version rule with input and match
+resource "cloudflare_zero_trust_device_posture_rule" "basic" {
+  account_id  = var.cloudflare_account_id
+  name        = "${local.name_prefix}-tf-test-posture-basic"
+  type        = "os_version"
+  description = "Device posture rule for corporate devices."
+  schedule    = "24h"
+  expiration  = "25h"
+
+
+  input = {
+    version            = "1.0.0"
+    operator           = "<"
+    os_distro_name     = "ubuntu"
+    os_distro_revision = "1.0.0"
+    os_version_extra   = "(a)"
+  }
+  match = [{
+    platform = "linux"
+  }]
+}
+
+
+# Test case 2: Firewall rule with enabled input
+resource "cloudflare_zero_trust_device_posture_rule" "firewall" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-tf-test-firewall"
+  type       = "firewall"
+  schedule   = "5m"
+
+
+  input = {
+    enabled = true
+  }
+  match = [{
+    platform = "windows"
+  }]
+}
+
+
+# Test case 3: Disk encryption with check_disks (Set->List conversion)
+resource "cloudflare_zero_trust_device_posture_rule" "disk_encryption" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-tf-test-disk"
+  type       = "disk_encryption"
+  schedule   = "5m"
+
+
+  input = {
+    check_disks = ["C:", "D:"]
+    require_all = true
+  }
+  match = [{
+    platform = "windows"
+  }]
+}
+
+
+# Test case 4: Multiple platforms (multiple match blocks)
+resource "cloudflare_zero_trust_device_posture_rule" "multi_platform" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-tf-test-multi"
+  type       = "firewall"
+  schedule   = "5m"
+
+
+
+
+  input = {
+    enabled = true
+  }
+  match = [{
+    platform = "windows"
+    }, {
+    platform = "mac"
+    }, {
+    platform = "linux"
+  }]
+}
+
+
+# Test case 5: Application rule with path and running (removed attribute)
+resource "cloudflare_zero_trust_device_posture_rule" "application" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-tf-test-application"
+  type       = "application"
+  schedule   = "30m"
+
+
+  input = {
+    path   = "/usr/bin/security-app"
+    sha256 = "abc123def456"
+  }
+  match = [{
+    platform = "linux"
+  }]
+}
+
+
+# Test case 6: Domain joined rule
+resource "cloudflare_zero_trust_device_posture_rule" "domain_joined" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-tf-test-domain-joined"
+  type       = "domain_joined"
+  schedule   = "5m"
+
+
+  input = {
+    domain = "example.com"
+  }
+  match = [{
+    platform = "windows"
+  }]
+}
+
+
+# Using old v4 name (cloudflare_device_posture_rule) -> becomes cloudflare_zero_trust_device_posture_rule
+resource "cloudflare_zero_trust_device_posture_rule" "ref_source_old_name" {
+  account_id  = var.cloudflare_account_id
+  name        = "${local.name_prefix}-ref-source-old-name"
+  type        = "os_version"
+  schedule    = "24h"
+  description = "Referenced by gateway policy (old name)"
+
+
+  input = {
+    version        = "22.4.0"
+    operator       = ">="
+    os_distro_name = "ubuntu"
+  }
+  match = [{
+    platform = "linux"
+  }]
+}
+
+
+# Using new v4 name (cloudflare_zero_trust_device_posture_rule) -> stays cloudflare_zero_trust_device_posture_rule
+resource "cloudflare_zero_trust_device_posture_rule" "ref_source_new_name" {
+  account_id  = var.cloudflare_account_id
+  name        = "${local.name_prefix}-ref-source-new-name"
+  type        = "firewall"
+  schedule    = "12h"
+  description = "Referenced by gateway policy (new name)"
+
+
+  input = {
+    enabled = true
+  }
+  match = [{
+    platform = "windows"
+  }]
+}
+
+variable "from_version" {
+  description = "Provider version under test, used to namespace resource names"
+  type        = string
+}

--- a/e2e-v5/testdata/zero_trust_device_profiles/zero_trust_device_profiles.tf
+++ b/e2e-v5/testdata/zero_trust_device_profiles/zero_trust_device_profiles.tf
@@ -1,0 +1,49 @@
+# E2E test for zero_trust_device_default_profile migration
+# This is a simplified version for actual API testing (singleton resource)
+
+variable "cloudflare_account_id" {
+  description = "Cloudflare account ID"
+  type        = string
+}
+
+variable "cloudflare_zone_id" {
+  description = "Cloudflare zone ID (not used by this account-scoped resource)"
+  type        = string
+}
+
+variable "cloudflare_domain" {
+  description = "Cloudflare domain (not used by this account-scoped resource)"
+  type        = string
+}
+
+
+# Single default profile test with all v4-valid fields populated
+# Note: This is a singleton resource - only one default profile exists per account
+resource "cloudflare_zero_trust_device_default_profile" "default" {
+  account_id = var.cloudflare_account_id
+
+  # All v4-supported optional fields
+  allow_mode_switch     = true
+  allow_updates         = true
+  allowed_to_leave      = false
+  auto_connect          = 0
+  captive_portal        = 180
+  switch_locked         = false
+  disable_auto_fallback = false
+  exclude_office_ips    = false
+  support_url           = "https://support.example.com"
+  tunnel_protocol       = "wireguard"
+
+  service_mode_v2 = {
+    mode = "proxy"
+    port = 8080
+  }
+  register_interface_ip_with_dns = true
+  sccm_vpn_boundary_support      = false
+}
+
+
+variable "from_version" {
+  description = "Provider version under test, used to namespace resource names"
+  type        = string
+}

--- a/e2e-v5/testdata/zero_trust_dex_test/zero_trust_dex_test.tf
+++ b/e2e-v5/testdata/zero_trust_dex_test/zero_trust_dex_test.tf
@@ -1,0 +1,327 @@
+variable "cloudflare_account_id" {
+  type = string
+}
+
+variable "cloudflare_zone_id" {
+  description = "Cloudflare zone ID (not used by Zero Trust resources)"
+  type        = string
+}
+
+variable "cloudflare_domain" {
+  description = "Cloudflare domain (not used by Zero Trust resources)"
+  type        = string
+}
+
+locals {
+  name_prefix = "v5-upgrade-${replace(var.from_version, ".", "-")}"
+}
+
+# Test 1: Basic HTTP test
+resource "cloudflare_zero_trust_dex_test" "http_basic" {
+  account_id  = var.cloudflare_account_id
+  name        = "${local.name_prefix}-basic-http-test"
+  description = "Test HTTP connectivity to example.com"
+  interval    = "0h30m0s"
+  enabled     = true
+
+  data = {
+    kind   = "http"
+    host   = "https://example.com"
+    method = "GET"
+  }
+}
+
+# Test 2: Traceroute test (no method field)
+resource "cloudflare_zero_trust_dex_test" "traceroute" {
+  account_id  = var.cloudflare_account_id
+  name        = "${local.name_prefix}-traceroute-to-dns"
+  description = "Test network path to Google DNS"
+  interval    = "1h0m0s"
+  enabled     = true
+
+  data = {
+    kind = "traceroute"
+    host = "8.8.8.8"
+  }
+}
+
+# Test 3: Disabled test
+resource "cloudflare_zero_trust_dex_test" "disabled" {
+  account_id  = var.cloudflare_account_id
+  name        = "${local.name_prefix}-disabled-test"
+  description = "Currently disabled for maintenance"
+  interval    = "0h15m0s"
+  enabled     = false
+
+  data = {
+    kind   = "http"
+    host   = "https://internal.example.com"
+    method = "GET"
+  }
+}
+
+# Test 4: HTTP test with short interval
+resource "cloudflare_zero_trust_dex_test" "http_frequent" {
+  account_id  = var.cloudflare_account_id
+  name        = "${local.name_prefix}-frequent-http-test"
+  description = "High-frequency monitoring"
+  interval    = "0h5m0s"
+  enabled     = true
+
+  data = {
+    kind   = "http"
+    host   = "https://api.example.com/health"
+    method = "GET"
+  }
+}
+
+# Test 5: Traceroute to hostname
+resource "cloudflare_zero_trust_dex_test" "traceroute_hostname" {
+  account_id  = var.cloudflare_account_id
+  name        = "${local.name_prefix}-traceroute-to-hostname"
+  description = "Test path to cloudflare.com"
+  interval    = "2h0m0s"
+  enabled     = true
+
+  data = {
+    kind = "traceroute"
+    host = "cloudflare.com"
+  }
+}
+
+# Test 6: for_each with map
+locals {
+  dex_tests = {
+    "production-api" = {
+      host        = "https://api.prod.example.com"
+      description = "Production API monitoring"
+      interval    = "0h5m0s"
+    }
+    "staging-api" = {
+      host        = "https://api.staging.example.com"
+      description = "Staging API monitoring"
+      interval    = "0h15m0s"
+    }
+    "dev-api" = {
+      host        = "https://api.dev.example.com"
+      description = "Dev API monitoring"
+      interval    = "0h30m0s"
+    }
+  }
+}
+
+resource "cloudflare_zero_trust_dex_test" "api_tests" {
+  for_each = local.dex_tests
+
+  account_id  = var.cloudflare_account_id
+  name        = "${local.name_prefix}-api-test-${each.key}"
+  description = each.value.description
+  interval    = each.value.interval
+  enabled     = true
+
+  data = {
+    kind   = "http"
+    host   = each.value.host
+    method = "GET"
+  }
+}
+
+# Test 7: for_each with set
+resource "cloudflare_zero_trust_dex_test" "dns_tests" {
+  for_each = toset(["1.1.1.1", "8.8.8.8", "8.8.4.4"])
+
+  account_id  = var.cloudflare_account_id
+  name        = "${local.name_prefix}-dns-test-${each.value}"
+  description = "Test connectivity to ${each.value}"
+  interval    = "1h0m0s"
+  enabled     = true
+
+  data = {
+    kind = "traceroute"
+    host = each.value
+  }
+}
+
+# Test 8: count pattern
+resource "cloudflare_zero_trust_dex_test" "regional_tests" {
+  count = 3
+
+  account_id  = var.cloudflare_account_id
+  name        = "${local.name_prefix}-regional-test-${count.index + 1}"
+  description = "Test endpoint in region ${count.index + 1}"
+  interval    = "0h30m0s"
+  enabled     = true
+
+  data = {
+    kind   = "http"
+    host   = "https://region${count.index + 1}.example.com"
+    method = "GET"
+  }
+}
+
+# Test 9: Conditional creation
+variable "enable_backup_tests" {
+  type    = bool
+  default = true
+}
+
+resource "cloudflare_zero_trust_dex_test" "backup_test" {
+  count = var.enable_backup_tests ? 1 : 0
+
+  account_id  = var.cloudflare_account_id
+  name        = "${local.name_prefix}-backup-system-test"
+  description = "Test backup system availability"
+  interval    = "4h0m0s"
+  enabled     = true
+
+  data = {
+    kind   = "http"
+    host   = "https://backup.example.com/status"
+    method = "GET"
+  }
+}
+
+# Test 10: Using dynamic values
+locals {
+  monitoring_config = {
+    interval_minutes = 30
+    enabled          = true
+  }
+}
+
+resource "cloudflare_zero_trust_dex_test" "dynamic_config" {
+  account_id  = var.cloudflare_account_id
+  name        = "${local.name_prefix}-dynamic-configuration-test"
+  description = "Test with dynamic configuration values"
+  interval    = "0h${local.monitoring_config.interval_minutes}m0s"
+  enabled     = local.monitoring_config.enabled
+
+  data = {
+    kind   = "http"
+    host   = "https://metrics.example.com"
+    method = "GET"
+  }
+}
+
+# Test 11: HTTP test with HTTPS URL
+resource "cloudflare_zero_trust_dex_test" "https_test" {
+  account_id  = var.cloudflare_account_id
+  name        = "${local.name_prefix}-https-connectivity-test"
+  description = "Verify HTTPS connectivity"
+  interval    = "0h10m0s"
+  enabled     = true
+
+  data = {
+    kind   = "http"
+    host   = "https://secure.example.com"
+    method = "GET"
+  }
+}
+
+# Test 12: Internal network test
+resource "cloudflare_zero_trust_dex_test" "internal" {
+  account_id  = var.cloudflare_account_id
+  name        = "${local.name_prefix}-internal-network-test"
+  description = "Test internal resource availability"
+  interval    = "0h5m0s"
+  enabled     = true
+
+  data = {
+    kind   = "http"
+    host   = "https://internal.corp.example.com/healthcheck"
+    method = "GET"
+  }
+}
+
+# Test 13: Long description
+resource "cloudflare_zero_trust_dex_test" "long_description" {
+  account_id  = var.cloudflare_account_id
+  name        = "${local.name_prefix}-test-with-long-description"
+  description = <<-EOT
+    This is a comprehensive DEX test with a very detailed description
+    that spans multiple lines and contains important information about
+    what this test does, why it exists, and how it should be monitored.
+  EOT
+  interval    = "1h0m0s"
+  enabled     = true
+
+  data = {
+    kind   = "http"
+    host   = "https://example.com/detailed"
+    method = "GET"
+  }
+}
+
+# Test 14: IPv6 traceroute
+resource "cloudflare_zero_trust_dex_test" "ipv6_traceroute" {
+  account_id  = var.cloudflare_account_id
+  name        = "${local.name_prefix}-ipv6-traceroute-test"
+  description = "Test IPv6 connectivity"
+  interval    = "2h0m0s"
+  enabled     = true
+
+  data = {
+    kind = "traceroute"
+    host = "2001:4860:4860::8888"
+  }
+}
+
+# Test 15: API endpoint with path
+resource "cloudflare_zero_trust_dex_test" "api_with_path" {
+  account_id  = var.cloudflare_account_id
+  name        = "${local.name_prefix}-api-endpoint-test"
+  description = "Test specific API endpoint"
+  interval    = "0h10m0s"
+  enabled     = true
+
+  data = {
+    kind   = "http"
+    host   = "https://api.example.com/v1/status"
+    method = "GET"
+  }
+}
+
+# ============================================================================
+# Pattern Group 9: Cross-File References (Resource Rename Test)
+# ============================================================================
+
+# Pattern 9 tests that cross-file references are updated when resource names change.
+# The migrator renames:
+#   cloudflare_device_dex_test -> cloudflare_zero_trust_dex_test
+#   cloudflare_zero_trust_dex_test -> cloudflare_zero_trust_dex_test (no-op)
+
+
+# Using new v4 name (cloudflare_zero_trust_dex_test) -> stays cloudflare_zero_trust_dex_test
+resource "cloudflare_zero_trust_dex_test" "ref_source_new_name" {
+  account_id  = var.cloudflare_account_id
+  name        = "${local.name_prefix}-ref-new-name"
+  description = "Referenced by dex test rename"
+  interval    = "2h0m0s"
+  enabled     = true
+
+  data = {
+    kind = "traceroute"
+    host = "1.1.1.1"
+  }
+}
+
+# Using old v4 name (cloudflare_device_dex_test) -> becomes cloudflare_zero_trust_dex_test
+resource "cloudflare_zero_trust_dex_test" "ref_source_old_name" {
+  account_id  = var.cloudflare_account_id
+  name        = "${local.name_prefix}-ref-old-name"
+  description = "Referenced by dex test rename"
+  interval    = "1h0m0s"
+  enabled     = true
+
+  data = {
+    kind   = "http"
+    host   = "https://test-old.example.com"
+    method = "GET"
+  }
+}
+
+
+variable "from_version" {
+  description = "Provider version under test, used to namespace resource names"
+  type        = string
+}

--- a/e2e-v5/testdata/zero_trust_dlp_custom_profile/zero_trust_dlp_custom_profile.tf
+++ b/e2e-v5/testdata/zero_trust_dlp_custom_profile/zero_trust_dlp_custom_profile.tf
@@ -1,0 +1,386 @@
+# Variables (standard - provided by test framework)
+variable "cloudflare_account_id" {
+  description = "Cloudflare account ID"
+  type        = string
+}
+
+variable "cloudflare_zone_id" {
+  description = "Cloudflare zone ID"
+  type        = string
+}
+
+variable "cloudflare_domain" {
+  description = "Cloudflare domain for testing"
+  type        = string
+}
+
+# Resource-specific variables with defaults
+variable "enable_credit_detection" {
+  type    = bool
+  default = true
+}
+
+variable "enable_pii_detection" {
+  type    = bool
+  default = false
+}
+
+variable "max_allowed_matches" {
+  type    = number
+  default = 5
+}
+
+# Locals for common values and computed configurations
+locals {
+  common_account     = var.cloudflare_account_id
+  name_prefix        = "v5-upgrade-${replace(var.from_version, ".", "-")}-dlp2"
+  tags               = ["migration", "test", "v4_to_v5"]
+  gateway_precedence = 100000 + tonumber(split(".", var.from_version)[1]) * 1000
+
+  # Map for for_each iteration
+  card_patterns = {
+    visa = {
+      regex      = "4[0-9]{12}(?:[0-9]{3})?"
+      validation = "luhn"
+      enabled    = true
+    }
+    mastercard = {
+      regex      = "5[1-5][0-9]{14}"
+      validation = "luhn"
+      enabled    = true
+    }
+    amex = {
+      regex      = "3[47][0-9]{13}"
+      validation = "luhn"
+      enabled    = false
+    }
+    discover = {
+      regex      = "6(?:011|5[0-9]{2})[0-9]{12}"
+      validation = "luhn"
+      enabled    = true
+    }
+  }
+
+  # Set for for_each iteration
+  pii_types = toset([
+    "ssn",
+    "passport",
+    "drivers_license",
+    "tax_id"
+  ])
+}
+
+
+
+
+
+
+
+
+
+
+
+
+# ============================================================================
+# Pattern Group 9: Cross-File References (Resource Rename Test)
+# ============================================================================
+
+# Pattern 9 tests that cross-file references are updated when resource names change.
+# The migrator renames:
+#   cloudflare_dlp_profile -> cloudflare_zero_trust_dlp_custom_profile
+#   cloudflare_zero_trust_dlp_profile -> cloudflare_zero_trust_dlp_custom_profile
+# We create dependent resources (gateway policies) that reference these DLP profiles via profile_id attribute.
+# After migration, the attribute references must be updated to use the new resource names.
+
+
+
+# Dependent resources that reference the above DLP profiles
+# Using realistic gateway policies with profile_id references
+
+# Gateway policy referencing old-name DLP profile via attribute
+resource "cloudflare_zero_trust_gateway_policy" "uses_old_dlp_profile" {
+  account_id  = var.cloudflare_account_id
+  name        = "${local.name_prefix} Gateway Policy - Old DLP Profile"
+  description = "Policy using old-name DLP profile"
+  action      = "block"
+  precedence  = local.gateway_precedence
+  enabled     = true
+  traffic     = "any(dns.domains[*] == \"dlp-old.example.com\")"
+
+  # Attribute reference that needs updating after migration
+  # profile_id = cloudflare_zero_trust_dlp_custom_profile.ref_source_old_name.id
+}
+
+# Gateway policy referencing new-name DLP profile via attribute
+resource "cloudflare_zero_trust_gateway_policy" "uses_new_dlp_profile" {
+  account_id  = var.cloudflare_account_id
+  name        = "${local.name_prefix} Gateway Policy - New DLP Profile"
+  description = "Policy using new-name DLP profile"
+  action      = "allow"
+  precedence  = local.gateway_precedence + 1
+  enabled     = true
+  traffic     = "any(dns.domains[*] == \"dlp-new.example.com\")"
+
+  # Attribute reference that needs updating after migration
+  # profile_id = cloudflare_zero_trust_dlp_custom_profile.ref_source_new_name.id
+}
+
+# Pattern 1: Basic profiles with entries
+resource "cloudflare_zero_trust_dlp_custom_profile" "credit_cards_basic" {
+  account_id          = local.common_account
+  name                = "${local.name_prefix}-credit-cards-basic"
+  description         = "Basic profile for detecting credit card numbers"
+  allowed_match_count = var.max_allowed_matches
+
+
+  entries = [{
+    name    = "${local.name_prefix}-visa-card"
+    enabled = true
+    pattern = {
+      regex      = "4[0-9]{12}(?:[0-9]{3})?"
+      validation = "luhn"
+    }
+    }, {
+    name    = "${local.name_prefix}-mastercard"
+    enabled = true
+    pattern = {
+      regex      = "5[1-5][0-9]{14}"
+      validation = "luhn"
+    }
+  }]
+}
+
+
+resource "cloudflare_zero_trust_dlp_custom_profile" "ssn_detection" {
+  account_id          = var.cloudflare_account_id
+  name                = join("-", [local.name_prefix, "ssn", "detection"])
+  allowed_match_count = 3
+
+  entries = [{
+    name    = "${local.name_prefix}-ssn-pattern"
+    enabled = true
+    pattern = {
+      regex = "[0-9]{3}-[0-9]{2}-[0-9]{4}"
+    }
+  }]
+}
+
+
+resource "cloudflare_zero_trust_dlp_custom_profile" "minimal" {
+  account_id          = var.cloudflare_account_id
+  name                = "${local.name_prefix}-minimal"
+  description         = "Minimal configuration for ${var.cloudflare_account_id}"
+  allowed_match_count = 1
+
+  entries = [{
+    name    = "${local.name_prefix}-simple-pattern"
+    enabled = true
+    pattern = {
+      regex = "test[0-9]{1,10}"
+    }
+  }]
+}
+
+
+# Pattern 2: for_each with maps (4 instances)
+resource "cloudflare_zero_trust_dlp_custom_profile" "card_profiles_map" {
+  for_each = local.card_patterns
+
+  account_id          = var.cloudflare_account_id
+  name                = "${local.name_prefix}-card-${each.key}"
+  description         = "Dedicated profile for ${each.key} cards"
+  allowed_match_count = 10
+
+  entries = [{
+    name    = "${local.name_prefix}-${each.key}-pattern"
+    enabled = each.value.enabled
+    pattern = {
+      regex      = each.value.regex
+      validation = each.value.validation
+    }
+  }]
+}
+
+
+# Pattern 3: for_each with sets (4 instances)
+resource "cloudflare_zero_trust_dlp_custom_profile" "pii_profiles_set" {
+  for_each = local.pii_types
+
+  account_id          = var.cloudflare_account_id
+  name                = "${local.name_prefix}-v5-pii-${each.value}"
+  allowed_match_count = 2
+
+  entries = [{
+    name    = "${local.name_prefix}-v5-pii-${each.value}-pattern"
+    enabled = true
+    pattern = {
+      regex = "[A-Z0-9]{8,15}"
+    }
+  }]
+}
+
+
+# Pattern 4: count-based resources (3 instances)
+resource "cloudflare_zero_trust_dlp_custom_profile" "counted_profiles" {
+  count = 3
+
+  account_id          = var.cloudflare_account_id
+  name                = "${local.name_prefix}-counted-${count.index}"
+  description         = "This is profile number ${count.index}"
+  allowed_match_count = count.index + 1
+
+  entries = [{
+    name    = "${local.name_prefix}-pattern-${count.index}"
+    enabled = count.index % 2 == 0 ? true : false
+    pattern = {
+      regex = "pattern-${count.index}-[0-9]{1,4}"
+    }
+  }]
+}
+
+
+# Pattern 5: Conditional creation (1 instance when enabled)
+resource "cloudflare_zero_trust_dlp_custom_profile" "conditional_credit" {
+  count = var.enable_credit_detection ? 1 : 0
+
+  account_id          = var.cloudflare_account_id
+  name                = "${local.name_prefix}-conditional-credit"
+  description         = "Created conditionally based on variable"
+  allowed_match_count = 15
+
+  entries = [{
+    name    = "${local.name_prefix}-all-credit-cards"
+    enabled = true
+    pattern = {
+      regex      = "(?:4[0-9]{12}(?:[0-9]{3})?|5[1-5][0-9]{14}|3[47][0-9]{13})"
+      validation = "luhn"
+    }
+  }]
+}
+
+
+resource "cloudflare_zero_trust_dlp_custom_profile" "conditional_pii" {
+  count = var.enable_pii_detection ? 1 : 0
+
+  account_id          = var.cloudflare_account_id
+  name                = "${local.name_prefix}-conditional-pii"
+  allowed_match_count = 20
+
+  entries = [{
+    name    = "${local.name_prefix}-pii-pattern"
+    enabled = true
+    pattern = {
+      regex = "[A-Z]{2}[0-9]{6}"
+    }
+  }]
+}
+
+
+# Pattern 6: Multiple entries
+resource "cloudflare_zero_trust_dlp_custom_profile" "dynamic_entries" {
+  account_id          = var.cloudflare_account_id
+  name                = "${local.name_prefix}-dynamic-entries"
+  description         = "Profile with multiple entries"
+  allowed_match_count = 30
+
+
+
+  entries = [{
+    name    = "${local.name_prefix}-api-key"
+    enabled = true
+    pattern = {
+      regex = "api_key[\\s:=][a-zA-Z0-9]{20,30}"
+    }
+    }, {
+    name    = "${local.name_prefix}-password"
+    enabled = false
+    pattern = {
+      regex = "password[\\s:=][a-zA-Z0-9]{8,16}"
+    }
+    }, {
+    name    = "${local.name_prefix}-token"
+    enabled = true
+    pattern = {
+      regex = "token[\\s:=][a-zA-Z0-9._-]{20,30}"
+    }
+  }]
+}
+
+
+# Pattern 7: Profile with null values
+resource "cloudflare_zero_trust_dlp_custom_profile" "with_nulls" {
+  account_id          = var.cloudflare_account_id
+  name                = "${local.name_prefix}-with-nulls"
+  description         = null
+  allowed_match_count = 4
+
+  entries = [{
+    name    = "${local.name_prefix}-entry-with-null-id"
+    enabled = true
+    pattern = {
+      regex      = "NULL[0-9]{1,4}"
+      validation = null
+    }
+  }]
+}
+
+
+# Pattern 8: Profile with lifecycle meta-arguments
+resource "cloudflare_zero_trust_dlp_custom_profile" "prevent_destroy" {
+  account_id          = var.cloudflare_account_id
+  name                = "${local.name_prefix}-protected"
+  description         = "This profile should not be destroyed"
+  allowed_match_count = 50
+
+
+  lifecycle {
+    prevent_destroy = false
+  }
+  entries = [{
+    name    = "${local.name_prefix}-protected-pattern"
+    enabled = true
+    pattern = {
+      regex = "PROTECTED[0-9]{1,4}"
+    }
+  }]
+}
+
+
+# Using old v4 name (cloudflare_dlp_profile) -> becomes cloudflare_zero_trust_dlp_custom_profile
+resource "cloudflare_zero_trust_dlp_custom_profile" "ref_source_old_name" {
+  account_id          = var.cloudflare_account_id
+  name                = "${local.name_prefix}-ref-old-name"
+  description         = "Referenced by gateway policy (old name)"
+  allowed_match_count = 10
+
+  entries = [{
+    name    = "${local.name_prefix}-reference-pattern-old"
+    enabled = true
+    pattern = {
+      regex = "REF-OLD-[0-9]{4}"
+    }
+  }]
+}
+
+
+# Using second v4 name (cloudflare_zero_trust_dlp_profile) -> becomes cloudflare_zero_trust_dlp_custom_profile
+resource "cloudflare_zero_trust_dlp_custom_profile" "ref_source_new_name" {
+  account_id          = var.cloudflare_account_id
+  name                = "${local.name_prefix}-ref-new-name"
+  description         = "Referenced by gateway policy (new name)"
+  allowed_match_count = 15
+
+  entries = [{
+    name    = "${local.name_prefix}-reference-pattern-new"
+    enabled = true
+    pattern = {
+      regex = "REF-NEW-[0-9]{4}"
+    }
+  }]
+}
+
+
+variable "from_version" {
+  description = "Provider version under test, used to namespace resource names"
+  type        = string
+}

--- a/e2e-v5/testdata/zero_trust_dlp_predefined_profile/zero_trust_dlp_predefined_profile.tf
+++ b/e2e-v5/testdata/zero_trust_dlp_predefined_profile/zero_trust_dlp_predefined_profile.tf
@@ -1,0 +1,37 @@
+# Variables (standard - provided by test framework)
+variable "cloudflare_account_id" {
+  description = "Cloudflare account ID"
+  type        = string
+}
+
+variable "cloudflare_zone_id" {
+  description = "Cloudflare zone ID"
+  type        = string
+}
+
+variable "cloudflare_domain" {
+  description = "Cloudflare domain for testing"
+  type        = string
+}
+
+
+# Predefined profile: "Credentials and Secrets"
+# This profile already exists in the account and must be imported.
+# tf-migrate:import-address=${var.cloudflare_account_id}/c8932cc4-3312-4152-8041-f3f257122dc4
+resource "cloudflare_zero_trust_dlp_predefined_profile" "credentials_and_secrets" {
+  profile_id = "c8932cc4-3312-4152-8041-f3f257122dc4"
+  account_id          = var.cloudflare_account_id
+  allowed_match_count = 0
+
+
+
+
+
+  enabled_entries = []
+}
+
+
+variable "from_version" {
+  description = "Provider version under test, used to namespace resource names"
+  type        = string
+}

--- a/e2e-v5/testdata/zero_trust_gateway_certificate/zero_trust_gateway_certificate.tf
+++ b/e2e-v5/testdata/zero_trust_gateway_certificate/zero_trust_gateway_certificate.tf
@@ -1,0 +1,38 @@
+variable "cloudflare_account_id" {
+  description = "Cloudflare account ID"
+  type        = string
+}
+
+variable "cloudflare_zone_id" {
+  description = "Cloudflare zone ID (unused)"
+  type        = string
+  default     = ""
+}
+
+variable "cloudflare_domain" {
+  description = "Cloudflare domain (unused)"
+  type        = string
+  default     = ""
+}
+
+variable "from_version" {
+  description = "Provider version under test, used to namespace resource names"
+  type        = string
+}
+
+locals {
+  name_prefix = "v5-upgrade-${replace(var.from_version, ".", "-")}"
+}
+
+# Only 1 gateway-managed certificate — API rate limit is 3 per 24 hours account-wide.
+# Keep to minimum to avoid exhausting the quota across concurrent or repeated runs.
+resource "cloudflare_zero_trust_gateway_certificate" "managed" {
+  account_id           = var.cloudflare_account_id
+  validity_period_days = 1826
+  activate             = true
+
+  lifecycle {
+    create_before_destroy = true
+    ignore_changes        = [activate]
+  }
+}

--- a/e2e-v5/testdata/zero_trust_gateway_policy/zero_trust_gateway_policy.tf
+++ b/e2e-v5/testdata/zero_trust_gateway_policy/zero_trust_gateway_policy.tf
@@ -1,0 +1,500 @@
+variable "cloudflare_account_id" {
+  description = "Cloudflare account ID"
+  type        = string
+}
+
+variable "cloudflare_zone_id" {
+  description = "Cloudflare zone ID"
+  type        = string
+}
+
+variable "cloudflare_domain" {
+  description = "Cloudflare domain for testing"
+  type        = string
+}
+
+# Resource-specific variables with defaults
+variable "policy_prefix" {
+  type    = string
+  default = "test"
+}
+
+variable "enable_security_policies" {
+  type    = bool
+  default = true
+}
+
+variable "policy_configs" {
+  type = map(object({
+    action      = string
+    precedence  = number
+    description = string
+  }))
+  default = {
+    allow_internal = {
+      action      = "allow"
+      precedence  = 100
+      description = "Allow internal traffic"
+    }
+    block_malware = {
+      action      = "block"
+      precedence  = 200
+      description = "Block known malware domains"
+    }
+    audit_api = {
+      action      = "allow"
+      precedence  = 300
+      description = "Audit API traffic"
+    }
+  }
+}
+
+# Locals with multiple values
+locals {
+  name_prefix               = "v5-upgrade-${replace(var.from_version, ".", "-")}"
+  common_account_id         = var.cloudflare_account_id
+  policy_name_prefix        = "${local.name_prefix}-${var.policy_prefix}-policy"
+  precedence_base           = 100000 + tonumber(split(".", var.from_version)[1]) * 1000
+  dns_filter                = ["dns"]
+  http_filter               = ["http"]
+  l4_filter                 = ["l4"]
+  common_traffic_expression = "any(dns.domains[*] == \"cf-tf-test.com\")"
+  block_reason              = "Access blocked by company policy - ${var.policy_prefix}"
+}
+
+# ============================================================================
+# Pattern Group 1: Basic Resources (Edge Cases)
+# ============================================================================
+
+
+
+
+
+
+
+# ============================================================================
+# Pattern Group 2: for_each with Maps
+# ============================================================================
+
+
+# ============================================================================
+# Pattern Group 3: for_each with Sets
+# ============================================================================
+
+
+# ============================================================================
+# Pattern Group 4: count-based Resources
+# ============================================================================
+
+
+# ============================================================================
+# Pattern Group 5: Conditional Creation
+# ============================================================================
+
+
+
+# ============================================================================
+# Pattern Group 6: Terraform Functions
+# ============================================================================
+
+
+
+# ============================================================================
+# Pattern Group 7: Lifecycle Meta-Arguments
+# ============================================================================
+
+
+
+# ============================================================================
+# Pattern Group 8: Additional Edge Cases & Action Types
+# ============================================================================
+
+
+
+
+
+
+
+# Total: 28 base resources + 3 from for_each map + 4 from for_each set + 3 from count = 38 instances
+
+# 1. Minimal gateway policy
+resource "cloudflare_zero_trust_gateway_policy" "minimal" {
+  account_id  = local.common_account_id
+  name        = "${local.name_prefix} Minimal Policy"
+  description = "Basic block policy"
+  precedence  = local.precedence_base + 100
+  action      = "block"
+  filters     = local.dns_filter
+  traffic     = local.common_traffic_expression
+}
+
+
+# 2. Maximal policy with all settings
+resource "cloudflare_zero_trust_gateway_policy" "maximal" {
+  account_id  = var.cloudflare_account_id
+  name        = "${local.policy_name_prefix}-maximal"
+  description = "Policy with DNS override settings"
+  precedence  = local.precedence_base + 150
+  action      = "override"
+  enabled     = true
+  filters     = local.dns_filter
+  traffic     = "any(dns.domains[*] in {\"example.com\" \"test.com\"})"
+
+  rule_settings = {
+    override_ips = ["1.1.1.1", "1.0.0.1"]
+  }
+}
+
+
+# 3. Policy with rule_settings and field renames
+resource "cloudflare_zero_trust_gateway_policy" "with_settings" {
+  account_id  = var.cloudflare_account_id
+  name        = "${local.name_prefix} Override Policy with Settings"
+  description = "Policy with DNS override settings"
+  precedence  = local.precedence_base + 200
+  action      = "override"
+  enabled     = true
+  filters     = ["dns"]
+  traffic     = "any(dns.domains[*] in {\"example.com\" \"test.com\"})"
+
+  rule_settings = {
+    override_ips = ["1.1.1.1", "1.0.0.1"]
+  }
+}
+
+
+# 4. Policy with nested blocks requiring transformation
+resource "cloudflare_zero_trust_gateway_policy" "with_nested_blocks" {
+  account_id  = var.cloudflare_account_id
+  name        = "${local.name_prefix} L4 Override Policy"
+  description = "Policy with L4 override and notification"
+  precedence  = local.precedence_base + 300
+  action      = "l4_override"
+  enabled     = true
+  filters     = local.l4_filter
+  traffic     = "net.dst.ip == 93.184.216.34"
+
+  rule_settings = {
+    l4override = {
+      ip   = "192.168.1.100"
+      port = 8080
+    }
+  }
+}
+
+
+# 5. Complex policy with multiple nested structures
+resource "cloudflare_zero_trust_gateway_policy" "complex" {
+  account_id  = var.cloudflare_account_id
+  name        = "${local.name_prefix} Complex Policy"
+  description = "Policy with many nested settings"
+  precedence  = local.precedence_base + 400
+  action      = "allow"
+  enabled     = true
+  filters     = local.http_filter
+  traffic     = "http.request.uri matches \".*api.*\""
+
+  rule_settings = {
+    audit_ssh = {
+      command_logging = true
+    }
+    biso_admin_controls = {
+      version = "v1"
+      dp      = true
+      dd      = true
+    }
+    check_session = {
+      enforce  = true
+      duration = "24h0m0s"
+    }
+    payload_log = {
+      enabled = true
+    }
+  }
+}
+
+
+# 6. Simple allow policy for testing rule_settings
+resource "cloudflare_zero_trust_gateway_policy" "simple_resolver" {
+  account_id  = var.cloudflare_account_id
+  name        = "${local.name_prefix} Simple Allow Policy"
+  description = "Simple allow policy with settings"
+  precedence  = local.precedence_base + 500
+  action      = "allow"
+  enabled     = true
+  filters     = ["dns"]
+  traffic     = "any(dns.domains[*] == \"allowed.cf-tf-test.com\")"
+
+  rule_settings = {
+    block_page_enabled = false
+  }
+}
+
+
+# 7-9. Resources created with for_each over map
+resource "cloudflare_zero_trust_gateway_policy" "policy_configs" {
+  for_each = var.policy_configs
+
+  account_id  = var.cloudflare_account_id
+  name        = "${local.policy_name_prefix}-${each.key}"
+  description = each.value.description
+  precedence  = local.precedence_base + each.value.precedence + 5000 # Add offset to avoid conflicts
+  action      = each.value.action
+  enabled     = true
+  filters     = ["dns"]
+  traffic     = "any(dns.domains[*] == \"${each.key}.cf-tf-test.com\")"
+}
+
+
+# 10-13. Resources created with for_each over set
+resource "cloudflare_zero_trust_gateway_policy" "environment_policies" {
+  for_each = toset(["staging", "production", "development", "testing"])
+
+  account_id  = var.cloudflare_account_id
+  name        = "${local.policy_name_prefix}-${each.value}"
+  description = "Policy for ${each.value} environment"
+  precedence  = local.precedence_base + 600 + index(["staging", "production", "development", "testing"], each.value)
+  action      = "allow"
+  enabled     = true
+  filters     = ["dns"]
+  traffic     = "any(dns.domains[*] == \"${each.value}.cf-tf-test.com\")"
+}
+
+
+# 14-16. Resources created with count
+resource "cloudflare_zero_trust_gateway_policy" "tiered_policies" {
+  count = 3
+
+  account_id  = var.cloudflare_account_id
+  name        = "${local.policy_name_prefix}-tier-${count.index}"
+  description = "Tier ${count.index} policy"
+  precedence  = local.precedence_base + 700 + (count.index * 10)
+  action      = count.index == 0 ? "block" : "allow"
+  enabled     = true
+  filters     = ["dns"]
+  traffic     = "any(dns.domains[*] == \"tier${count.index}.cf-tf-test.com\")"
+}
+
+
+# 17. Conditionally created policy
+resource "cloudflare_zero_trust_gateway_policy" "conditional_enabled" {
+  count = var.enable_security_policies ? 1 : 0
+
+  account_id  = var.cloudflare_account_id
+  name        = "${local.name_prefix} Security Policy - Enabled"
+  description = "This policy is conditionally created"
+  precedence  = local.precedence_base + 800
+  action      = "block"
+  enabled     = true
+  filters     = ["dns"]
+  traffic     = "any(dns.domains[*] in {\"malware.cf-tf-test.com\" \"phishing.cf-tf-test.com\"})"
+
+  rule_settings = {
+    block_page_enabled = true
+    block_reason       = "This domain is blocked for security reasons"
+  }
+}
+
+
+# 18. Conditionally not created policy
+resource "cloudflare_zero_trust_gateway_policy" "conditional_disabled" {
+  count = var.enable_security_policies ? 0 : 1
+
+  account_id  = var.cloudflare_account_id
+  name        = "${local.name_prefix} Security Policy - Disabled"
+  description = "This policy is conditionally not created"
+  precedence  = local.precedence_base + 900
+  action      = "allow"
+  enabled     = false
+  filters     = ["dns"]
+  traffic     = "any(dns.domains[*] == \"insecure.cf-tf-test.com\")"
+}
+
+
+# 19. Policy using join() function
+resource "cloudflare_zero_trust_gateway_policy" "with_join" {
+  account_id  = var.cloudflare_account_id
+  name        = join("-", [local.policy_name_prefix, "joined", "policy"])
+  description = "Policy created with join function"
+  precedence  = local.precedence_base + 1000
+  action      = "allow"
+  enabled     = true
+  filters     = ["dns"]
+  traffic     = "any(dns.domains[*] == \"${join(".", ["subdomain", "example", "com"])}\")"
+}
+
+
+# 20. Policy using string interpolation
+resource "cloudflare_zero_trust_gateway_policy" "with_interpolation" {
+  account_id  = var.cloudflare_account_id
+  name        = "${local.name_prefix} Policy for account ${var.cloudflare_account_id}"
+  description = "Description with ${local.policy_name_prefix} interpolation"
+  precedence  = local.precedence_base + 1200
+  action      = "allow"
+  enabled     = true
+  filters     = ["http"]
+  traffic     = "http.request.host == \"${var.policy_prefix}.cf-tf-test.com\""
+}
+
+
+# 21. Policy with lifecycle block
+resource "cloudflare_zero_trust_gateway_policy" "with_lifecycle" {
+  account_id  = var.cloudflare_account_id
+  name        = "${local.name_prefix} Protected Policy"
+  description = "Policy with lifecycle settings"
+  precedence  = local.precedence_base + 1210
+  action      = "block"
+  enabled     = true
+  filters     = ["dns"]
+  traffic     = "any(dns.domains[*] == \"protected.cf-tf-test.com\")"
+
+  lifecycle {
+    create_before_destroy = true
+    ignore_changes        = [description]
+  }
+}
+
+
+# 22. Policy with prevent_destroy (set to false for testing)
+resource "cloudflare_zero_trust_gateway_policy" "with_prevent_destroy" {
+  account_id  = var.cloudflare_account_id
+  name        = "${local.name_prefix} Important Policy"
+  description = "Critical policy"
+  precedence  = local.precedence_base + 1300
+  action      = "block"
+  enabled     = true
+  filters     = ["dns"]
+  traffic     = "any(dns.domains[*] == \"critical.cf-tf-test.com\")"
+
+  lifecycle {
+    prevent_destroy = false # Set to false for testing
+  }
+
+  rule_settings = {
+    block_page_enabled = true
+    block_reason       = "Critical domain blocked"
+  }
+}
+
+
+# 23. L4 Override policy with specific settings
+resource "cloudflare_zero_trust_gateway_policy" "l4_override_detailed" {
+  account_id  = var.cloudflare_account_id
+  name        = "${local.name_prefix} L4 Override Detailed"
+  description = "Detailed L4 override configuration"
+  precedence  = local.precedence_base + 1400
+  action      = "l4_override"
+  enabled     = true
+  filters     = ["l4"]
+  traffic     = "net.dst.ip == 203.0.113.1"
+
+  rule_settings = {
+    l4override = {
+      ip   = "10.0.0.1"
+      port = 9090
+    }
+  }
+}
+
+
+# 24. Policy with audit SSH settings
+resource "cloudflare_zero_trust_gateway_policy" "with_audit_ssh" {
+  account_id  = var.cloudflare_account_id
+  name        = "${local.name_prefix} SSH Audit Policy"
+  description = "Policy with SSH auditing enabled"
+  precedence  = local.precedence_base + 1500
+  action      = "allow"
+  enabled     = true
+  filters     = ["l4"]
+  traffic     = "net.dst.port == 22"
+
+  rule_settings = {
+    audit_ssh = {
+      command_logging = true
+    }
+  }
+}
+
+
+# 25. Policy with check_session settings
+resource "cloudflare_zero_trust_gateway_policy" "with_check_session" {
+  account_id  = var.cloudflare_account_id
+  name        = "${local.name_prefix} Session Check Policy"
+  description = "Policy with session validation"
+  precedence  = local.precedence_base + 1600
+  action      = "allow"
+  enabled     = true
+  filters     = ["http"]
+  traffic     = "http.request.host == \"secure.cf-tf-test.com\""
+
+  rule_settings = {
+    check_session = {
+      enforce  = true
+      duration = "12h0m0s"
+    }
+  }
+}
+
+
+# 26. Policy with BISO admin controls
+resource "cloudflare_zero_trust_gateway_policy" "with_biso" {
+  account_id  = var.cloudflare_account_id
+  name        = "${local.name_prefix} BISO Controls Policy"
+  description = "Policy with browser isolation controls"
+  precedence  = local.precedence_base + 1700
+  action      = "isolate"
+  enabled     = true
+  filters     = ["http"]
+  traffic     = "http.request.host == \"isolated.cf-tf-test.com\""
+
+  rule_settings = {
+    biso_admin_controls = {
+      version = "v2"
+      dp      = true
+      dd      = true
+    }
+  }
+}
+
+
+# 27. Policy with payload logging
+resource "cloudflare_zero_trust_gateway_policy" "with_payload_log" {
+  account_id  = var.cloudflare_account_id
+  name        = "${local.name_prefix} Payload Logging Policy"
+  description = "Policy with payload logging enabled"
+  precedence  = local.precedence_base + 1800
+  action      = "allow"
+  enabled     = true
+  filters     = ["http"]
+  traffic     = "http.request.uri matches \".*/api/.*\""
+
+  rule_settings = {
+    payload_log = {
+      enabled = true
+    }
+  }
+}
+
+
+# 28. Policy with override IPs
+resource "cloudflare_zero_trust_gateway_policy" "with_override_ips" {
+  account_id  = var.cloudflare_account_id
+  name        = "${local.name_prefix} DNS Override Policy"
+  description = "Policy with custom DNS servers"
+  precedence  = local.precedence_base + 1900
+  action      = "override"
+  enabled     = true
+  filters     = ["dns"]
+  traffic     = "any(dns.domains[*] == \"override.cf-tf-test.com\")"
+
+  rule_settings = {
+    override_ips  = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+    ip_categories = false
+  }
+}
+
+
+variable "from_version" {
+  description = "Provider version under test, used to namespace resource names"
+  type        = string
+}

--- a/e2e-v5/testdata/zero_trust_gateway_settings/zero_trust_gateway_settings.tf
+++ b/e2e-v5/testdata/zero_trust_gateway_settings/zero_trust_gateway_settings.tf
@@ -1,0 +1,107 @@
+variable "cloudflare_account_id" {
+  description = "Cloudflare account ID for E2E testing"
+  type        = string
+}
+
+variable "cloudflare_zone_id" {
+  description = "Cloudflare zone ID (not used by gateway settings, but required by test harness)"
+  type        = string
+}
+
+variable "cloudflare_domain" {
+  description = "Cloudflare domain (not used by gateway settings, but required by test harness)"
+  type        = string
+  default     = ""
+}
+
+# ============================================================================
+# E2E Test: Gateway Settings Configuration (Basic Features Only)
+# ============================================================================
+# This is the ONLY test case that should be applied in E2E testing, as there
+# can only be ONE gateway settings resource per account.
+#
+# This test case uses only basic features that don't require paid entitlements:
+# - Basic boolean settings (activity_log, tls_decrypt, protocol_detection)
+# - Browser isolation with defaults (false - no entitlement needed)
+# - Basic blocks: block_page, body_scanning, fips
+# - Deprecated blocks that create separate resources (logging, proxy)
+#
+# Features excluded due to entitlement requirements:
+# - antivirus (requires entitlement)
+# - extended_email_matching (may require entitlement)
+# - certificate/custom_certificate (requires real cert IDs)
+#
+# Note: tls_decrypt_enabled is set to false because the Cloudflare API now
+# requires a certificate to be configured when TLS decryption is enabled
+# (API error 2211). fips.tls is also set to false since FIPS TLS mode
+# depends on TLS decryption being active.
+# ============================================================================
+
+
+resource "cloudflare_zero_trust_gateway_settings" "e2e_comprehensive" {
+  account_id = var.cloudflare_account_id
+
+  settings = {
+    activity_log = {
+      enabled = true
+    }
+    tls_decrypt = {
+      enabled = false
+    }
+    protocol_detection = {
+      enabled = true
+    }
+    browser_isolation = {
+      url_browser_isolation_enabled = false
+      non_identity_enabled          = false
+    }
+    block_page = {
+      enabled          = true
+      name             = "E2E Test Block Page"
+      footer_text      = "Contact IT Security"
+      header_text      = "Access Denied"
+      logo_path        = "https://example.com/logo.png"
+      background_color = "#1a1a1a"
+    }
+    body_scanning = {
+      inspection_mode = "deep"
+    }
+    fips = {
+      tls = false
+    }
+  }
+}
+
+resource "cloudflare_zero_trust_gateway_logging" "e2e_comprehensive_logging" {
+  account_id = var.cloudflare_account_id
+  settings_by_rule_type = {
+    dns = {
+      log_all    = true
+      log_blocks = false
+    }
+    http = {
+      log_all    = true
+      log_blocks = true
+    }
+    l4 = {
+      log_all    = false
+      log_blocks = true
+    }
+  }
+  redact_pii = true
+}
+
+resource "cloudflare_zero_trust_device_settings" "e2e_comprehensive_device_settings" {
+  account_id                            = var.cloudflare_account_id
+  gateway_proxy_enabled                 = true
+  gateway_udp_proxy_enabled             = true
+  root_certificate_installation_enabled = true
+  use_zt_virtual_ip                     = false
+  disable_for_time                      = 600
+}
+
+
+variable "from_version" {
+  description = "Provider version under test, used to namespace resource names"
+  type        = string
+}

--- a/e2e-v5/testdata/zero_trust_list/zero_trust_list.tf
+++ b/e2e-v5/testdata/zero_trust_list/zero_trust_list.tf
@@ -1,0 +1,460 @@
+variable "cloudflare_account_id" {
+  description = "Cloudflare account ID"
+  type        = string
+}
+
+variable "cloudflare_zone_id" {
+  description = "Cloudflare zone ID"
+  type        = string
+}
+
+variable "cloudflare_domain" {
+  description = "Cloudflare domain for testing"
+  type        = string
+}
+
+# Resource-specific variables with defaults
+variable "list_prefix" {
+  type    = string
+  default = "v5-upgrade"
+}
+
+variable "enable_security_lists" {
+  type    = bool
+  default = true
+}
+
+variable "security_domains" {
+  type = map(object({
+    type        = string
+    description = string
+  }))
+  default = {
+    malware = {
+      type        = "DOMAIN"
+      description = "Known malware domains"
+    }
+    phishing = {
+      type        = "DOMAIN"
+      description = "Phishing sites"
+    }
+    spam = {
+      type        = "DOMAIN"
+      description = "Spam domains"
+    }
+  }
+}
+
+# Locals with multiple values
+locals {
+  name_prefix       = "v5-upgrade-${replace(var.from_version, ".", "-")}"
+  common_account_id = var.cloudflare_account_id
+  list_name_prefix  = "${var.list_prefix}-list"
+  ip_ranges = [
+    "192.168.1.0/24",
+    "10.0.0.0/8",
+    "172.16.0.0/12"
+  ]
+  common_description = "Managed by Terraform - ${var.list_prefix}"
+}
+
+# ============================================================================
+# Pattern Group 1: Basic Resources (Edge Cases)
+# ============================================================================
+
+
+
+
+
+
+
+# ============================================================================
+# Pattern Group 2: for_each with Maps
+# ============================================================================
+
+
+# ============================================================================
+# Pattern Group 3: for_each with Sets
+# ============================================================================
+
+
+# ============================================================================
+# Pattern Group 4: count-based Resources
+# ============================================================================
+
+
+# ============================================================================
+# Pattern Group 5: Conditional Creation
+# ============================================================================
+
+
+
+# ============================================================================
+# Pattern Group 6: Terraform Functions
+# ============================================================================
+
+
+
+# ============================================================================
+# Pattern Group 7: Lifecycle Meta-Arguments
+# ============================================================================
+
+
+
+# ============================================================================
+# Pattern Group 8: Additional Edge Cases & Type Coverage
+# ============================================================================
+
+
+
+
+
+# Total: 26 base resources + 3 from for_each map + 4 from for_each set + 3 from count = 36 instances
+
+# 1. Minimal resource - only required fields
+resource "cloudflare_zero_trust_list" "minimal" {
+  account_id = local.common_account_id
+  name       = "${local.name_prefix} Minimal List"
+  type       = "IP"
+  items = [{
+    description = null
+    value       = "192.168.1.1"
+  }]
+}
+
+
+# 2. Maximal resource - all fields populated
+resource "cloudflare_zero_trust_list" "maximal" {
+  account_id  = local.common_account_id
+  name        = "${local.list_name_prefix}-maximal"
+  type        = "DOMAIN"
+  description = local.common_description
+
+
+  items = [{
+    description = "Secure subdomain"
+    value       = "secure.cf-tf-test.com"
+    }, {
+    description = "Admin portal"
+    value       = "admin.cf-tf-test.com"
+    }, {
+    description = null
+    value       = "cf-tf-test.com"
+    }, {
+    description = null
+    value       = "test.cf-tf-test.com"
+    }, {
+    description = null
+    value       = "api.cf-tf-test.com"
+  }]
+}
+
+
+# 3. Empty list - edge case
+resource "cloudflare_zero_trust_list" "empty" {
+  account_id  = var.cloudflare_account_id
+  name        = "${local.name_prefix} Empty List"
+  type        = "URL"
+  description = "Empty list for testing"
+}
+
+
+# 4. Basic IP list with simple items array
+resource "cloudflare_zero_trust_list" "ip_list" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix} IP Allowlist"
+  type       = "IP"
+  items = [{
+    description = null
+    value       = "192.168.1.1"
+    }, {
+    description = null
+    value       = "192.168.1.2"
+    }, {
+    description = null
+    value       = "10.0.0.0/8"
+  }]
+}
+
+
+# 5. Domain list with items_with_description blocks
+resource "cloudflare_zero_trust_list" "domain_list" {
+  account_id  = var.cloudflare_account_id
+  name        = "${local.name_prefix} Allowed Domains"
+  type        = "DOMAIN"
+  description = "Company approved domains"
+
+
+
+  items = [{
+    description = "Main company domain"
+    value       = "cf-tf-test.com"
+    }, {
+    description = "API subdomain"
+    value       = "api.cf-tf-test.com"
+    }, {
+    description = "Testing environment"
+    value       = "test.cf-tf-test.com"
+  }]
+}
+
+
+# 6. Mixed list with both items and items_with_description
+resource "cloudflare_zero_trust_list" "email_list" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix} VIP Emails"
+  type       = "EMAIL"
+
+
+  items = [{
+    description = "CEO email address"
+    value       = "ceo@cf-tf-test.com"
+    }, {
+    description = "CTO email address"
+    value       = "cto@cf-tf-test.com"
+    }, {
+    description = null
+    value       = "admin@cf-tf-test.com"
+    }, {
+    description = null
+    value       = "security@cf-tf-test.com"
+  }]
+}
+
+
+# 7-9. Resources created with for_each over map
+resource "cloudflare_zero_trust_list" "security_domains" {
+  for_each = var.security_domains
+
+  account_id  = var.cloudflare_account_id
+  name        = "${local.list_name_prefix}-${each.key}"
+  type        = each.value.type
+  description = each.value.description
+  items = [
+    {
+      value       = "${each.key}.cf-tf-test.com"
+      description = null
+    },
+    {
+      value       = "www.${each.key}.cf-tf-test.com"
+      description = null
+    }
+  ]
+}
+
+
+# 10-13. Resources created with for_each over set
+resource "cloudflare_zero_trust_list" "list_types" {
+  for_each = toset(["staging", "production", "development", "testing"])
+
+  account_id  = var.cloudflare_account_id
+  name        = "${local.list_name_prefix}-${each.value}"
+  type        = "DOMAIN"
+  description = "List for ${each.value} environment"
+  items = [
+    {
+      value       = "${each.value}.cf-tf-test.com"
+      description = null
+    }
+  ]
+}
+
+
+# 14-16. Resources created with count
+resource "cloudflare_zero_trust_list" "ip_ranges" {
+  count = 3
+
+  account_id  = var.cloudflare_account_id
+  name        = "${local.list_name_prefix}-range-${count.index}"
+  type        = "IP"
+  description = "IP range ${count.index}"
+  items = [
+    {
+      value       = local.ip_ranges[count.index]
+      description = null
+    }
+  ]
+}
+
+
+# 17. Conditionally created resource
+resource "cloudflare_zero_trust_list" "conditional_enabled" {
+  count = var.enable_security_lists ? 1 : 0
+
+  account_id  = var.cloudflare_account_id
+  name        = "${local.name_prefix} Security List - Enabled"
+  type        = "DOMAIN"
+  description = "This list is conditionally created"
+  items = [{
+    description = null
+    value       = "secure.cf-tf-test.com"
+    }, {
+    description = null
+    value       = "protected.cf-tf-test.com"
+  }]
+}
+
+
+# 18. Conditionally not created resource
+resource "cloudflare_zero_trust_list" "conditional_disabled" {
+  count = var.enable_security_lists ? 0 : 1
+
+  account_id  = var.cloudflare_account_id
+  name        = "${local.name_prefix} Security List - Disabled"
+  type        = "DOMAIN"
+  description = "This list is conditionally not created"
+  items = [{
+    description = null
+    value       = "insecure.cf-tf-test.com"
+  }]
+}
+
+
+# 19. Resource using join() function
+resource "cloudflare_zero_trust_list" "with_join" {
+  account_id  = var.cloudflare_account_id
+  name        = join("-", [local.list_name_prefix, "joined", "name"])
+  type        = "DOMAIN"
+  description = "List created with join function"
+  items = [
+    {
+      value       = "${join(".", ["subdomain", "example", "com"])}"
+      description = null
+    }
+  ]
+}
+
+
+# 20. Resource using string interpolation
+resource "cloudflare_zero_trust_list" "with_interpolation" {
+  account_id  = var.cloudflare_account_id
+  name        = "${local.list_name_prefix} List for account ${var.cloudflare_account_id}"
+  type        = "URL"
+  description = "Description with ${local.list_name_prefix} interpolation"
+  items = [
+    {
+      value       = "https://${var.list_prefix}.cf-tf-test.com/path"
+      description = null
+    }
+  ]
+}
+
+
+# 21. Resource with lifecycle block
+resource "cloudflare_zero_trust_list" "with_lifecycle" {
+  account_id  = var.cloudflare_account_id
+  name        = "${local.name_prefix} Protected List"
+  type        = "IP"
+  description = "List with lifecycle settings"
+
+  lifecycle {
+    create_before_destroy = true
+    ignore_changes        = [description]
+  }
+  items = [{
+    description = null
+    value       = "203.0.113.0/24"
+  }]
+}
+
+
+# 22. Resource with prevent_destroy (set to false for testing)
+resource "cloudflare_zero_trust_list" "with_prevent_destroy" {
+  account_id  = var.cloudflare_account_id
+  name        = "${local.name_prefix} Important List"
+  type        = "DOMAIN"
+  description = "Critical list"
+
+  lifecycle {
+    prevent_destroy = false # Set to false for testing
+  }
+  items = [{
+    description = null
+    value       = "critical.cf-tf-test.com"
+  }]
+}
+
+
+# 23. URL list with only items_with_description
+resource "cloudflare_zero_trust_list" "url_list" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix} Blocked URLs"
+  type       = "URL"
+
+
+  items = [{
+    description = "Known phishing site"
+    value       = "https://malicious.cf-tf-test.com/path"
+    }, {
+    description = "Spam website"
+    value       = "https://spam.example.org/ads"
+  }]
+}
+
+
+# 24. SERIAL type list
+resource "cloudflare_zero_trust_list" "serial_list" {
+  account_id  = var.cloudflare_account_id
+  name        = "${local.name_prefix} Certificate Serials"
+  type        = "SERIAL"
+  description = "Revoked certificate serial numbers"
+
+  items = [{
+    description = "Compromised certificate"
+    value       = "DEADBEEF12345678"
+    }, {
+    description = null
+    value       = "1234567890ABCDEF"
+    }, {
+    description = null
+    value       = "FEDCBA0987654321"
+  }]
+}
+
+
+# 25. List with special characters and various IP formats
+resource "cloudflare_zero_trust_list" "complex_ips" {
+  account_id  = var.cloudflare_account_id
+  name        = "${local.name_prefix} Complex IP List"
+  type        = "IP"
+  description = "Various IP formats"
+
+  items = [{
+    description = "Documentation range"
+    value       = "198.51.100.0/24"
+    }, {
+    description = null
+    value       = "172.16.0.0/12"
+    }, {
+    description = null
+    value       = "192.168.0.0/16"
+    }, {
+    description = null
+    value       = "203.0.113.0/24"
+  }]
+}
+
+
+# 26. EMAIL type with complex addresses
+resource "cloudflare_zero_trust_list" "complex_emails" {
+  account_id  = var.cloudflare_account_id
+  name        = "${local.name_prefix} Complex Email List"
+  type        = "EMAIL"
+  description = "Emails with various formats"
+  items = [{
+    description = null
+    value       = "user+tag@cf-tf-test.com"
+    }, {
+    description = null
+    value       = "user.name@subdomain.cf-tf-test.com"
+    }, {
+    description = null
+    value       = "admin@test.cf-tf-test.com"
+  }]
+}
+
+
+variable "from_version" {
+  description = "Provider version under test, used to namespace resource names"
+  type        = string
+}

--- a/e2e-v5/testdata/zero_trust_local_fallback_domain/zero_trust_local_fallback_domain.tf
+++ b/e2e-v5/testdata/zero_trust_local_fallback_domain/zero_trust_local_fallback_domain.tf
@@ -1,0 +1,78 @@
+# Test comprehensive migration of zero_trust_local_fallback_domain resources
+# This includes both default profile (no policy_id) and custom profile (with policy_id) variants
+# Custom profile migration now works because zero_trust_device_profiles with match/precedence
+# migrates to zero_trust_device_custom_profile
+
+variable "cloudflare_account_id" {
+  description = "Cloudflare account ID"
+  type        = string
+}
+
+variable "cloudflare_zone_id" {
+  description = "Cloudflare zone ID"
+  type        = string
+}
+
+variable "cloudflare_domain" {
+  description = "Cloudflare domain for testing"
+  type        = string
+}
+
+locals {
+  name_prefix               = "v5-upgrade-${replace(var.from_version, ".", "-")}"
+  custom_profile_precedence = 100000 + tonumber(split(".", var.from_version)[1]) * 1000 + 776
+}
+
+
+
+
+# Default profile - multiple domains with all fields
+resource "cloudflare_zero_trust_device_default_profile_local_domain_fallback" "default_multi" {
+  account_id = var.cloudflare_account_id
+
+  domains = [
+    {
+      suffix      = "corp.${var.cloudflare_domain}"
+      description = "Corporate network"
+      dns_server  = ["10.0.0.1", "10.0.0.2"]
+    },
+    {
+      suffix      = "internal.${var.cloudflare_domain}"
+      description = "Internal services"
+      dns_server  = ["10.1.0.1"]
+    },
+    {
+      suffix = "local.${var.cloudflare_domain}"
+    }
+  ]
+}
+
+
+# Custom device profile for e2e testing
+resource "cloudflare_zero_trust_device_custom_profile" "custom_e2e" {
+  account_id  = var.cloudflare_account_id
+  name        = "${local.name_prefix} E2E Custom Profile"
+  description = "Custom profile for e2e testing"
+  match       = "identity.email == \"e2e@example.com\""
+  precedence  = local.custom_profile_precedence
+}
+
+
+# Custom profile - fallback domain with policy_id
+resource "cloudflare_zero_trust_device_custom_profile_local_domain_fallback" "custom_e2e" {
+  account_id = var.cloudflare_account_id
+  policy_id  = cloudflare_zero_trust_device_custom_profile.custom_e2e.id
+
+  domains = [
+    {
+      suffix      = "custom-e2e.${var.cloudflare_domain}"
+      description = "Custom profile e2e fallback"
+      dns_server  = ["192.168.1.1"]
+    }
+  ]
+}
+
+variable "from_version" {
+  description = "Provider version under test, used to namespace resource names"
+  type        = string
+}

--- a/e2e-v5/testdata/zero_trust_organization/zero_trust_organization.tf
+++ b/e2e-v5/testdata/zero_trust_organization/zero_trust_organization.tf
@@ -1,0 +1,105 @@
+# E2E Test Configuration for zero_trust_organization
+#
+# IMPORTANT: This resource is IMPORT-ONLY in v4 and is a SINGLETON.
+# - Organizations cannot be created via Terraform
+# - They are created when you enable Zero Trust in the Cloudflare dashboard
+# - Each account has exactly ONE organization
+# - Therefore, this config has only ONE resource
+#
+# E2E TEST WORKFLOW (AUTOMATED):
+# ================================
+#
+# The resource is imported using Terraform's native import block!
+# The import annotation below is detected by the e2e runner during init,
+# which generates an import block in the root main.tf.
+#
+# Automated workflow (run via `e2e run`):
+# 1. PREREQUISITE: Enable Zero Trust in your Cloudflare account via dashboard
+# 2. E2E runner generates import block in root main.tf (from annotation below)
+# 3. Terraform import block automatically imports the organization during apply
+# 4. V4 apply configures the imported organization
+# 5. Migration transforms v4 config to v5
+# 6. V5 plan verifies no drift
+# 7. V5 apply succeeds
+#
+# Manual workflow (for testing without E2E runner):
+# 1. PREREQUISITE: Enable Zero Trust via dashboard
+# 2. RUN: ./bin/e2e-runner init  # Generates main.tf with import blocks
+# 3. INIT: cd e2e/tf/v4 && terraform init
+# 4. APPLY: terraform apply
+# 5. MIGRATE: ../../bin/tf-migrate migrate --config-dir .
+# 6. UPGRADE: terraform init -upgrade
+# 7. VERIFY: terraform plan  # Should show "No changes"
+# 8. APPLY: terraform apply
+#
+# SUCCESS CRITERIA:
+# - Import succeeds (automatic in E2E runner)
+# - V4 apply succeeds
+# - Migration transforms config correctly
+# - V5 plan shows no changes
+# - V5 apply succeeds
+#
+# NOTE: We only have ONE resource because organizations are singletons.
+# We cannot test both v4 resource names (cloudflare_access_organization and
+# cloudflare_zero_trust_access_organization) simultaneously because they would
+# both try to manage the same underlying organization.
+
+variable "cloudflare_account_id" {
+  description = "Cloudflare account ID"
+  type        = string
+}
+
+variable "cloudflare_zone_id" {
+  description = "Cloudflare zone ID"
+  type        = string
+}
+
+variable "cloudflare_domain" {
+  description = "Cloudflare domain for testing"
+  type        = string
+}
+
+# Generate unique, stable auth domain per account
+# Each account gets a deterministic domain based on account ID hash
+# This prevents collisions between different test accounts
+locals {
+  name_prefix  = "v5-upgrade-${replace(var.from_version, ".", "-")}"
+  account_hash = substr(md5(var.cloudflare_account_id), 0, 8)
+  auth_domain  = "${local.name_prefix}-${local.account_hash}.cloudflareaccess.com"
+}
+
+
+# Basic organization configuration for E2E testing
+# NOTE: This is a SINGLETON resource - only one organization per account.
+#
+# IMPORT ANNOTATION: The line below tells the E2E runner to generate an import block in root main.tf.
+# The runner will generate: import { to = module.zero_trust_organization.cloudflare_zero_trust_organization.test, id = "ACCOUNT_ID" }
+# tf-migrate:import-address=${var.cloudflare_account_id}
+resource "cloudflare_zero_trust_organization" "test" {
+  account_id  = var.cloudflare_account_id
+  name        = "${local.name_prefix} E2E Test Organization"
+  auth_domain = local.auth_domain # Unique per account, stable across runs
+
+
+  # Test all optional fields
+  session_duration                   = "24h"
+  user_seat_expiration_inactive_time = "730h"
+  warp_auth_session_duration         = "12h"
+  is_ui_read_only                    = true
+  # ui_read_only_toggle_reason         = "E2E Testing"
+  auto_redirect_to_identity   = true
+  allow_authenticate_via_warp = true
+  login_design = {
+    background_color = "#000000"
+    text_color       = "#FFFFFF"
+    logo_path        = "https://e2e-test.cf-tf-test.com/logo.png"
+    header_text      = "E2E Test Portal"
+    footer_text      = "E2E Testing"
+  }
+}
+
+
+variable "from_version" {
+  description = "Provider version under test, used to namespace resource names"
+  type        = string
+}

--- a/e2e-v5/testdata/zero_trust_split_tunnel/zero_trust_split_tunnel.tf
+++ b/e2e-v5/testdata/zero_trust_split_tunnel/zero_trust_split_tunnel.tf
@@ -1,0 +1,27 @@
+# E2E tests are not applicable for cloudflare_split_tunnel.
+#
+# cloudflare_split_tunnel does not exist in v5 — it is dissolved into
+# cloudflare_zero_trust_device_custom_profile and cloudflare_zero_trust_device_default_profile.
+# The migration requires a manual `terraform state rm` step for each split tunnel entry,
+# which cannot be automated by the e2e runner. No resources are created here.
+
+
+variable "cloudflare_account_id" {
+  description = "Cloudflare account ID"
+  type        = string
+}
+
+variable "cloudflare_zone_id" {
+  description = "Cloudflare zone ID"
+  type        = string
+}
+
+variable "cloudflare_domain" {
+  description = "Cloudflare domain for testing"
+  type        = string
+}
+
+variable "from_version" {
+  description = "Provider version under test, used to namespace resource names"
+  type        = string
+}

--- a/e2e-v5/testdata/zero_trust_tunnel_cloudflared/zero_trust_tunnel_cloudflared.tf
+++ b/e2e-v5/testdata/zero_trust_tunnel_cloudflared/zero_trust_tunnel_cloudflared.tf
@@ -1,0 +1,276 @@
+variable "cloudflare_account_id" {
+  description = "Cloudflare account ID"
+  type        = string
+}
+
+variable "cloudflare_zone_id" {
+  description = "Cloudflare zone ID"
+  type        = string
+}
+
+variable "cloudflare_domain" {
+  description = "Cloudflare domain for testing"
+  type        = string
+}
+
+# ========================================
+# Basic Tunnel Resources
+# ========================================
+
+
+
+
+# ========================================
+# Advanced Terraform Patterns for Testing
+# ========================================
+
+# Pattern 1: Variable references
+variable "tunnel_prefix" {
+  type    = string
+  default = "var-test"
+}
+
+variable "config_source" {
+  type    = string
+  default = "local"
+}
+
+# Pattern 2: Local values with expressions
+locals {
+  name_prefix        = "v5-upgrade-${replace(var.from_version, ".", "-")}"
+  tunnel_secret_base = "generated-secret-that-is-32-bytes-long"
+  common_account_id  = var.cloudflare_account_id
+  tunnel_suffix      = "prod"
+  full_tunnel_name   = "${local.name_prefix}-${var.tunnel_prefix}-${local.tunnel_suffix}"
+}
+
+
+# Pattern 3: for_each with map
+variable "application_tunnels" {
+  type = map(object({
+    secret     = string
+    config_src = string
+  }))
+  default = {
+    "api" = {
+      secret     = "api-tunnel-secret-that-is-32-bytes"
+      config_src = "local"
+    }
+    "web" = {
+      secret     = "web-tunnel-secret-that-is-32-bytes"
+      config_src = "cloudflare"
+    }
+    "backend" = {
+      secret     = "backend-secret-that-is-32-bytes-ok"
+      config_src = "local"
+    }
+  }
+}
+
+
+# Pattern 4: for_each with list converted to set
+variable "environment_tunnels" {
+  type = list(object({
+    name       = string
+    secret     = string
+    config_src = string
+  }))
+  default = [
+    {
+      name       = "dev"
+      secret     = "dev-environment-secret-32-bytes-min"
+      config_src = "local"
+    },
+    {
+      name       = "staging"
+      secret     = "staging-environment-secret-32-byte"
+      config_src = "cloudflare"
+    },
+    {
+      name       = "prod"
+      secret     = "prod-environment-secret-32-bytes-ok"
+      config_src = "cloudflare"
+    }
+  ]
+}
+
+
+# Pattern 5: Count-based resources
+variable "replica_count" {
+  type    = number
+  default = 3
+}
+
+
+# Pattern 6: Conditional resource creation
+variable "enable_backup_tunnel" {
+  type    = bool
+  default = true
+}
+
+
+
+
+
+# Pattern 9: Using terraform expressions
+variable "use_cloudflare_config" {
+  type    = bool
+  default = false
+}
+
+
+
+
+# Pattern 12: Complex expression for config_src
+variable "is_production" {
+  type    = bool
+  default = true
+}
+
+
+# Basic tunnel with minimal configuration
+resource "cloudflare_zero_trust_tunnel_cloudflared" "minimal" {
+  account_id    = var.cloudflare_account_id
+  name          = "${local.name_prefix}-minimal-tunnel"
+  config_src    = "local"
+  tunnel_secret = base64encode("test-secret-that-is-at-least-32-bytes-long")
+}
+
+
+# Tunnel with local config source
+resource "cloudflare_zero_trust_tunnel_cloudflared" "local_config" {
+  account_id    = var.cloudflare_account_id
+  name          = "${local.name_prefix}-local-config-tunnel"
+  config_src    = "local"
+  tunnel_secret = base64encode("another-secret-32-bytes-or-longer-here")
+}
+
+
+# Tunnel with cloudflare config source
+resource "cloudflare_zero_trust_tunnel_cloudflared" "cloudflare_config" {
+  account_id    = var.cloudflare_account_id
+  name          = "${local.name_prefix}-cloudflare-config-tunnel"
+  config_src    = "cloudflare"
+  tunnel_secret = base64encode("remote-tunnel-secret-32-bytes-minimum")
+}
+
+
+# Tunnel using variables and locals
+resource "cloudflare_zero_trust_tunnel_cloudflared" "with_vars" {
+  account_id    = local.common_account_id
+  name          = local.full_tunnel_name
+  config_src    = var.config_source
+  tunnel_secret = base64encode(local.tunnel_secret_base)
+}
+
+
+resource "cloudflare_zero_trust_tunnel_cloudflared" "applications" {
+  for_each = var.application_tunnels
+
+  account_id    = var.cloudflare_account_id
+  name          = "${local.name_prefix}-${each.key}-tunnel"
+  config_src    = each.value.config_src
+  tunnel_secret = base64encode(each.value.secret)
+}
+
+
+resource "cloudflare_zero_trust_tunnel_cloudflared" "environments" {
+  for_each = { for idx, tunnel in var.environment_tunnels : tunnel.name => tunnel }
+
+  account_id    = var.cloudflare_account_id
+  name          = "${local.name_prefix}-${each.value.name}-env-tunnel"
+  config_src    = each.value.config_src
+  tunnel_secret = base64encode(each.value.secret)
+}
+
+
+resource "cloudflare_zero_trust_tunnel_cloudflared" "replicas" {
+  count = var.replica_count
+
+  account_id    = var.cloudflare_account_id
+  name          = "${local.name_prefix}-replica-tunnel-${count.index + 1}"
+  config_src    = "local"
+  tunnel_secret = base64encode("replica-${count.index}-secret-32-bytes-long")
+}
+
+
+resource "cloudflare_zero_trust_tunnel_cloudflared" "backup" {
+  count = var.enable_backup_tunnel ? 1 : 0
+
+  account_id    = var.cloudflare_account_id
+  name          = "${local.name_prefix}-backup-tunnel"
+  config_src    = "cloudflare"
+  tunnel_secret = base64encode("backup-tunnel-secret-32-bytes-long")
+}
+
+
+# Pattern 7: Cross-resource references
+resource "cloudflare_zero_trust_tunnel_cloudflared" "primary" {
+  account_id    = var.cloudflare_account_id
+  name          = "${local.name_prefix}-primary-tunnel"
+  config_src    = "local"
+  tunnel_secret = base64encode("primary-tunnel-secret-32-bytes-long")
+}
+
+
+# Tunnel that references another tunnel in its name
+resource "cloudflare_zero_trust_tunnel_cloudflared" "secondary" {
+  account_id    = var.cloudflare_account_id
+  name          = "${cloudflare_zero_trust_tunnel_cloudflared.primary.name}-secondary"
+  config_src    = "cloudflare"
+  tunnel_secret = base64encode("secondary-tunnel-secret-32-bytes-ok")
+}
+
+
+# Pattern 8: Resource with lifecycle meta-arguments
+resource "cloudflare_zero_trust_tunnel_cloudflared" "protected" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-protected-tunnel"
+  config_src = "local"
+
+  lifecycle {
+    prevent_destroy       = false
+    create_before_destroy = true
+  }
+  tunnel_secret = base64encode("protected-tunnel-secret-32-bytes-ok")
+}
+
+
+resource "cloudflare_zero_trust_tunnel_cloudflared" "conditional_config" {
+  account_id    = var.cloudflare_account_id
+  name          = "${local.name_prefix}-conditional-config-tunnel"
+  config_src    = var.use_cloudflare_config ? "cloudflare" : "local"
+  tunnel_secret = base64encode("conditional-secret-32-bytes-or-more")
+}
+
+
+# Pattern 10: Tunnel with base64encode function
+resource "cloudflare_zero_trust_tunnel_cloudflared" "encoded" {
+  account_id    = var.cloudflare_account_id
+  name          = "${local.name_prefix}-encoded-tunnel"
+  config_src    = "local"
+  tunnel_secret = base64encode("this-secret-is-base64-encoded-32b")
+}
+
+
+# Pattern 11: Tunnel using string interpolation
+resource "cloudflare_zero_trust_tunnel_cloudflared" "interpolated" {
+  account_id    = var.cloudflare_account_id
+  name          = "${local.name_prefix}-${var.tunnel_prefix}-interpolated-${local.tunnel_suffix}"
+  config_src    = "local"
+  tunnel_secret = base64encode("interpolated-secret-32-bytes-or-more")
+}
+
+
+resource "cloudflare_zero_trust_tunnel_cloudflared" "complex_config" {
+  account_id    = var.cloudflare_account_id
+  name          = "${local.name_prefix}-${var.is_production ? "prod" : "dev"}-complex-tunnel"
+  config_src    = var.is_production ? "cloudflare" : "local"
+  tunnel_secret = base64encode("complex-tunnel-secret-32-bytes-long")
+}
+
+
+variable "from_version" {
+  description = "Provider version under test, used to namespace resource names"
+  type        = string
+}

--- a/e2e-v5/testdata/zero_trust_tunnel_cloudflared_config/zero_trust_tunnel_cloudflared_config.tf
+++ b/e2e-v5/testdata/zero_trust_tunnel_cloudflared_config/zero_trust_tunnel_cloudflared_config.tf
@@ -1,0 +1,232 @@
+variable "cloudflare_account_id" {
+  type = string
+}
+
+variable "cloudflare_zone_id" {
+  description = "Cloudflare zone ID"
+  type        = string
+}
+
+variable "cloudflare_domain" {
+  description = "Cloudflare domain for testing"
+  type        = string
+}
+
+locals {
+  name_prefix = "v5-upgrade-${replace(var.from_version, ".", "-")}"
+}
+
+# ========================================
+# Parent Tunnel Resources
+# ========================================
+
+
+
+
+# ========================================
+# Tunnel Config Resources
+# ========================================
+
+# Test 1: Minimal configuration using preferred resource name
+resource "cloudflare_zero_trust_tunnel_cloudflared_config" "minimal" {
+  account_id = var.cloudflare_account_id
+  tunnel_id  = cloudflare_zero_trust_tunnel_cloudflared.minimal.id
+
+  config = {
+    ingress = [
+      {
+        service = "http_status:404"
+      }
+    ]
+  }
+}
+
+
+
+# ============================================================================
+# Pattern 9: Cross-resource reference using both v4 names
+# ============================================================================
+# This validates that GetResourceRename() returns ALL v4 names for cross-file reference updates
+# v4 name option 1: cloudflare_tunnel_config
+# v4 name option 2: cloudflare_zero_trust_tunnel_cloudflared_config
+# v5 name: cloudflare_zero_trust_tunnel_cloudflared_config
+
+
+
+
+# Resource using v4 name option 2
+resource "cloudflare_zero_trust_tunnel_cloudflared_config" "resourcename_opt2" {
+  account_id = var.cloudflare_account_id
+  tunnel_id  = cloudflare_zero_trust_tunnel_cloudflared.resourcename_opt2.id
+
+  config = {
+    ingress = [
+      {
+        service = "http_status:404"
+      }
+    ]
+  }
+}
+
+
+
+# Tunnel for minimal config test
+resource "cloudflare_zero_trust_tunnel_cloudflared" "minimal" {
+  account_id    = var.cloudflare_account_id
+  name          = "${local.name_prefix}-minimal-tunnel-config"
+  config_src    = "cloudflare"
+  tunnel_secret = base64encode("test-secret-that-is-at-least-32-bytes-long")
+}
+
+
+# Tunnel for comprehensive config test
+resource "cloudflare_zero_trust_tunnel_cloudflared" "comprehensive" {
+  account_id    = var.cloudflare_account_id
+  name          = "${local.name_prefix}-comprehensive-tunnel-config"
+  config_src    = "cloudflare"
+  tunnel_secret = base64encode("another-secret-32-bytes-or-longer-here")
+}
+
+
+# Tunnel for testing deprecated resource name
+resource "cloudflare_zero_trust_tunnel_cloudflared" "deprecated_name" {
+  account_id    = var.cloudflare_account_id
+  name          = "${local.name_prefix}-deprecated-tunnel-config"
+  config_src    = "cloudflare"
+  tunnel_secret = base64encode("deprecated-tunnel-secret-32-bytes-minimum")
+}
+
+
+# Test 2: Deprecated resource name (cloudflare_tunnel_config)
+resource "cloudflare_zero_trust_tunnel_cloudflared_config" "deprecated_name" {
+  account_id = var.cloudflare_account_id
+  tunnel_id  = cloudflare_zero_trust_tunnel_cloudflared.deprecated_name.id
+
+  config = {
+    ingress = [
+      {
+        hostname = "app.example.com"
+        service  = "http://localhost:8080"
+      },
+      {
+        service = "http_status:404"
+      }
+    ]
+  }
+}
+
+
+# Test 3: Comprehensive configuration with all transformations
+resource "cloudflare_zero_trust_tunnel_cloudflared_config" "comprehensive" {
+  account_id = var.cloudflare_account_id
+  tunnel_id  = cloudflare_zero_trust_tunnel_cloudflared.comprehensive.id
+
+  config = {
+    ingress = [
+      {
+        hostname = "app.example.com"
+        path     = "/api"
+        service  = "http://localhost:8080"
+        origin_request = {
+          connect_timeout          = 15
+          tls_timeout              = 5
+          ca_pool                  = ""
+          disable_chunked_encoding = false
+          http2_origin             = false
+          keep_alive_connections   = 100
+          keep_alive_timeout       = 90
+          no_happy_eyeballs        = false
+          no_tls_verify            = false
+          origin_server_name       = ""
+          proxy_type               = ""
+          tcp_keep_alive           = 30
+        }
+      },
+      {
+        hostname = "api.example.com"
+        service  = "http://localhost:3000"
+      },
+      {
+        service = "http_status:404"
+      }
+    ]
+    origin_request = {
+      connect_timeout          = 30
+      tls_timeout              = 10
+      tcp_keep_alive           = 90
+      keep_alive_timeout       = 90
+      keep_alive_connections   = 100
+      http_host_header         = "example.com"
+      origin_server_name       = "origin.example.com"
+      ca_pool                  = "/path/to/ca.pem"
+      no_tls_verify            = false
+      disable_chunked_encoding = false
+      proxy_type               = ""
+      http2_origin             = false
+      no_happy_eyeballs        = false
+      access = {
+        required  = true
+        team_name = "my-team"
+        aud_tag   = ["abc123"]
+      }
+    }
+  }
+}
+
+
+# Parent tunnels for Pattern 9
+resource "cloudflare_zero_trust_tunnel_cloudflared" "resourcename_opt1" {
+  account_id    = var.cloudflare_account_id
+  name          = "${local.name_prefix}-pattern9-opt1-tunnel"
+  config_src    = "cloudflare"
+  tunnel_secret = base64encode("pattern9-opt1-secret-32-bytes-minimum-here")
+}
+
+
+resource "cloudflare_zero_trust_tunnel_cloudflared" "resourcename_opt2" {
+  account_id    = var.cloudflare_account_id
+  name          = "${local.name_prefix}-pattern9-opt2-tunnel"
+  config_src    = "cloudflare"
+  tunnel_secret = base64encode("pattern9-opt2-secret-32-bytes-minimum-here")
+}
+
+
+# Resource using v4 name option 1
+resource "cloudflare_zero_trust_tunnel_cloudflared_config" "resourcename_opt1" {
+  account_id = var.cloudflare_account_id
+  tunnel_id  = cloudflare_zero_trust_tunnel_cloudflared.resourcename_opt1.id
+
+  config = {
+    ingress = [
+      {
+        service = "http_status:404"
+      }
+    ]
+  }
+}
+
+
+# Dependent resource that references option 1
+resource "cloudflare_zero_trust_tunnel_cloudflared_route" "ref_opt1" {
+  account_id = var.cloudflare_account_id
+  tunnel_id  = cloudflare_zero_trust_tunnel_cloudflared.resourcename_opt1.id
+  network    = "192.0.2.0/24"
+
+  depends_on = [cloudflare_zero_trust_tunnel_cloudflared_config.resourcename_opt1]
+}
+
+
+# Dependent resource that references option 2
+resource "cloudflare_zero_trust_tunnel_cloudflared_route" "ref_opt2" {
+  account_id = var.cloudflare_account_id
+  tunnel_id  = cloudflare_zero_trust_tunnel_cloudflared.resourcename_opt2.id
+  network    = "198.51.100.0/24"
+
+  depends_on = [cloudflare_zero_trust_tunnel_cloudflared_config.resourcename_opt2]
+}
+
+
+variable "from_version" {
+  description = "Provider version under test, used to namespace resource names"
+  type        = string
+}

--- a/e2e-v5/testdata/zero_trust_tunnel_cloudflared_route/zero_trust_tunnel_cloudflared_route.tf
+++ b/e2e-v5/testdata/zero_trust_tunnel_cloudflared_route/zero_trust_tunnel_cloudflared_route.tf
@@ -1,0 +1,533 @@
+variable "cloudflare_account_id" {
+  description = "Cloudflare account ID"
+  type        = string
+}
+
+variable "cloudflare_zone_id" {
+  description = "Cloudflare zone ID"
+  type        = string
+}
+
+variable "cloudflare_domain" {
+  description = "Cloudflare domain for testing"
+  type        = string
+}
+
+# ========================================
+# Tunnel Resources (Referenced by Routes Below)
+# ========================================
+# These tunnel resources are included to support cross-resource
+# references in the tunnel_route resources below
+
+
+
+
+# ========================================
+# Tunnel Resources - Advanced Patterns
+# ========================================
+
+# Variable references for tunnels
+variable "tunnel_prefix" {
+  type    = string
+  default = "v5-upgrade-var-test"
+}
+
+variable "config_source" {
+  type    = string
+  default = "local"
+}
+
+# Local values with expressions for tunnels
+locals {
+  name_prefix        = "v5-upgrade-${replace(var.from_version, ".", "-")}"
+  tunnel_secret_base = "generated-secret-that-is-32-bytes-long"
+  common_account_id  = var.cloudflare_account_id
+  tunnel_suffix      = "prod"
+  full_tunnel_name   = "${var.tunnel_prefix}-${local.tunnel_suffix}"
+}
+
+
+# for_each tunnels with map
+variable "application_tunnels" {
+  type = map(object({
+    secret     = string
+    config_src = string
+  }))
+  default = {
+    "api" = {
+      secret     = "api-tunnel-secret-that-is-32-bytes"
+      config_src = "local"
+    }
+    "web" = {
+      secret     = "web-tunnel-secret-that-is-32-bytes"
+      config_src = "cloudflare"
+    }
+    "backend" = {
+      secret     = "backend-secret-that-is-32-bytes-ok"
+      config_src = "local"
+    }
+  }
+}
+
+
+# for_each tunnels with list converted to set
+variable "environment_tunnels" {
+  type = list(object({
+    name       = string
+    secret     = string
+    config_src = string
+  }))
+  default = [
+    {
+      name       = "dev"
+      secret     = "dev-environment-secret-32-bytes-min"
+      config_src = "local"
+    },
+    {
+      name       = "staging"
+      secret     = "staging-environment-secret-32-byte"
+      config_src = "cloudflare"
+    },
+    {
+      name       = "prod"
+      secret     = "prod-environment-secret-32-bytes-ok"
+      config_src = "cloudflare"
+    }
+  ]
+}
+
+
+# Count-based tunnel resources
+variable "replica_count" {
+  type    = number
+  default = 3
+}
+
+
+# Conditional tunnel creation
+variable "enable_backup_tunnel" {
+  type    = bool
+  default = true
+}
+
+
+
+
+
+# Tunnel using terraform expressions
+variable "use_cloudflare_config" {
+  type    = bool
+  default = false
+}
+
+
+
+
+# Complex expression for config_src
+variable "is_production" {
+  type    = bool
+  default = true
+}
+
+
+# ========================================
+# Tunnel Route Resources
+# ========================================
+# These resources reference the tunnels defined above
+
+# ========================================
+# Basic Resource Configurations
+# ========================================
+
+
+
+
+
+
+# ========================================
+# Variable-Driven Configurations
+# ========================================
+
+variable "tunnel_networks" {
+  type = map(object({
+    network = string
+    comment = string
+  }))
+  default = {
+    "staging" = {
+      network = "10.10.0.0/16"
+      comment = "Staging environment"
+    }
+    "development" = {
+      network = "10.20.0.0/16"
+      comment = "Development environment"
+    }
+  }
+}
+
+# ========================================
+# Local Values with Expressions
+# ========================================
+
+locals {
+  # Network configuration
+  network_prefix = "10.100"
+  base_comment   = "Automated tunnel route"
+
+  # Computed values
+  primary_network = "${local.network_prefix}.0.0/16"
+  backup_network  = "${local.network_prefix}.128.0/17"
+
+  # Tags for routes
+  environment_tags  = ["production", "automated", "managed"]
+  route_description = "${local.base_comment} - ${local.environment_tags[0]}"
+}
+
+# ========================================
+# Production-Like Patterns
+# ========================================
+
+
+# Pattern 2: for_each with set conversion referencing environment tunnels
+variable "additional_networks" {
+  type = list(object({
+    env     = string
+    network = string
+    comment = string
+  }))
+  default = [
+    {
+      env     = "dev"
+      network = "10.30.0.0/16"
+      comment = "Additional network 1"
+    },
+    {
+      env     = "staging"
+      network = "10.40.0.0/16"
+      comment = "Additional network 2"
+    }
+  ]
+}
+
+
+# Pattern 3: Count-based resources referencing replicas
+variable "subnet_count" {
+  type    = number
+  default = 3
+}
+
+
+# Pattern 4: Conditional resources using locals and backup tunnel
+locals {
+  enable_backup_routes = true
+  backup_networks = local.enable_backup_routes ? [
+    "10.200.0.0/16",
+    "10.201.0.0/16"
+  ] : []
+}
+
+
+# ========================================
+# Edge Cases and Complex Scenarios
+# ========================================
+
+
+
+
+
+
+
+
+# Basic tunnel with minimal configuration
+resource "cloudflare_zero_trust_tunnel_cloudflared" "minimal" {
+  account_id    = var.cloudflare_account_id
+  name          = "${local.name_prefix}-route-minimal-tunnel"
+  config_src    = "local"
+  tunnel_secret = base64encode("test-secret-that-is-at-least-32-bytes-long")
+}
+
+
+# Tunnel with local config source
+resource "cloudflare_zero_trust_tunnel_cloudflared" "local_config" {
+  account_id    = var.cloudflare_account_id
+  name          = "${local.name_prefix}-route-local-config-tunnel"
+  config_src    = "local"
+  tunnel_secret = base64encode("another-secret-32-bytes-or-longer-here")
+}
+
+
+# Tunnel with cloudflare config source
+resource "cloudflare_zero_trust_tunnel_cloudflared" "cloudflare_config" {
+  account_id    = var.cloudflare_account_id
+  name          = "${local.name_prefix}-route-cloudflare-config-tunnel"
+  config_src    = "cloudflare"
+  tunnel_secret = base64encode("remote-tunnel-secret-32-bytes-minimum")
+}
+
+
+# Tunnel using variables and locals
+resource "cloudflare_zero_trust_tunnel_cloudflared" "with_vars" {
+  account_id    = local.common_account_id
+  name          = "${local.name_prefix}-route-${local.full_tunnel_name}"
+  config_src    = var.config_source
+  tunnel_secret = base64encode(local.tunnel_secret_base)
+}
+
+
+resource "cloudflare_zero_trust_tunnel_cloudflared" "applications" {
+  for_each = var.application_tunnels
+
+  account_id    = var.cloudflare_account_id
+  name          = "${local.name_prefix}-route-${each.key}-tunnel"
+  config_src    = each.value.config_src
+  tunnel_secret = base64encode(each.value.secret)
+}
+
+
+resource "cloudflare_zero_trust_tunnel_cloudflared" "environments" {
+  for_each = { for idx, tunnel in var.environment_tunnels : tunnel.name => tunnel }
+
+  account_id    = var.cloudflare_account_id
+  name          = "${local.name_prefix}-route-${each.value.name}-env-tunnel"
+  config_src    = each.value.config_src
+  tunnel_secret = base64encode(each.value.secret)
+}
+
+
+resource "cloudflare_zero_trust_tunnel_cloudflared" "replicas" {
+  count = var.replica_count
+
+  account_id    = var.cloudflare_account_id
+  name          = "${local.name_prefix}-route-replica-tunnel-${count.index + 1}"
+  config_src    = "local"
+  tunnel_secret = base64encode("replica-${count.index}-secret-32-bytes-long")
+}
+
+
+resource "cloudflare_zero_trust_tunnel_cloudflared" "backup" {
+  count = var.enable_backup_tunnel ? 1 : 0
+
+  account_id    = var.cloudflare_account_id
+  name          = "${local.name_prefix}-route-backup-tunnel"
+  config_src    = "cloudflare"
+  tunnel_secret = base64encode("backup-tunnel-secret-32-bytes-long")
+}
+
+
+# Cross-resource references between tunnels
+resource "cloudflare_zero_trust_tunnel_cloudflared" "primary" {
+  account_id    = var.cloudflare_account_id
+  name          = "${local.name_prefix}-route-primary-tunnel"
+  config_src    = "local"
+  tunnel_secret = base64encode("primary-tunnel-secret-32-bytes-long")
+}
+
+
+resource "cloudflare_zero_trust_tunnel_cloudflared" "secondary" {
+  account_id    = var.cloudflare_account_id
+  name          = "${local.name_prefix}-${cloudflare_zero_trust_tunnel_cloudflared.primary.name}-secondary"
+  config_src    = "cloudflare"
+  tunnel_secret = base64encode("secondary-tunnel-secret-32-bytes-ok")
+}
+
+
+# Tunnel with lifecycle meta-arguments
+resource "cloudflare_zero_trust_tunnel_cloudflared" "protected" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-route-protected-tunnel"
+  config_src = "local"
+
+  lifecycle {
+    prevent_destroy       = false
+    create_before_destroy = true
+  }
+  tunnel_secret = base64encode("protected-tunnel-secret-32-bytes-ok")
+}
+
+
+resource "cloudflare_zero_trust_tunnel_cloudflared" "conditional_config" {
+  account_id    = var.cloudflare_account_id
+  name          = "${local.name_prefix}-route-conditional-config-tunnel"
+  config_src    = var.use_cloudflare_config ? "cloudflare" : "local"
+  tunnel_secret = base64encode("conditional-secret-32-bytes-or-more")
+}
+
+
+# Tunnel with base64encode function
+resource "cloudflare_zero_trust_tunnel_cloudflared" "encoded" {
+  account_id    = var.cloudflare_account_id
+  name          = "${local.name_prefix}-route-encoded-tunnel"
+  config_src    = "local"
+  tunnel_secret = base64encode("this-secret-is-base64-encoded-32b")
+}
+
+
+# Tunnel using string interpolation
+resource "cloudflare_zero_trust_tunnel_cloudflared" "interpolated" {
+  account_id    = var.cloudflare_account_id
+  name          = "${local.name_prefix}-route-${var.tunnel_prefix}-interpolated-${local.tunnel_suffix}"
+  config_src    = "local"
+  tunnel_secret = base64encode("interpolated-secret-32-bytes-or-more")
+}
+
+
+resource "cloudflare_zero_trust_tunnel_cloudflared" "complex_config" {
+  account_id    = var.cloudflare_account_id
+  name          = "${local.name_prefix}-route-${var.is_production ? "prod" : "dev"}-complex-tunnel"
+  config_src    = var.is_production ? "cloudflare" : "local"
+  tunnel_secret = base64encode("complex-tunnel-secret-32-bytes-long")
+}
+
+
+# Test Case 1: Minimal resource referencing minimal tunnel
+resource "cloudflare_zero_trust_tunnel_cloudflared_route" "minimal" {
+  account_id = var.cloudflare_account_id
+  tunnel_id  = cloudflare_zero_trust_tunnel_cloudflared.minimal.id
+  network    = "10.0.0.0/16"
+}
+
+
+# Test Case 2: Full resource with all optional fields referencing local_config tunnel
+resource "cloudflare_zero_trust_tunnel_cloudflared_route" "full" {
+  account_id = var.cloudflare_account_id
+  tunnel_id  = cloudflare_zero_trust_tunnel_cloudflared.local_config.id
+  network    = "172.16.0.0/12"
+  comment    = "Production tunnel route for internal services"
+}
+
+
+# Test Case 3: IPv6 network with comment referencing cloudflare_config tunnel
+resource "cloudflare_zero_trust_tunnel_cloudflared_route" "ipv6" {
+  account_id = var.cloudflare_account_id
+  tunnel_id  = cloudflare_zero_trust_tunnel_cloudflared.cloudflare_config.id
+  network    = "2001:db8::/32"
+  comment    = "IPv6 tunnel route"
+}
+
+
+# Test Case 4: Empty comment referencing with_vars tunnel
+resource "cloudflare_zero_trust_tunnel_cloudflared_route" "empty_comment" {
+  account_id = var.cloudflare_account_id
+  tunnel_id  = cloudflare_zero_trust_tunnel_cloudflared.with_vars.id
+  network    = "192.168.0.0/16"
+  comment    = ""
+}
+
+
+# Test Case 5: Special characters in comment referencing primary tunnel
+resource "cloudflare_zero_trust_tunnel_cloudflared_route" "special_chars" {
+  account_id = var.cloudflare_account_id
+  tunnel_id  = cloudflare_zero_trust_tunnel_cloudflared.primary.id
+  network    = "10.1.0.0/16"
+  comment    = "Route with special chars: !@#$%^&*() and unicode: éçà"
+}
+
+
+# Pattern 1: for_each with map referencing applications tunnels
+resource "cloudflare_zero_trust_tunnel_cloudflared_route" "environment_routes" {
+  for_each = var.tunnel_networks
+
+  account_id = var.cloudflare_account_id
+  tunnel_id  = cloudflare_zero_trust_tunnel_cloudflared.applications[each.key == "staging" ? "api" : "web"].id
+  network    = each.value.network
+  comment    = "${each.key}: ${each.value.comment}"
+}
+
+
+resource "cloudflare_zero_trust_tunnel_cloudflared_route" "additional_routes" {
+  for_each = { for idx, net in var.additional_networks : net.network => net }
+
+  account_id = var.cloudflare_account_id
+  tunnel_id  = cloudflare_zero_trust_tunnel_cloudflared.environments[each.value.env].id
+  network    = each.value.network
+  comment    = each.value.comment
+}
+
+
+resource "cloudflare_zero_trust_tunnel_cloudflared_route" "subnet_routes" {
+  count = var.subnet_count
+
+  account_id = var.cloudflare_account_id
+  tunnel_id  = cloudflare_zero_trust_tunnel_cloudflared.replicas[count.index].id
+  network    = "10.${count.index + 50}.0.0/24"
+  comment    = "Subnet ${count.index + 1} route"
+}
+
+
+resource "cloudflare_zero_trust_tunnel_cloudflared_route" "backup_routes" {
+  for_each = toset(local.backup_networks)
+
+  account_id = var.cloudflare_account_id
+  tunnel_id  = cloudflare_zero_trust_tunnel_cloudflared.backup[0].id
+  network    = each.value
+  comment    = "Backup route for ${each.value}"
+}
+
+
+# Test Case 6: Private IPv4 ranges referencing secondary tunnel
+resource "cloudflare_zero_trust_tunnel_cloudflared_route" "private_ranges" {
+  account_id = var.cloudflare_account_id
+  tunnel_id  = cloudflare_zero_trust_tunnel_cloudflared.secondary.id
+  network    = "172.31.0.0/16"
+  comment    = "Private range 172.16.0.0/12"
+}
+
+
+# Test Case 7: Large CIDR (small subnet) referencing protected tunnel
+resource "cloudflare_zero_trust_tunnel_cloudflared_route" "small_subnet" {
+  account_id = var.cloudflare_account_id
+  tunnel_id  = cloudflare_zero_trust_tunnel_cloudflared.protected.id
+  network    = "192.168.1.0/28"
+  comment    = "Small subnet /28"
+}
+
+
+# Test Case 8: IPv6 with virtual network referencing conditional_config tunnel
+resource "cloudflare_zero_trust_tunnel_cloudflared_route" "ipv6_with_vnet" {
+  account_id = var.cloudflare_account_id
+  tunnel_id  = cloudflare_zero_trust_tunnel_cloudflared.conditional_config.id
+  network    = "fd00::/8"
+  comment    = "IPv6 private network"
+}
+
+
+# Test Case 9: Multiple character encodings in comment referencing encoded tunnel
+resource "cloudflare_zero_trust_tunnel_cloudflared_route" "unicode_comment" {
+  account_id = var.cloudflare_account_id
+  tunnel_id  = cloudflare_zero_trust_tunnel_cloudflared.encoded.id
+  network    = "10.250.0.0/16"
+  comment    = "Multi-language: English, Español, 中文, Русский, العربية"
+}
+
+
+# Test Case 10: Comment at max length (100 chars) referencing interpolated tunnel
+resource "cloudflare_zero_trust_tunnel_cloudflared_route" "long_comment" {
+  account_id = var.cloudflare_account_id
+  tunnel_id  = cloudflare_zero_trust_tunnel_cloudflared.interpolated.id
+  network    = "10.255.0.0/16"
+  comment    = "This comment is exactly one hundred characters long to test the maximum API length constraint limit"
+}
+
+
+# Test Case 11: Computed values with expressions referencing complex_config tunnel
+resource "cloudflare_zero_trust_tunnel_cloudflared_route" "computed_values" {
+  account_id = var.cloudflare_account_id
+  tunnel_id  = cloudflare_zero_trust_tunnel_cloudflared.complex_config.id
+  network    = "10.60.0.0/16"
+  comment    = "Computed from locals"
+}
+
+
+# Test Case 12: Route with cross-reference to tunnel name
+resource "cloudflare_zero_trust_tunnel_cloudflared_route" "cross_reference" {
+  account_id = var.cloudflare_account_id
+  tunnel_id  = cloudflare_zero_trust_tunnel_cloudflared.minimal.id
+  network    = "10.245.0.0/16"
+  comment    = "Route for tunnel: ${cloudflare_zero_trust_tunnel_cloudflared.minimal.name}"
+}
+
+
+variable "from_version" {
+  description = "Provider version under test, used to namespace resource names"
+  type        = string
+}

--- a/e2e-v5/testdata/zero_trust_tunnel_cloudflared_virtual_network/zero_trust_tunnel_cloudflared_virtual_network.tf
+++ b/e2e-v5/testdata/zero_trust_tunnel_cloudflared_virtual_network/zero_trust_tunnel_cloudflared_virtual_network.tf
@@ -1,0 +1,139 @@
+# Comprehensive Integration Test for zero_trust_tunnel_cloudflared_virtual_network
+
+variable "cloudflare_account_id" {
+  type = string
+}
+
+variable "cloudflare_zone_id" {
+  description = "Cloudflare zone ID"
+  type        = string
+}
+
+variable "cloudflare_domain" {
+  description = "Cloudflare domain for testing"
+  type        = string
+}
+
+locals {
+  name_prefix = "v5-upgrade-${replace(var.from_version, ".", "-")}"
+  account_id = var.cloudflare_account_id
+  prefix     = "${local.name_prefix}-vnet"
+}
+
+
+
+
+
+
+
+
+
+# Pattern 9: Cross-resource reference using both v4 names
+# This validates that GetResourceRename() returns ALL v4 names for cross-file reference updates
+# v4 resource name option 1: cloudflare_zero_trust_tunnel_virtual_network
+# v4 resource name option 2: cloudflare_tunnel_virtual_network
+
+
+
+
+# Pattern 1: OLD v4 name - minimal
+resource "cloudflare_zero_trust_tunnel_cloudflared_virtual_network" "minimal" {
+  account_id = local.account_id
+  name       = "${local.prefix}-minimal"
+}
+
+
+# Pattern 2: NEW v4 name - complete
+resource "cloudflare_zero_trust_tunnel_cloudflared_virtual_network" "complete" {
+  account_id         = local.account_id
+  name               = "${local.prefix}-complete"
+  is_default_network = false
+  comment            = "Integration test"
+}
+
+
+# Pattern 4: Empty optionals (tests default handling)
+resource "cloudflare_zero_trust_tunnel_cloudflared_virtual_network" "empty_opts" {
+  account_id = local.account_id
+  name       = "${local.prefix}-empty"
+}
+
+
+# Pattern 5: for_each
+resource "cloudflare_zero_trust_tunnel_cloudflared_virtual_network" "foreach" {
+  for_each = toset(["prod", "staging", "dev"])
+
+  account_id = local.account_id
+  name       = "${local.prefix}-${each.key}"
+  comment    = "Network for ${each.key}"
+}
+
+
+# Pattern 6: count
+resource "cloudflare_zero_trust_tunnel_cloudflared_virtual_network" "counted" {
+  count = 3
+
+  account_id = local.account_id
+  name       = "${local.prefix}-count-${count.index}"
+}
+
+
+# Pattern 7: Lifecycle
+resource "cloudflare_zero_trust_tunnel_cloudflared_virtual_network" "lifecycle" {
+  account_id = local.account_id
+  name       = "${local.prefix}-lifecycle"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+
+# Pattern 8: Both v4 names together
+resource "cloudflare_zero_trust_tunnel_cloudflared_virtual_network" "old_name" {
+  account_id = local.account_id
+  name       = "${local.prefix}-old"
+}
+
+
+resource "cloudflare_zero_trust_tunnel_cloudflared_virtual_network" "new_name" {
+  account_id = local.account_id
+  name       = "${local.prefix}-new"
+}
+
+
+# Create a tunnel to reference in the route
+resource "cloudflare_zero_trust_tunnel_cloudflared" "for_route_test" {
+  account_id    = local.account_id
+  name          = "${local.prefix}-route-test-tunnel"
+  tunnel_secret = base64encode("test-secret-that-is-at-least-32-bytes-long")
+  config_src    = "local"
+}
+
+
+# Route using option 1 v4 name that references the virtual network
+# cloudflare_zero_trust_tunnel_virtual_network (the "option 1" v4 name)
+resource "cloudflare_zero_trust_tunnel_cloudflared_route" "test_opt1_v4_name_ref" {
+  account_id         = local.account_id
+  tunnel_id          = cloudflare_zero_trust_tunnel_cloudflared.for_route_test.id
+  network            = "10.254.0.0/16"
+  virtual_network_id = cloudflare_zero_trust_tunnel_cloudflared_virtual_network.new_name.id
+  comment            = "VNet: ${cloudflare_zero_trust_tunnel_cloudflared_virtual_network.new_name.name}"
+}
+
+
+# Route using option 2 v4 name that references the virtual network
+# cloudflare_tunnel_virtual_network (the "option 2" v4 name)
+resource "cloudflare_zero_trust_tunnel_cloudflared_route" "test_opt2_v4_name_ref" {
+  account_id         = local.account_id
+  tunnel_id          = cloudflare_zero_trust_tunnel_cloudflared.for_route_test.id
+  network            = "10.255.0.0/16"
+  virtual_network_id = cloudflare_zero_trust_tunnel_cloudflared_virtual_network.old_name.id
+  comment            = "VNet: ${cloudflare_zero_trust_tunnel_cloudflared_virtual_network.old_name.name}"
+}
+
+
+variable "from_version" {
+  description = "Provider version under test, used to namespace resource names"
+  type        = string
+}

--- a/e2e-v5/testdata/zone/zone.tf
+++ b/e2e-v5/testdata/zone/zone.tf
@@ -1,0 +1,292 @@
+# Comprehensive Zone Migration Integration Test
+# Covers all Terraform patterns and zone-specific edge cases
+
+# ========================================
+# Variables
+# ========================================
+variable "cloudflare_account_id" {
+  description = "Cloudflare account ID"
+  type        = string
+}
+
+variable "cloudflare_zone_id" {
+  description = "Cloudflare zone ID"
+  type        = string
+}
+
+variable "cloudflare_domain" {
+  description = "Cloudflare domain for testing"
+  type        = string
+}
+
+# ========================================
+# Pattern Group 1: Locals
+# ========================================
+
+locals {
+  common_account = var.cloudflare_account_id
+  name_prefix    = "v5-upgrade-${replace(var.from_version, ".", "-")}"
+  zone_types     = ["full", "partial", "secondary"]
+  test_domains   = ["cf-tf-test.com", "test.com", "demo.com"]
+}
+
+# ========================================
+# Pattern Group 2: Basic Zone Configurations
+# ========================================
+
+# Test Case 1: Minimal zone (only required fields)
+resource "cloudflare_zone" "minimal" {
+  name = "${local.name_prefix}-minimal.cf-tf-test.com"
+  account = {
+    id = var.cloudflare_account_id
+  }
+}
+
+# Test Case 2: Zone with paused = true
+resource "cloudflare_zone" "paused_zone" {
+  paused = true
+  type   = "full"
+  name   = "${local.name_prefix}-paused.cf-tf-test.com"
+  account = {
+    id = var.cloudflare_account_id
+  }
+}
+
+# ========================================
+# Pattern Group 3: for_each with Maps
+# ========================================
+
+resource "cloudflare_zone" "map_zones" {
+  for_each = {
+    "prod" = {
+      domain = "${local.name_prefix}-prod.cf-tf-test.com"
+      type   = "full"
+      paused = false
+    }
+    "staging" = {
+      domain = "${local.name_prefix}-staging.cf-tf-test.com"
+      type   = "full"
+      paused = false
+    }
+    # "dev" = {
+    #   domain = "cftftest-dev.cf-tf-test.com"
+    #   type   = "partial"
+    #   paused = true
+    # }
+  }
+
+  type   = each.value.type
+  paused = each.value.paused
+  name   = each.value.domain
+  account = {
+    id = var.cloudflare_account_id
+  }
+}
+
+# ========================================
+# Pattern Group 4: for_each with Sets
+# ========================================
+
+resource "cloudflare_zone" "set_zones" {
+  for_each = toset([
+    "${local.name_prefix}-alpha.cf-tf-test.com",
+    "${local.name_prefix}-beta.cf-tf-test.com",
+    "${local.name_prefix}-gamma.cf-tf-test.com",
+    "${local.name_prefix}-delta.cf-tf-test.com"
+  ])
+
+  type = "full"
+  name = each.value
+  account = {
+    id = var.cloudflare_account_id
+  }
+}
+
+# ========================================
+# Pattern Group 5: count-based Resources
+# ========================================
+
+resource "cloudflare_zone" "counted_zones" {
+  count = 3
+
+  type   = "full"
+  paused = count.index == 1 ? true : false
+  name   = "${local.name_prefix}-zone-${count.index}.cf-tf-test.com"
+  account = {
+    id = var.cloudflare_account_id
+  }
+}
+
+# ========================================
+# Pattern Group 6: Conditional Creation
+# ========================================
+
+locals {
+  enable_test_zone    = true
+  enable_feature_zone = false
+}
+
+resource "cloudflare_zone" "conditional_enabled" {
+  count = local.enable_test_zone ? 1 : 0
+
+  type = "full"
+  name = "${local.name_prefix}-conditional-enabled.cf-tf-test.com"
+  account = {
+    id = var.cloudflare_account_id
+  }
+}
+
+resource "cloudflare_zone" "conditional_disabled" {
+  count = local.enable_feature_zone ? 1 : 0
+
+  type = "full"
+  name = "${local.name_prefix}-conditional-disabled.cf-tf-test.com"
+  account = {
+    id = var.cloudflare_account_id
+  }
+}
+
+# ========================================
+# Pattern Group 7: Terraform Functions
+# ========================================
+
+resource "cloudflare_zone" "with_functions" {
+  type = "full"
+  name = join("-", ["${local.name_prefix}", "function", "test.cf-tf-test.com"])
+  account = {
+    id = var.cloudflare_account_id
+  }
+}
+
+resource "cloudflare_zone" "with_interpolation" {
+  type   = "full"
+  paused = false
+  name   = "${local.name_prefix}-interpolated.cf-tf-test.com"
+  account = {
+    id = var.cloudflare_account_id
+  }
+}
+
+resource "cloudflare_zone" "with_locals" {
+  type = local.zone_types[0]
+  name = "${local.name_prefix}-with-locals.cf-tf-test.com"
+  account = {
+    id = local.common_account
+  }
+}
+
+# ========================================
+# Pattern Group 8: Lifecycle Meta-Arguments
+# ========================================
+
+resource "cloudflare_zone" "with_lifecycle" {
+  type   = "full"
+  paused = false
+
+  lifecycle {
+    create_before_destroy = true
+  }
+  name = "${local.name_prefix}-lifecycle-test.cf-tf-test.com"
+  account = {
+    id = var.cloudflare_account_id
+  }
+}
+
+resource "cloudflare_zone" "with_ignore_changes" {
+  type = "full"
+
+  lifecycle {
+    ignore_changes = [paused]
+  }
+  name = "${local.name_prefix}-ignore-changes.cf-tf-test.com"
+  account = {
+    id = var.cloudflare_account_id
+  }
+}
+
+resource "cloudflare_zone" "with_prevent_destroy" {
+  type = "full"
+
+  lifecycle {
+    prevent_destroy = false
+  }
+  name = "${local.name_prefix}-prevent-destroy.cf-tf-test.com"
+  account = {
+    id = var.cloudflare_account_id
+  }
+}
+
+# ========================================
+# Pattern Group 9: Edge Cases
+# ========================================
+
+# Test Case: Hyphenated domain
+resource "cloudflare_zone" "hyphenated_domain" {
+  type = "full"
+  name = "${local.name_prefix}-hyphen-domain.cf-tf-test.com"
+  account = {
+    id = var.cloudflare_account_id
+  }
+}
+
+# Test Case: Subdomain with many levels
+resource "cloudflare_zone" "deep_subdomain" {
+  type = "full"
+  name = "${local.name_prefix}-level4.level3.level2.level1.cf-tf-test.com"
+  account = {
+    id = var.cloudflare_account_id
+  }
+}
+
+# Test Case: Zone with removed attributes (jump_start and plan)
+resource "cloudflare_zone" "with_removed_attrs" {
+  type = "full"
+  name = "${local.name_prefix}-removed-attrs.cf-tf-test.com"
+  account = {
+    id = var.cloudflare_account_id
+  }
+}
+
+# Test Case: Zone with all plan types
+resource "cloudflare_zone" "with_pro_plan" {
+  type = "full"
+  name = "${local.name_prefix}-pro-plan.cf-tf-test.com"
+  account = {
+    id = var.cloudflare_account_id
+  }
+}
+
+resource "cloudflare_zone" "with_business_plan" {
+  type = "full"
+  name = "${local.name_prefix}-business-plan.cf-tf-test.com"
+  account = {
+    id = var.cloudflare_account_id
+  }
+}
+
+# ========================================
+# Total Resource Count Summary
+# ========================================
+# Minimal: 1
+# Basic variations: 2 (paused, removed_attrs)
+# for_each with maps: 2 instances (prod, staging)
+# for_each with sets: 4 instances
+# count-based: 3 instances
+# Conditional: 1 instance (enabled only)
+# With functions: 3 instances
+# Lifecycle: 3 instances
+# Edge cases: 4 instances (hyphenated, deep, plan variations)
+# TOTAL: 23 resource instances
+#
+# REMOVED (require Business/Enterprise plans):
+# - maximal (vanity name servers)
+# - partial_zone (partial zone type)
+# - secondary_zone (secondary zone type)
+# - with_vanity_ns (vanity name servers)
+# - map_zones["dev"] (partial zone type)
+# - unicode_domain (commented out by linter)
+
+variable "from_version" {
+  description = "Provider version under test, used to namespace resource names"
+  type        = string
+}

--- a/e2e-v5/testdata/zone_dnssec/zone_dnssec.tf
+++ b/e2e-v5/testdata/zone_dnssec/zone_dnssec.tf
@@ -1,0 +1,28 @@
+locals {
+  name_prefix = "v5-upgrade-${replace(var.from_version, ".", "-")}"
+}
+
+variable "cloudflare_account_id" {
+  description = "Cloudflare account ID"
+  type        = string
+}
+
+variable "cloudflare_zone_id" {
+  description = "Cloudflare zone ID"
+  type        = string
+}
+
+variable "cloudflare_domain" {
+  description = "Cloudflare domain for testing"
+  type        = string
+}
+
+# Zone DNSSEC with modified_on field (should be removed during migration)
+# Tests: modified_on removal, status preservation from state
+resource "cloudflare_zone_dnssec" "test" {
+  zone_id = var.cloudflare_zone_id
+}
+variable "from_version" {
+  description = "Provider version under test, used to namespace resource names"
+  type        = string
+}

--- a/e2e-v5/testdata/zone_setting/zone_setting.tf
+++ b/e2e-v5/testdata/zone_setting/zone_setting.tf
@@ -1,0 +1,399 @@
+# Zone Settings Migration Test - Safe settings for all plans
+# Covers migration patterns without plan-restricted features
+
+variable "cloudflare_account_id" {
+  description = "Cloudflare account ID"
+  type        = string
+}
+
+variable "cloudflare_zone_id" {
+  description = "Cloudflare zone ID"
+  type        = string
+}
+
+variable "cloudflare_domain" {
+  description = "Cloudflare domain for testing"
+  type        = string
+}
+
+locals {
+  primary_zone_id = var.cloudflare_zone_id
+  cache_ttls      = [14400, 28800, 43200]
+}
+
+
+
+
+# Test Cases 4-6: Removed - Invalid Pattern
+# Multiple zone_settings_override resources for the same zone will conflict
+# In v4, cloudflare_zone_settings_override manages ALL settings for a zone
+# Having multiple such resources causes them to overwrite each other
+# This pattern is not supported and should not be used
+
+# Test Case 7: Conditional creation
+locals {
+  enable_advanced_settings = true
+  enable_test_settings     = false
+}
+
+
+
+
+
+
+
+
+
+resource "cloudflare_zone_setting" "minimal_always_online" {
+  zone_id    = var.cloudflare_zone_id
+  setting_id = "always_online"
+  value      = "on"
+}
+
+
+resource "cloudflare_zone_setting" "minimal_brotli" {
+  zone_id    = var.cloudflare_zone_id
+  setting_id = "brotli"
+  value      = "on"
+}
+
+
+removed {
+  from = cloudflare_zone_settings_override.minimal
+  lifecycle {
+    destroy = false
+  }
+  # MIGRATION NOTES:
+  # 1. Before running terraform plan/apply, remove the old state entry:
+  #      terraform state rm 'cloudflare_zone_settings_override.minimal'
+  #    If inside a module named "mymod":
+  #      terraform state rm 'module.mymod.cloudflare_zone_settings_override.minimal'
+  # 2. The import blocks above are only valid in the root Terraform module.
+  #    If this file is a child module, move the import blocks to your root
+  #    module and prefix 'to' with the module path:
+  #      to = module.mymod.cloudflare_zone_setting.minimal_<setting>
+}
+
+resource "cloudflare_zone_setting" "with_integers_browser_cache_ttl" {
+  zone_id    = var.cloudflare_zone_id
+  setting_id = "browser_cache_ttl"
+  value      = 14400
+}
+
+
+resource "cloudflare_zone_setting" "with_integers_challenge_ttl" {
+  zone_id    = var.cloudflare_zone_id
+  setting_id = "challenge_ttl"
+  value      = 1800
+}
+
+
+removed {
+  from = cloudflare_zone_settings_override.with_integers
+  lifecycle {
+    destroy = false
+  }
+  # MIGRATION NOTES:
+  # 1. Before running terraform plan/apply, remove the old state entry:
+  #      terraform state rm 'cloudflare_zone_settings_override.with_integers'
+  #    If inside a module named "mymod":
+  #      terraform state rm 'module.mymod.cloudflare_zone_settings_override.with_integers'
+  # 2. The import blocks above are only valid in the root Terraform module.
+  #    If this file is a child module, move the import blocks to your root
+  #    module and prefix 'to' with the module path:
+  #      to = module.mymod.cloudflare_zone_setting.with_integers_<setting>
+}
+
+resource "cloudflare_zone_setting" "with_security_header_ssl" {
+  zone_id    = var.cloudflare_zone_id
+  setting_id = "ssl"
+  value      = "flexible"
+}
+
+
+resource "cloudflare_zone_setting" "with_security_header_security_header" {
+  zone_id    = var.cloudflare_zone_id
+  setting_id = "security_header"
+  value = {
+    strict_transport_security = {
+      enabled            = true
+      include_subdomains = true
+      max_age            = 86400
+      nosniff            = true
+      preload            = true
+    }
+  }
+}
+
+
+removed {
+  from = cloudflare_zone_settings_override.with_security_header
+  lifecycle {
+    destroy = false
+  }
+  # MIGRATION NOTES:
+  # 1. Before running terraform plan/apply, remove the old state entry:
+  #      terraform state rm 'cloudflare_zone_settings_override.with_security_header'
+  #    If inside a module named "mymod":
+  #      terraform state rm 'module.mymod.cloudflare_zone_settings_override.with_security_header'
+  # 2. The import blocks above are only valid in the root Terraform module.
+  #    If this file is a child module, move the import blocks to your root
+  #    module and prefix 'to' with the module path:
+  #      to = module.mymod.cloudflare_zone_setting.with_security_header_<setting>
+}
+
+resource "cloudflare_zone_setting" "conditional_enabled_rocket_loader" {
+  zone_id    = var.cloudflare_zone_id
+  setting_id = "rocket_loader"
+  value      = "on"
+  count      = local.enable_advanced_settings ? 1 : 0
+}
+
+resource "cloudflare_zone_setting" "conditional_enabled_websockets" {
+  zone_id    = var.cloudflare_zone_id
+  setting_id = "websockets"
+  value      = "on"
+  count      = local.enable_advanced_settings ? 1 : 0
+}
+
+removed {
+  from = cloudflare_zone_settings_override.conditional_enabled
+  lifecycle {
+    destroy = false
+  }
+  # MIGRATION NOTES:
+  # 1. Before running terraform plan/apply, remove the old state entry:
+  #      terraform state rm 'cloudflare_zone_settings_override.conditional_enabled[0]'
+  #    If inside a module named "mymod":
+  #      terraform state rm 'module.mymod.cloudflare_zone_settings_override.conditional_enabled[0]'
+  # 2. The import blocks above are only valid in the root Terraform module.
+  #    If this file is a child module, move the import blocks to your root
+  #    module and prefix 'to' with the module path:
+  #      to = module.mymod.cloudflare_zone_setting.conditional_enabled_<setting>
+}
+
+resource "cloudflare_zone_setting" "conditional_disabled_browser_check" {
+  zone_id    = var.cloudflare_zone_id
+  setting_id = "browser_check"
+  value      = "on"
+  count      = local.enable_test_settings ? 1 : 0
+}
+
+removed {
+  from = cloudflare_zone_settings_override.conditional_disabled
+  lifecycle {
+    destroy = false
+  }
+  # MIGRATION NOTES:
+  # 1. Before running terraform plan/apply, remove the old state entry:
+  #      terraform state rm 'cloudflare_zone_settings_override.conditional_disabled[0]'
+  #    If inside a module named "mymod":
+  #      terraform state rm 'module.mymod.cloudflare_zone_settings_override.conditional_disabled[0]'
+  # 2. The import blocks above are only valid in the root Terraform module.
+  #    If this file is a child module, move the import blocks to your root
+  #    module and prefix 'to' with the module path:
+  #      to = module.mymod.cloudflare_zone_setting.conditional_disabled_<setting>
+}
+
+resource "cloudflare_zone_setting" "with_functions_browser_cache_ttl" {
+  zone_id    = var.cloudflare_zone_id
+  setting_id = "browser_cache_ttl"
+  value      = lookup({ "default" = 14400, "custom" = 28800 }, "default")
+}
+
+
+resource "cloudflare_zone_setting" "with_functions_cache_level" {
+  zone_id    = var.cloudflare_zone_id
+  setting_id = "cache_level"
+  value      = "aggressive"
+}
+
+
+removed {
+  from = cloudflare_zone_settings_override.with_functions
+  lifecycle {
+    destroy = false
+  }
+  # MIGRATION NOTES:
+  # 1. Before running terraform plan/apply, remove the old state entry:
+  #      terraform state rm 'cloudflare_zone_settings_override.with_functions'
+  #    If inside a module named "mymod":
+  #      terraform state rm 'module.mymod.cloudflare_zone_settings_override.with_functions'
+  # 2. The import blocks above are only valid in the root Terraform module.
+  #    If this file is a child module, move the import blocks to your root
+  #    module and prefix 'to' with the module path:
+  #      to = module.mymod.cloudflare_zone_setting.with_functions_<setting>
+}
+
+resource "cloudflare_zone_setting" "with_interpolation_automatic_https_rewrites" {
+  zone_id    = local.primary_zone_id
+  setting_id = "automatic_https_rewrites"
+  value      = "on"
+}
+
+# NOTE: import block not hoisted to root — id references a module-local value.
+# Add this import block manually in your root module with the resolved id value:
+# import {
+#   to = cloudflare_zone_setting.with_interpolation_automatic_https_rewrites
+#   id = "${local.primary_zone_id}/automatic_https_rewrites"
+# }
+
+resource "cloudflare_zone_setting" "with_interpolation_min_tls_version" {
+  zone_id    = local.primary_zone_id
+  setting_id = "min_tls_version"
+  value      = "1.2"
+}
+
+# NOTE: import block not hoisted to root — id references a module-local value.
+# Add this import block manually in your root module with the resolved id value:
+# import {
+#   to = cloudflare_zone_setting.with_interpolation_min_tls_version
+#   id = "${local.primary_zone_id}/min_tls_version"
+# }
+
+removed {
+  from = cloudflare_zone_settings_override.with_interpolation
+  lifecycle {
+    destroy = false
+  }
+  # MIGRATION NOTES:
+  # 1. Before running terraform plan/apply, remove the old state entry:
+  #      terraform state rm 'cloudflare_zone_settings_override.with_interpolation'
+  #    If inside a module named "mymod":
+  #      terraform state rm 'module.mymod.cloudflare_zone_settings_override.with_interpolation'
+  # 2. The import blocks above are only valid in the root Terraform module.
+  #    If this file is a child module, move the import blocks to your root
+  #    module and prefix 'to' with the module path:
+  #      to = module.mymod.cloudflare_zone_setting.with_interpolation_<setting>
+}
+
+resource "cloudflare_zone_setting" "with_lifecycle_always_online" {
+  zone_id    = var.cloudflare_zone_id
+  setting_id = "always_online"
+  value      = "on"
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+
+resource "cloudflare_zone_setting" "with_lifecycle_ipv6" {
+  zone_id    = var.cloudflare_zone_id
+  setting_id = "ipv6"
+  value      = "on"
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+
+removed {
+  from = cloudflare_zone_settings_override.with_lifecycle
+  lifecycle {
+    destroy = false
+  }
+  # MIGRATION NOTES:
+  # 1. Before running terraform plan/apply, remove the old state entry:
+  #      terraform state rm 'cloudflare_zone_settings_override.with_lifecycle'
+  #    If inside a module named "mymod":
+  #      terraform state rm 'module.mymod.cloudflare_zone_settings_override.with_lifecycle'
+  # 2. The import blocks above are only valid in the root Terraform module.
+  #    If this file is a child module, move the import blocks to your root
+  #    module and prefix 'to' with the module path:
+  #      to = module.mymod.cloudflare_zone_setting.with_lifecycle_<setting>
+}
+
+resource "cloudflare_zone_setting" "with_ignore_changes_email_obfuscation" {
+  zone_id    = var.cloudflare_zone_id
+  setting_id = "email_obfuscation"
+  value      = "on"
+}
+
+
+resource "cloudflare_zone_setting" "with_ignore_changes_server_side_exclude" {
+  zone_id    = var.cloudflare_zone_id
+  setting_id = "server_side_exclude"
+  value      = "on"
+}
+
+
+removed {
+  from = cloudflare_zone_settings_override.with_ignore_changes
+  lifecycle {
+    destroy = false
+  }
+  # MIGRATION NOTES:
+  # 1. Before running terraform plan/apply, remove the old state entry:
+  #      terraform state rm 'cloudflare_zone_settings_override.with_ignore_changes'
+  #    If inside a module named "mymod":
+  #      terraform state rm 'module.mymod.cloudflare_zone_settings_override.with_ignore_changes'
+  # 2. The import blocks above are only valid in the root Terraform module.
+  #    If this file is a child module, move the import blocks to your root
+  #    module and prefix 'to' with the module path:
+  #      to = module.mymod.cloudflare_zone_setting.with_ignore_changes_<setting>
+}
+
+resource "cloudflare_zone_setting" "with_name_mapping_http2" {
+  zone_id    = var.cloudflare_zone_id
+  setting_id = "http2"
+  value      = "on"
+}
+
+
+resource "cloudflare_zone_setting" "with_name_mapping_http3" {
+  zone_id    = var.cloudflare_zone_id
+  setting_id = "http3"
+  value      = "on"
+}
+
+
+removed {
+  from = cloudflare_zone_settings_override.with_name_mapping
+  lifecycle {
+    destroy = false
+  }
+  # MIGRATION NOTES:
+  # 1. Before running terraform plan/apply, remove the old state entry:
+  #      terraform state rm 'cloudflare_zone_settings_override.with_name_mapping'
+  #    If inside a module named "mymod":
+  #      terraform state rm 'module.mymod.cloudflare_zone_settings_override.with_name_mapping'
+  # 2. The import blocks above are only valid in the root Terraform module.
+  #    If this file is a child module, move the import blocks to your root
+  #    module and prefix 'to' with the module path:
+  #      to = module.mymod.cloudflare_zone_setting.with_name_mapping_<setting>
+}
+
+resource "cloudflare_zone_setting" "with_deprecated_always_online" {
+  zone_id    = var.cloudflare_zone_id
+  setting_id = "always_online"
+  value      = "on"
+}
+
+
+resource "cloudflare_zone_setting" "with_deprecated_brotli" {
+  zone_id    = var.cloudflare_zone_id
+  setting_id = "brotli"
+  value      = "on"
+}
+
+
+removed {
+  from = cloudflare_zone_settings_override.with_deprecated
+  lifecycle {
+    destroy = false
+  }
+  # MIGRATION NOTES:
+  # 1. Before running terraform plan/apply, remove the old state entry:
+  #      terraform state rm 'cloudflare_zone_settings_override.with_deprecated'
+  #    If inside a module named "mymod":
+  #      terraform state rm 'module.mymod.cloudflare_zone_settings_override.with_deprecated'
+  # 2. The import blocks above are only valid in the root Terraform module.
+  #    If this file is a child module, move the import blocks to your root
+  #    module and prefix 'to' with the module path:
+  #      to = module.mymod.cloudflare_zone_setting.with_deprecated_<setting>
+}
+
+variable "from_version" {
+  description = "Provider version under test, used to namespace resource names"
+  type        = string
+}

--- a/internal/e2e-runner/v5_upgrade.go
+++ b/internal/e2e-runner/v5_upgrade.go
@@ -1,0 +1,1053 @@
+// state_upgrader.go provides the main orchestration for v5→v5 v5 upgrade tests.
+//
+// This file implements the complete test workflow that validates provider v5 upgrades
+// work correctly when upgrading between v5 versions. Unlike v4→v5 migrations, these tests:
+//   - Do NOT use tf-migrate (configs are already v5 syntax)
+//   - Test the provider's built-in UpgradeState mechanism
+//   - Create resources with an older v5 version, then upgrade the provider
+//
+// Test workflow:
+//  1. Initialize: Sync testdata, generate configs with source version
+//  2. Create: terraform init/apply with source version provider
+//  3. Upgrade: Update provider version, terraform init -upgrade
+//  4. Verify: terraform plan to check state upgrade success
+//  5. Stabilize: Apply if needed, verify no ongoing drift
+package e2e
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// suTestContext holds shared state for v5 upgrade test execution
+type suTestContext struct {
+	cfg          *V5UpgradeConfig
+	env          *E2EEnv
+	repoRoot     string
+	e2eV5Root    string
+	tfDir        string
+	tmpDir       string
+	testdataRoot string
+	resourceList []string
+	tfConfigFile string // for dev_overrides when using local provider
+
+	// Drift tracking
+	hasChanges             bool
+	hasPostApplyChanges    bool
+	initialDrift           []string
+	postApplyDrift         []string
+	initialMaterial        int
+	postApplyMaterial      int
+	initialReal            int
+	postApplyReal          int
+	initialExempted        int
+	postApplyExempted      int
+	initialExemptedLines   []string
+	postApplyExemptedLines []string
+
+	// Output tracking
+	planOutput     string
+	postPlanOutput string
+}
+
+// RunV5UpgradeTests executes the complete v5 upgrade test workflow
+func RunV5UpgradeTests(cfg *V5UpgradeConfig) error {
+	if cfg.Parallelism < 0 {
+		return fmt.Errorf("parallelism must be >= 0, got %d", cfg.Parallelism)
+	}
+
+	// Normalize versions
+	if cfg.FromVersion == "" {
+		cfg.FromVersion = DefaultFromVersion
+	}
+	if cfg.ToVersion == "" {
+		cfg.ToVersion = DefaultToVersion
+	}
+
+	// Get paths
+	repoRoot := getRepoRoot()
+	e2eV5Root := filepath.Join(repoRoot, "e2e-v5")
+	tfDir := filepath.Join(e2eV5Root, "tf")
+	tmpDir := filepath.Join(e2eV5Root, "tmp")
+	testdataRoot := filepath.Join(e2eV5Root, "testdata")
+
+	// Create tmp directory
+	if err := os.MkdirAll(tmpDir, permDir); err != nil {
+		return fmt.Errorf("failed to create tmp directory %s: %w", tmpDir, err)
+	}
+
+	printHeader("V5 Upgrade Tests")
+	printCyan("Testing provider v5 upgrades: %s → %s", cfg.FromVersion, cfg.ToVersion)
+	fmt.Println()
+
+	printYellow("Configuration:")
+	printYellow("  From version:     %s", cfg.FromVersion)
+	if cfg.ProviderPath != "" {
+		printYellow("  To version:       Local provider (%s)", cfg.ProviderPath)
+	} else {
+		printYellow("  To version:       %s", cfg.ToVersion)
+	}
+	printYellow("  State key:        %s", GenerateStateKey(cfg.FromVersion, cfg.ToVersion))
+	if cfg.Resources != "" {
+		printYellow("  Resources:        %s", cfg.Resources)
+	}
+	if cfg.ApplyExemptions {
+		printYellow("  Exemptions:       Enabled")
+	}
+	fmt.Println()
+
+	// Load environment
+	env, err := LoadEnv(EnvForRunner)
+	if err != nil {
+		return err
+	}
+
+	// Parse resource list
+	var resourceList []string
+	if cfg.Resources != "" {
+		for _, r := range strings.Split(cfg.Resources, ",") {
+			resourceList = append(resourceList, strings.TrimSpace(r))
+		}
+	}
+
+	// Build target args for terraform commands
+	var targetArgs []string
+	for _, resource := range resourceList {
+		targetArgs = append(targetArgs, "-target=module."+resource)
+	}
+
+	// Set up local provider if specified (for target version)
+	var tfConfigFile string
+	if cfg.ProviderPath != "" {
+		var err error
+		tfConfigFile, err = setupLocalProvider(cfg.ProviderPath, repoRoot)
+		if err != nil {
+			return err
+		}
+	}
+
+	// Create test context
+	ctx := &suTestContext{
+		cfg:          cfg,
+		env:          env,
+		repoRoot:     repoRoot,
+		e2eV5Root:    e2eV5Root,
+		tfDir:        tfDir,
+		tmpDir:       tmpDir,
+		testdataRoot: testdataRoot,
+		resourceList: resourceList,
+		tfConfigFile: tfConfigFile,
+	}
+
+	// Step 1: Initialize test resources
+	if !cfg.SkipCreate {
+		printCyan("Step 1: Initializing test resources")
+		if err := RunV5UpgradeInit(cfg); err != nil {
+			printError("Initialization failed")
+			return err
+		}
+		printSuccess("Initialization complete")
+		fmt.Println()
+	} else {
+		printCyan("Step 1: Skipped initialization (--skip-create)")
+		fmt.Println()
+	}
+
+	// cleanOnExit runs cleanup if --clean is set, regardless of success or failure.
+	// This prevents orphaned resources when the test fails partway through.
+	cleanOnExit := func(testErr error) error {
+		if !cfg.Clean {
+			return testErr
+		}
+		fmt.Println()
+		if testErr != nil {
+			printCyan("Cleaning up resources after failure (--clean)...")
+		} else {
+			printCyan("Step 7: Cleaning up resources (--clean)")
+		}
+		if cleanErr := RunV5UpgradeClean(cfg, nil); cleanErr != nil {
+			printError("Cleanup failed: %v", cleanErr)
+			if testErr == nil {
+				return cleanErr
+			}
+		}
+		return testErr
+	}
+
+	// Step 2: Create resources with source version
+	if !cfg.SkipCreate {
+		if err := runCreateWithSourceVersion(ctx); err != nil {
+			return cleanOnExit(err)
+		}
+	} else {
+		printCyan("Step 2: Skipped resource creation (--skip-create)")
+		fmt.Println()
+	}
+
+	// Step 3: Upgrade provider version
+	if err := runUpgradeProvider(ctx); err != nil {
+		return cleanOnExit(err)
+	}
+
+	// Steps 4-6: Verify state upgrade (plan → apply → plan)
+	if err := runVerifyStateUpgrade(ctx); err != nil {
+		return cleanOnExit(err)
+	}
+
+	// Report results (not a numbered step - just summary)
+	testErr := reportResults(ctx)
+
+	return cleanOnExit(testErr)
+}
+
+// runCreateWithSourceVersion creates resources using the source provider version
+func runCreateWithSourceVersion(ctx *suTestContext) error {
+	printCyan("Step 2: Creating resources with provider %s", ctx.cfg.FromVersion)
+
+	tf := NewTerraformRunner(ctx.tfDir)
+	tf.EnvVars["AWS_ACCESS_KEY_ID"] = ctx.env.R2AccessKeyID
+	tf.EnvVars["AWS_SECRET_ACCESS_KEY"] = ctx.env.R2SecretAccessKey
+
+	// Initialize terraform with source version
+	printYellow("Running terraform init...")
+	initArgs := []string{"init", "-no-color", "-input=false", "-backend-config=backend.configured.hcl", "-reconfigure", "-upgrade"}
+	if err := tf.RunToFile(filepath.Join(ctx.tmpDir, "source-init.log"), initArgs...); err != nil {
+		printError("Terraform init failed")
+		content, _ := os.ReadFile(filepath.Join(ctx.tmpDir, "source-init.log"))
+		fmt.Println(string(content))
+		return err
+	}
+	printSuccess("Terraform init successful")
+
+	// Run plan
+	printYellow("Running terraform plan...")
+	planArgs := append([]string{"plan", "-no-color", "-out=" + filepath.Join(ctx.tmpDir, "source.tfplan"), "-input=false"}, ctx.targetArgs()...)
+	planArgs = addParallelismArg(planArgs, ctx.cfg.Parallelism)
+	if err := tf.RunToFile(filepath.Join(ctx.tmpDir, "source-plan.log"), planArgs...); err != nil {
+		content, _ := os.ReadFile(filepath.Join(ctx.tmpDir, "source-plan.log"))
+		planLog := string(content)
+
+		// When running a targeted batch with an older source provider, stale state
+		// from previously-upgraded modules can trigger:
+		// "Resource instance managed by newer provider version".
+		// In that case, prune non-target module state and retry the source plan once.
+		if strings.Contains(planLog, "Resource instance managed by newer provider version") && len(ctx.resourceList) > 0 {
+			printYellow("Detected newer-provider state outside target modules; pruning non-target module state and retrying plan once...")
+			removed, pruneErr := pruneNonTargetModuleState(tf, ctx.resourceList)
+			if pruneErr != nil {
+				printError("Failed to prune non-target module state")
+				fmt.Println(planLog)
+				return pruneErr
+			}
+			if removed > 0 {
+				printSuccess("Pruned %d non-target state entries", removed)
+			} else {
+				printYellow("No non-target module state entries found to prune")
+			}
+
+			if retryErr := tf.RunToFile(filepath.Join(ctx.tmpDir, "source-plan.log"), planArgs...); retryErr != nil {
+				printError("Terraform plan failed (after prune retry)")
+				retryContent, _ := os.ReadFile(filepath.Join(ctx.tmpDir, "source-plan.log"))
+				fmt.Println(string(retryContent))
+				return retryErr
+			}
+			printSuccess("Terraform plan successful after state prune")
+		} else {
+			printError("Terraform plan failed")
+			fmt.Println(planLog)
+			return err
+		}
+	}
+	printSuccess("Terraform plan successful")
+
+	// Run apply
+	printYellow("Running terraform apply...")
+	applyArgs := []string{"apply", "-no-color", "-input=false", filepath.Join(ctx.tmpDir, "source.tfplan")}
+	if err := tf.RunToFile(filepath.Join(ctx.tmpDir, "source-apply.log"), applyArgs...); err != nil {
+		printError("Terraform apply failed")
+		content, _ := os.ReadFile(filepath.Join(ctx.tmpDir, "source-apply.log"))
+		fmt.Println(string(content))
+		return err
+	}
+	printSuccess("Terraform apply successful")
+	printSuccess("Resources created with provider %s", ctx.cfg.FromVersion)
+	fmt.Println()
+
+	return nil
+}
+
+// pruneNonTargetModuleState removes module.* state entries that do not belong
+// to the current resource target list.
+func pruneNonTargetModuleState(tf *TerraformRunner, targetModules []string) (int, error) {
+	output, err := tf.Run("state", "list")
+	if err != nil {
+		return 0, err
+	}
+
+	targetSet := make(map[string]struct{}, len(targetModules))
+	for _, m := range targetModules {
+		targetSet[m] = struct{}{}
+	}
+
+	removed := 0
+	for _, line := range strings.Split(output, "\n") {
+		addr := strings.TrimSpace(line)
+		if addr == "" || !strings.HasPrefix(addr, "module.") {
+			continue
+		}
+
+		remainder := strings.TrimPrefix(addr, "module.")
+		dot := strings.Index(remainder, ".")
+		if dot <= 0 {
+			continue
+		}
+		moduleName := remainder[:dot]
+
+		if _, ok := targetSet[moduleName]; ok {
+			continue
+		}
+
+		if _, rmErr := tf.Run("state", "rm", addr); rmErr != nil {
+			return removed, rmErr
+		}
+		removed++
+	}
+
+	return removed, nil
+}
+
+// runUpgradeProvider upgrades the provider to the target version
+func runUpgradeProvider(ctx *suTestContext) error {
+	printCyan("Step 3: Upgrading provider to %s", ctx.cfg.ToVersion)
+
+	tf := NewTerraformRunner(ctx.tfDir)
+	tf.EnvVars["AWS_ACCESS_KEY_ID"] = ctx.env.R2AccessKeyID
+	tf.EnvVars["AWS_SECRET_ACCESS_KEY"] = ctx.env.R2SecretAccessKey
+
+	if ctx.cfg.ProviderPath != "" {
+		// Using local provider - set up dev_overrides
+		printYellow("Using local provider from: %s", ctx.cfg.ProviderPath)
+		tf.TFConfigFile = ctx.tfConfigFile
+
+		// Clean .terraform directory to ensure dev_overrides are used
+		tfDirPath := filepath.Join(ctx.tfDir, ".terraform")
+		if _, err := os.Stat(tfDirPath); err == nil {
+			printYellow("Cleaning .terraform directory for fresh init with local provider...")
+			if err := os.RemoveAll(tfDirPath); err != nil {
+				return fmt.Errorf("failed to remove .terraform directory: %w", err)
+			}
+		}
+
+		// Remove lock file
+		lockFile := filepath.Join(ctx.tfDir, ".terraform.lock.hcl")
+		if _, err := os.Stat(lockFile); err == nil {
+			if err := os.Remove(lockFile); err != nil {
+				return fmt.Errorf("failed to remove lock file: %w", err)
+			}
+		}
+
+		// Re-init with local provider
+		printYellow("Running terraform init with local provider...")
+		initArgs := []string{"init", "-no-color", "-input=false", "-backend-config=backend.configured.hcl"}
+		if err := tf.RunToFile(filepath.Join(ctx.tmpDir, "upgrade-init.log"), initArgs...); err != nil {
+			printError("Terraform init failed")
+			content, _ := os.ReadFile(filepath.Join(ctx.tmpDir, "upgrade-init.log"))
+			fmt.Println(string(content))
+			return err
+		}
+	} else {
+		// Using registry provider - update provider.tf and run init -upgrade
+		printYellow("Updating provider.tf to version %s...", ctx.cfg.ToVersion)
+		targetConstraint, _ := ResolveTargetVersion(ctx.cfg.ToVersion)
+		providerContent := GenerateProviderTF(targetConstraint)
+		providerFile := filepath.Join(ctx.tfDir, "provider.tf")
+		if err := os.WriteFile(providerFile, []byte(providerContent), permFile); err != nil {
+			return fmt.Errorf("failed to update provider.tf: %w", err)
+		}
+
+		// Run terraform init -upgrade
+		printYellow("Running terraform init -upgrade...")
+		initArgs := []string{"init", "-no-color", "-input=false", "-backend-config=backend.configured.hcl", "-upgrade"}
+		if err := tf.RunToFile(filepath.Join(ctx.tmpDir, "upgrade-init.log"), initArgs...); err != nil {
+			printError("Terraform init -upgrade failed")
+			content, _ := os.ReadFile(filepath.Join(ctx.tmpDir, "upgrade-init.log"))
+			fmt.Println(string(content))
+			return err
+		}
+	}
+
+	printSuccess("Provider upgraded successfully")
+	fmt.Println()
+
+	// Resync module configs to the default (target-version) files.
+	// If any module had a version-specific config for the source version
+	// (e.g. page_rule_5_1_0.tf), it must be replaced with the default config
+	// before the post-upgrade plan runs, since the old syntax is no longer
+	// valid against the upgraded provider.
+	if err := resyncForTargetVersion(ctx.testdataRoot, ctx.tfDir, ctx.resourceList); err != nil {
+		return fmt.Errorf("failed to resync configs for target version: %w", err)
+	}
+	fmt.Println()
+
+	return nil
+}
+
+// runVerifyStateUpgrade verifies the state upgrade was successful
+// This follows the same flow as v4→v5 tests: Plan → Apply → Plan (verify stable)
+func runVerifyStateUpgrade(ctx *suTestContext) error {
+	printCyan("Step 4: Verifying state upgrade")
+
+	tf := NewTerraformRunner(ctx.tfDir)
+	tf.EnvVars["AWS_ACCESS_KEY_ID"] = ctx.env.R2AccessKeyID
+	tf.EnvVars["AWS_SECRET_ACCESS_KEY"] = ctx.env.R2SecretAccessKey
+	if ctx.tfConfigFile != "" {
+		tf.TFConfigFile = ctx.tfConfigFile
+	}
+
+	// Run terraform plan
+	printYellow("Running terraform plan...")
+	planArgs := append([]string{"plan", "-no-color", "-out=" + filepath.Join(ctx.tmpDir, "upgrade.tfplan"), "-input=false"}, ctx.targetArgs()...)
+	planArgs = addParallelismArg(planArgs, ctx.cfg.Parallelism)
+
+	var err error
+	ctx.planOutput, err = tf.Run(planArgs...)
+	if err != nil {
+		printError("Terraform plan failed - STATE UPGRADE MAY HAVE FAILED")
+		fmt.Println()
+		printRed("Error output:")
+		fmt.Println(ctx.planOutput)
+
+		// Save plan output for debugging
+		planLog := filepath.Join(ctx.tmpDir, "upgrade-plan.log")
+		os.WriteFile(planLog, []byte(ctx.planOutput), permFile)
+
+		return fmt.Errorf("state upgrade verification failed: terraform plan error")
+	}
+
+	// Save plan output
+	planLog := filepath.Join(ctx.tmpDir, "upgrade-plan.log")
+	if err := os.WriteFile(planLog, []byte(ctx.planOutput), permFile); err != nil {
+		printYellow("Warning: Failed to save plan log: %v", err)
+	}
+
+	// Check for drift
+	driftResult := checkAndDisplayDriftForSU(ctx.planOutput, ctx.cfg, "upgrade", ctx.resourceList, ctx.e2eV5Root)
+	ctx.hasChanges = driftResult.hasDrift
+	ctx.initialDrift = driftResult.driftLines
+	ctx.initialMaterial = driftResult.materialCount
+	ctx.initialReal = driftResult.realCount
+	ctx.initialExempted = driftResult.exemptedCount
+	ctx.initialExemptedLines = driftResult.exemptedLines
+
+	// Always apply (even if no changes) to match v4→v5 test flow
+	// This ensures we verify state stability consistently
+	printYellow("Running terraform apply...")
+	applyArgs := []string{"apply", "-no-color", "-auto-approve", "-input=false", filepath.Join(ctx.tmpDir, "upgrade.tfplan")}
+	applyOutput, err := tf.Run(applyArgs...)
+	if err != nil {
+		printError("Terraform apply failed")
+		fmt.Println()
+		printRed("Error output:")
+		fmt.Println(applyOutput)
+		return err
+	}
+
+	// Save apply output for debugging
+	applyLog := filepath.Join(ctx.tmpDir, "upgrade-apply.log")
+	if err := os.WriteFile(applyLog, []byte(applyOutput), permFile); err != nil {
+		printYellow("Warning: Failed to save apply log: %v", err)
+	}
+	printSuccess("Terraform apply successful")
+
+	// Capture state snapshot
+	printYellow("Capturing state...")
+	stateOutput, err := tf.Run("show", "-no-color", "-json")
+	if err != nil {
+		printYellow("Warning: Failed to capture state: %v", err)
+	} else {
+		stateLog := filepath.Join(ctx.tmpDir, "upgrade-state.json")
+		if err := os.WriteFile(stateLog, []byte(stateOutput), permFile); err != nil {
+			printYellow("Warning: Failed to save state to %s: %v", stateLog, err)
+		} else {
+			printSuccess("Saved state to tmp/upgrade-state.json")
+		}
+	}
+
+	// Step 5: Verify stable state (plan after apply)
+	fmt.Println()
+	printCyan("Step 5: Verifying stable state (plan after apply)")
+	printYellow("Running terraform plan again to check for ongoing drift...")
+
+	postPlanArgs := append([]string{"plan", "-no-color", "-out=" + filepath.Join(ctx.tmpDir, "upgrade-post.tfplan"), "-input=false"}, ctx.targetArgs()...)
+	postPlanArgs = addParallelismArg(postPlanArgs, ctx.cfg.Parallelism)
+
+	ctx.postPlanOutput, err = tf.Run(postPlanArgs...)
+	if err != nil {
+		printError("Post-apply terraform plan failed")
+		fmt.Println()
+		printRed("Error output:")
+		fmt.Println(ctx.postPlanOutput)
+		return err
+	}
+
+	// Save post-apply plan output
+	postPlanLog := filepath.Join(ctx.tmpDir, "upgrade-post-plan.log")
+	if err := os.WriteFile(postPlanLog, []byte(ctx.postPlanOutput), permFile); err != nil {
+		printYellow("Warning: Failed to save post-apply plan log: %v", err)
+	}
+
+	// Check for ongoing drift
+	postDriftResult := checkAndDisplayDriftForSU(ctx.postPlanOutput, ctx.cfg, "post-apply", ctx.resourceList, ctx.e2eV5Root)
+	ctx.hasPostApplyChanges = postDriftResult.hasDrift
+	ctx.postApplyDrift = postDriftResult.driftLines
+	ctx.postApplyMaterial = postDriftResult.materialCount
+	ctx.postApplyReal = postDriftResult.realCount
+	ctx.postApplyExempted = postDriftResult.exemptedCount
+	ctx.postApplyExemptedLines = postDriftResult.exemptedLines
+
+	fmt.Println()
+	return nil
+}
+
+// reportResults reports the final test results
+// This follows the same reporting style as v4→v5 tests with drift report and step summary
+func reportResults(ctx *suTestContext) error {
+	// Display drift report if there were real changes OR exempted changes
+	hasExemptedChanges := len(ctx.initialExemptedLines) > 0 || len(ctx.postApplyExemptedLines) > 0
+	if ctx.hasChanges || ctx.hasPostApplyChanges || hasExemptedChanges {
+		printHeader("Drift Report")
+
+		if ctx.hasChanges && len(ctx.initialDrift) > 0 {
+			printYellow("Real drift detected after upgrade (before apply):")
+			displayGroupedDrift(ctx.initialDrift)
+			fmt.Println()
+		}
+
+		if len(ctx.initialExemptedLines) > 0 {
+			printSuccess("Exempted changes after upgrade (before apply):")
+			printYellow("The following changes were detected but exempted by drift exemption rules:")
+			displayGroupedDrift(ctx.initialExemptedLines)
+			fmt.Println()
+		}
+
+		if ctx.hasPostApplyChanges && len(ctx.postApplyDrift) > 0 {
+			printYellow("Ongoing drift detected (after apply):")
+			displayGroupedDrift(ctx.postApplyDrift)
+			fmt.Println()
+		}
+
+		if len(ctx.postApplyExemptedLines) > 0 {
+			printSuccess("Exempted changes (after apply):")
+			printYellow("The following changes were detected but exempted by drift exemption rules:")
+			displayGroupedDrift(ctx.postApplyExemptedLines)
+			fmt.Println()
+		}
+	}
+
+	// Summary at the END (matching v4→v5 style)
+	fmt.Println()
+	if ctx.hasPostApplyChanges || ctx.hasChanges {
+		printHeader("✗ V5 Upgrade Test Failed!")
+	} else {
+		printHeader("✓ V5 Upgrade Test Complete!")
+	}
+
+	printYellow("Summary:")
+	printYellow("")
+	printYellow("  Provider upgrade: %s → %s", ctx.cfg.FromVersion, ctx.cfg.ToVersion)
+	printYellow("  State key:        %s", GenerateStateKey(ctx.cfg.FromVersion, ctx.cfg.ToVersion))
+	printYellow("")
+
+	printYellow("  Step 1: Initialization")
+	printYellow("    Status: %s", colorGreen+"✓ SUCCESS"+colorReset)
+	printYellow("")
+
+	printYellow("  Step 2: Create resources with %s", ctx.cfg.FromVersion)
+	if ctx.cfg.SkipCreate {
+		printYellow("    Status: %s", colorYellow+"⊘ SKIPPED"+colorReset)
+	} else {
+		printYellow("    Status: %s", colorGreen+"✓ SUCCESS"+colorReset)
+	}
+	printYellow("")
+
+	printYellow("  Step 3: Upgrade provider to %s", ctx.cfg.ToVersion)
+	printYellow("    Status: %s", colorGreen+"✓ SUCCESS"+colorReset)
+	printYellow("")
+
+	printYellow("  Step 4: Plan after upgrade")
+	if !ctx.hasChanges {
+		printYellow("    Status: %s", colorGreen+"✓ No changes needed"+colorReset)
+	} else {
+		uniqueDrifts := countUniqueDrifts(ctx.initialDrift)
+		printYellow("    Status: %s", colorRed+"✗ DRIFT DETECTED"+colorReset)
+		if ctx.initialExempted > 0 {
+			printYellow("    Result: %d real changes detected (%d exempted)", uniqueDrifts, ctx.initialExempted)
+		} else {
+			printYellow("    Result: %d real changes detected", uniqueDrifts)
+		}
+	}
+	printYellow("")
+
+	printYellow("  Step 5: Apply")
+	if ctx.hasChanges {
+		printYellow("    Status: %s", colorYellow+"⚠ Applied drift changes"+colorReset)
+	} else {
+		printYellow("    Status: %s", colorGreen+"✓ SUCCESS"+colorReset)
+	}
+	printYellow("")
+
+	printYellow("  Step 6: Plan after apply (stability check)")
+	if ctx.hasPostApplyChanges {
+		uniqueDrifts := countUniqueDrifts(ctx.postApplyDrift)
+		printYellow("    Status: %s", colorRed+"✗ FAILED - Resources keep changing"+colorReset)
+		if ctx.postApplyExempted > 0 {
+			printYellow("    Result: %d ongoing drift patterns (%d exempted)", uniqueDrifts, ctx.postApplyExempted)
+		} else {
+			printYellow("    Result: %d ongoing drift patterns", uniqueDrifts)
+		}
+	} else {
+		if ctx.postApplyMaterial > 0 {
+			printYellow("    Status: %s", colorGreen+"✓ SUCCESS - Stable state achieved"+colorReset)
+			printYellow("    Result: %d material changes matched exemptions (%d unmatched)", ctx.postApplyMaterial, ctx.postApplyReal)
+		} else {
+			printYellow("    Status: %s", colorGreen+"✓ SUCCESS - Stable state achieved"+colorReset)
+			printYellow("    Result: No changes detected")
+		}
+	}
+
+	fmt.Println()
+	printYellow("Logs saved to:")
+	printCyan("  - %s", ctx.tmpDir)
+	fmt.Println()
+
+	// Exit with error if there's ongoing drift or if there were real changes in first plan
+	if ctx.hasPostApplyChanges {
+		printRed("Test failed: Resources are unstable and keep changing")
+		printYellow("This prevents safe upgrade to %s - likely a provider bug", ctx.cfg.ToVersion)
+		return fmt.Errorf("ongoing drift detected - resources keep changing")
+	}
+
+	if ctx.hasChanges {
+		printRed("Test failed: Upgrade produced drift")
+		printYellow("The upgraded state doesn't match your infrastructure")
+		printYellow("Review the changes above and check for StateUpgrader bugs")
+		return fmt.Errorf("upgrade produced drift")
+	}
+
+	return nil
+}
+
+// RunV5UpgradeClean removes specified modules from remote Terraform state
+// This directly manipulates state JSON (pull, modify, push) to handle
+// resources that may have been deleted outside of Terraform.
+func RunV5UpgradeClean(cfg *V5UpgradeConfig, modules []string) error {
+	// Normalize versions
+	if cfg.FromVersion == "" {
+		cfg.FromVersion = DefaultFromVersion
+	}
+	if cfg.ToVersion == "" {
+		cfg.ToVersion = DefaultToVersion
+	}
+
+	// Load environment
+	env, err := LoadEnv(EnvForClean)
+	if err != nil {
+		return err
+	}
+
+	// Get paths
+	repoRoot := getRepoRoot()
+	e2eV5Root := filepath.Join(repoRoot, "e2e-v5")
+	tfDir := filepath.Join(e2eV5Root, "tf")
+
+	printHeader("V5 Upgrade Cleanup")
+	printCyan("Cleaning up: %s → %s", cfg.FromVersion, cfg.ToVersion)
+	printCyan("State key: %s", GenerateStateKey(cfg.FromVersion, cfg.ToVersion))
+	fmt.Println()
+
+	// Check if tf directory exists
+	if _, err := os.Stat(tfDir); os.IsNotExist(err) {
+		printYellow("No tf directory found at %s - nothing to clean", tfDir)
+		return nil
+	}
+
+	tf := NewTerraformRunner(tfDir)
+	tf.EnvVars["AWS_ACCESS_KEY_ID"] = env.R2AccessKeyID
+	tf.EnvVars["AWS_SECRET_ACCESS_KEY"] = env.R2SecretAccessKey
+
+	// Check if terraform is initialized
+	if _, err := os.Stat(filepath.Join(tfDir, ".terraform")); os.IsNotExist(err) {
+		printYellow("Terraform not initialized - running init...")
+		initArgs := []string{"init", "-no-color", "-input=false", "-backend-config=backend.configured.hcl"}
+		tmpDir := filepath.Join(e2eV5Root, "tmp")
+		os.MkdirAll(tmpDir, permDir)
+		if err := tf.RunToFile(filepath.Join(tmpDir, "clean-init.log"), initArgs...); err != nil {
+			printError("Terraform init failed")
+			return err
+		}
+	}
+
+	// If specific modules requested, clean them from state
+	if len(modules) > 0 {
+		printYellow("Modules to clean:")
+		for _, module := range modules {
+			printYellow("  - %s", module)
+		}
+		fmt.Println()
+
+		// Pull latest state from remote
+		printYellow("Pulling latest state from R2...")
+		stateJSON, err := tf.Run("state", "pull")
+		if err != nil {
+			printError("Failed to pull state from R2")
+			fmt.Println(stateJSON)
+			return err
+		}
+		printSuccess("State pulled successfully")
+
+		// Parse state
+		var state map[string]interface{}
+		if err := json.Unmarshal([]byte(stateJSON), &state); err != nil {
+			return fmt.Errorf("failed to parse state: %w", err)
+		}
+
+		// Count resources before cleanup
+		resourcesArray, ok := state["resources"].([]interface{})
+		if !ok {
+			return fmt.Errorf("invalid state format: resources array not found")
+		}
+		totalBefore := len(resourcesArray)
+		printCyan("Total resources before cleanup: %d", totalBefore)
+		fmt.Println()
+
+		// Clean the state - remove specified modules
+		printYellow("Cleaning state...")
+		var filteredResources []interface{}
+		removed := 0
+
+		for _, res := range resourcesArray {
+			resMap, ok := res.(map[string]interface{})
+			if !ok {
+				filteredResources = append(filteredResources, res)
+				continue
+			}
+
+			resModule, ok := resMap["module"].(string)
+			if !ok {
+				filteredResources = append(filteredResources, res)
+				continue
+			}
+
+			// Check if this resource belongs to any of the modules to clean
+			shouldRemove := false
+			for _, module := range modules {
+				if resModule == "module."+module {
+					shouldRemove = true
+					removed++
+					break
+				}
+			}
+
+			if !shouldRemove {
+				filteredResources = append(filteredResources, res)
+			}
+		}
+
+		state["resources"] = filteredResources
+
+		// Increment serial number
+		if serial, ok := state["serial"].(float64); ok {
+			state["serial"] = serial + 1
+		}
+
+		// Count resources after cleanup
+		totalAfter := len(filteredResources)
+
+		printSuccess("State cleaned")
+		printCyan("  Before: %d resources", totalBefore)
+		printCyan("  After:  %d resources", totalAfter)
+		printSuccess("  Removed: %d resources", removed)
+		fmt.Println()
+
+		// Save cleaned state to temp file
+		cleanedStateFile := filepath.Join(tfDir, "terraform.tfstate.cleaned")
+		cleanedStateJSON, err := json.MarshalIndent(state, "", "  ")
+		if err != nil {
+			return fmt.Errorf("failed to marshal cleaned state: %w", err)
+		}
+
+		if err := os.WriteFile(cleanedStateFile, cleanedStateJSON, permSecretFile); err != nil {
+			return fmt.Errorf("failed to write cleaned state to %s: %w", cleanedStateFile, err)
+		}
+
+		// Push cleaned state back to remote
+		printYellow("Pushing cleaned state to R2...")
+		output, err := tf.Run("state", "push", cleanedStateFile)
+		if err != nil {
+			printError("Failed to push state to R2")
+			fmt.Println(output)
+			printYellow("You can manually push it with: terraform state push %s", cleanedStateFile)
+			return err
+		}
+		printSuccess("State pushed successfully")
+
+		// Remove temp file
+		os.Remove(cleanedStateFile)
+
+		fmt.Println()
+		printHeader("Cleanup Complete")
+		printSuccess("Removed %d resources from %d modules", removed, len(modules))
+		fmt.Println()
+
+		return nil
+	}
+
+	// No specific modules - destroy all resources.
+	//
+	// Always ensure provider.tf is at the TARGET version before destroying.
+	// After a successful upgrade the state is at schema_version=500; using the
+	// source version provider would fail with "Resource instance managed by
+	// newer provider version". This also handles the standalone --clean case
+	// where runUpgradeProvider never ran and provider.tf is still at the source
+	// version constraint.
+	printYellow("Destroying all resources...")
+	tmpDir := filepath.Join(e2eV5Root, "tmp")
+	os.MkdirAll(tmpDir, permDir)
+
+	// Always refresh provider.tf to target constraint for destroy.
+	// This keeps cleanup deterministic and ensures required provider metadata
+	// matches the active configuration (including auxiliary providers like tls).
+	printYellow("Updating provider.tf to target version %s for destroy...", cfg.ToVersion)
+	targetConstraint, _ := ResolveTargetVersion(cfg.ToVersion)
+	providerContent := GenerateProviderTF(targetConstraint)
+	providerFile := filepath.Join(tfDir, "provider.tf")
+	if err := os.WriteFile(providerFile, []byte(providerContent), permFile); err != nil {
+		return fmt.Errorf("failed to update provider.tf for destroy: %w", err)
+	}
+
+	if cfg.ProviderPath != "" {
+		// Local provider: configure dev_overrides so destroy uses the local binary.
+		// Keep lockfile and run init so auxiliary providers (e.g. hashicorp/tls)
+		// are selected consistently before destroy.
+		printYellow("Configuring local provider for destroy: %s", cfg.ProviderPath)
+		tfConfigFile, err := setupLocalProvider(cfg.ProviderPath, repoRoot)
+		if err != nil {
+			return fmt.Errorf("failed to set up local provider for destroy: %w", err)
+		}
+		tf.TFConfigFile = tfConfigFile
+
+		initArgs := []string{"init", "-no-color", "-input=false", "-backend-config=backend.configured.hcl", "-upgrade"}
+		if err := tf.RunToFile(filepath.Join(tmpDir, "clean-init.log"), initArgs...); err != nil {
+			printError("Terraform init for destroy failed")
+			content, _ := os.ReadFile(filepath.Join(tmpDir, "clean-init.log"))
+			fmt.Println(string(content))
+			return err
+		}
+		printSuccess("Provider and lockfile initialized for destroy")
+	} else {
+		// Registry provider: run init -upgrade so Terraform installs target binaries.
+		initArgs := []string{"init", "-no-color", "-input=false", "-backend-config=backend.configured.hcl", "-upgrade"}
+		if err := tf.RunToFile(filepath.Join(tmpDir, "clean-init.log"), initArgs...); err != nil {
+			printError("Terraform init -upgrade for destroy failed")
+			content, _ := os.ReadFile(filepath.Join(tmpDir, "clean-init.log"))
+			fmt.Println(string(content))
+			return err
+		}
+		printSuccess("Provider updated to target version for destroy")
+	}
+
+	// Run terraform destroy
+	destroyArgs := []string{"destroy", "-no-color", "-input=false", "-auto-approve"}
+	printYellow("Running terraform destroy...")
+	output, err := tf.Run(destroyArgs...)
+	if err != nil {
+		printError("Terraform destroy failed")
+		fmt.Println(output)
+		return err
+	}
+	printSuccess("Resources destroyed")
+	fmt.Println()
+
+	printHeader("Cleanup Complete")
+	printSuccess("State key %s has been cleaned", GenerateStateKey(cfg.FromVersion, cfg.ToVersion))
+	fmt.Println()
+
+	return nil
+}
+
+// setupLocalProvider builds the local provider and creates dev_overrides config
+func setupLocalProvider(providerPath, repoRoot string) (string, error) {
+	printHeader("Setting up local provider")
+	printYellow("Using provider from: %s", providerPath)
+
+	// Determine if providerPath is a file or directory
+	var providerBinary string
+	var providerDir string
+
+	info, err := os.Stat(providerPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			providerBinary = providerPath
+			providerDir = filepath.Dir(providerPath)
+			if dirInfo, dirErr := os.Stat(providerDir); dirErr != nil || !dirInfo.IsDir() {
+				return "", fmt.Errorf("provider directory does not exist: %s", providerDir)
+			}
+		} else {
+			return "", fmt.Errorf("failed to check provider path: %w", err)
+		}
+	} else if info.IsDir() {
+		providerDir = providerPath
+		providerBinary = filepath.Join(providerDir, "terraform-provider-cloudflare")
+	} else {
+		providerBinary = providerPath
+		providerDir = filepath.Dir(providerPath)
+	}
+
+	// Build the provider
+	printYellow("Building provider...")
+	buildCmd := exec.Command("go", "build", "-o", providerBinary, ".")
+	buildCmd.Dir = providerDir
+	buildCmd.Stdout = os.Stdout
+	buildCmd.Stderr = os.Stderr
+
+	if err := buildCmd.Run(); err != nil {
+		printError("Failed to build provider: %v", err)
+		return "", fmt.Errorf("failed to build provider: %w", err)
+	}
+	printSuccess("Provider built successfully: %s", providerBinary)
+
+	// Create dev overrides config
+	tfConfigFile := filepath.Join(repoRoot, ".terraformrc-su-test")
+	absProviderDir, err := filepath.Abs(providerDir)
+	if err != nil {
+		return "", fmt.Errorf("failed to get absolute path for provider directory: %w", err)
+	}
+
+	configContent := fmt.Sprintf(`provider_installation {
+  dev_overrides {
+    "cloudflare/cloudflare" = "%s"
+  }
+  direct {}
+}
+`, absProviderDir)
+
+	if err := os.WriteFile(tfConfigFile, []byte(configContent), permFile); err != nil {
+		return "", fmt.Errorf("failed to create provider config at %s: %w", tfConfigFile, err)
+	}
+
+	printSuccess("Created dev overrides config: %s", tfConfigFile)
+	fmt.Println()
+
+	return tfConfigFile, nil
+}
+
+// targetArgs returns terraform target arguments for the test context
+func (ctx *suTestContext) targetArgs() []string {
+	var args []string
+	for _, resource := range ctx.resourceList {
+		args = append(args, "-target=module."+resource)
+	}
+	return args
+}
+
+// checkAndDisplayDriftForSU checks drift for v5 upgrade tests using e2e-v5/ exemptions.
+//
+// Unlike checkAndDisplayDrift (which hardcodes e2e/), this function loads exemptions
+// from e2eV5Root (e2e-v5/) so that v5-specific exemption rules are applied.
+func checkAndDisplayDriftForSU(planOutput string, cfg *V5UpgradeConfig, phase string, resourceList []string, e2eV5Root string) driftCheckResult {
+	result := driftCheckResult{}
+
+	if strings.Contains(planOutput, "No changes") {
+		printSuccess("No drift detected - state upgrade successful!")
+		return result
+	}
+
+	// Load exemptions from e2e-v5/ directory (not e2e/)
+	exemptionConfig, err := LoadDriftExemptionsFromDir(e2eV5Root, resourceList)
+	if err != nil {
+		printYellow("Warning: failed to load v5 drift exemptions from %s: %v", e2eV5Root, err)
+		// Fall back to standard drift check without exemptions
+		runCfg := &RunConfig{ApplyExemptions: false}
+		return checkAndDisplayDrift(planOutput, runCfg, phase, resourceList)
+	}
+
+	// Override ApplyExemptions from config
+	if !cfg.ApplyExemptions {
+		exemptionConfig.Settings.ApplyExemptions = false
+	}
+
+	driftResult := CheckDriftWithConfig(planOutput, exemptionConfig)
+
+	totalExempted := 0
+	for _, count := range driftResult.TriggeredExemptions {
+		totalExempted += count
+	}
+	result.exemptedCount = totalExempted
+	result.exemptedLines = driftResult.ExemptedDriftLines
+	result.computedLines = driftResult.ComputedRefreshLines
+	result.realCount = len(driftResult.RealDriftLines)
+	result.materialCount = len(driftResult.RealDriftLines) + len(driftResult.ExemptedDriftLines)
+
+	if len(driftResult.ComputedRefreshLines) > 0 || totalExempted > 0 || len(driftResult.RealDriftLines) > 0 {
+		printYellow("Drift breakdown: %d material, %d computed refresh, %d exempted",
+			result.materialCount, len(driftResult.ComputedRefreshLines), totalExempted)
+	}
+
+	if driftResult.OnlyComputedChanges {
+		if phase == "upgrade" {
+			printSuccess("Only computed value refreshes detected after upgrade (exempted) - state upgrade successful!")
+		} else {
+			printSuccess("Only computed value refreshes detected (exempted) - state is stable!")
+		}
+
+		// Show plan summary even for exempted changes
+		planSummary := extractPlanSummary(planOutput)
+		if planSummary != "" {
+			fmt.Println()
+			printYellow("Plan summary: %s", planSummary)
+		}
+
+		if driftResult.ExemptionsEnabled && len(driftResult.TriggeredExemptions) > 0 {
+			fmt.Println()
+			printYellow("Drift exemptions applied:")
+			for exemptionName, count := range driftResult.TriggeredExemptions {
+				printYellow("  - %s: %d change(s) exempted", exemptionName, count)
+			}
+		}
+		return result
+	}
+
+	// Real drift detected
+	result.hasDrift = true
+	result.driftLines = driftResult.RealDriftLines
+
+	if phase == "upgrade" {
+		printRed("Drift detected after state upgrade:")
+	} else {
+		printRed("Ongoing drift detected after apply:")
+	}
+
+	// Display plan summary and changes
+	planSummary := extractPlanSummary(planOutput)
+	if planSummary != "" {
+		fmt.Println()
+		printYellow("Plan summary: %s", planSummary)
+	}
+	fmt.Println()
+	fmt.Println(extractPlanChanges(planOutput))
+
+	// Also list drift lines for quick reference
+	if len(driftResult.RealDriftLines) > 0 {
+		fmt.Println()
+		printYellow("Affected resources:")
+		for _, line := range driftResult.RealDriftLines {
+			printRed("  %s", line)
+		}
+	}
+
+	return result
+}

--- a/internal/e2e-runner/v5_upgrade.go
+++ b/internal/e2e-runner/v5_upgrade.go
@@ -843,8 +843,7 @@ func RunV5UpgradeClean(cfg *V5UpgradeConfig, modules []string) error {
 		initArgs := []string{"init", "-no-color", "-input=false", "-backend-config=backend.configured.hcl", "-upgrade"}
 		if err := tf.RunToFile(filepath.Join(tmpDir, "clean-init.log"), initArgs...); err != nil {
 			printError("Terraform init for destroy failed")
-			content, _ := os.ReadFile(filepath.Join(tmpDir, "clean-init.log"))
-			fmt.Println(string(content))
+			printYellow("See log: %s", filepath.Join(tmpDir, "clean-init.log"))
 			return err
 		}
 		printSuccess("Provider and lockfile initialized for destroy")
@@ -853,8 +852,7 @@ func RunV5UpgradeClean(cfg *V5UpgradeConfig, modules []string) error {
 		initArgs := []string{"init", "-no-color", "-input=false", "-backend-config=backend.configured.hcl", "-upgrade"}
 		if err := tf.RunToFile(filepath.Join(tmpDir, "clean-init.log"), initArgs...); err != nil {
 			printError("Terraform init -upgrade for destroy failed")
-			content, _ := os.ReadFile(filepath.Join(tmpDir, "clean-init.log"))
-			fmt.Println(string(content))
+			printYellow("See log: %s", filepath.Join(tmpDir, "clean-init.log"))
 			return err
 		}
 		printSuccess("Provider updated to target version for destroy")
@@ -863,10 +861,10 @@ func RunV5UpgradeClean(cfg *V5UpgradeConfig, modules []string) error {
 	// Run terraform destroy
 	destroyArgs := []string{"destroy", "-no-color", "-input=false", "-auto-approve"}
 	printYellow("Running terraform destroy...")
-	output, err := tf.Run(destroyArgs...)
-	if err != nil {
+	destroyLog := filepath.Join(tmpDir, "clean-destroy.log")
+	if err := tf.RunToFile(destroyLog, destroyArgs...); err != nil {
 		printError("Terraform destroy failed")
-		fmt.Println(output)
+		printYellow("See log: %s", destroyLog)
 		return err
 	}
 	printSuccess("Resources destroyed")

--- a/internal/e2e-runner/v5_upgrade_init.go
+++ b/internal/e2e-runner/v5_upgrade_init.go
@@ -1,0 +1,493 @@
+// state_upgrader_init.go handles initialization of v5→v5 v5 upgrade test infrastructure.
+//
+// This file provides functionality to set up v5 upgrade test environments, including:
+//   - Syncing v5 test fixtures from e2e-v5/testdata/ to e2e-v5/tf/
+//   - Generating provider.tf with appropriate version constraints
+//   - Generating backend configuration with version-specific state keys
+//   - Generating main.tf with module references
+package e2e
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// V5UpgradeConfig holds configuration for v5 upgrade tests
+type V5UpgradeConfig struct {
+	FromVersion     string // Source provider version (e.g., "5.18.0")
+	ToVersion       string // Target provider version (e.g., "latest" or "5.20.0")
+	Resources       string // Comma-separated resource names to include
+	Exclude         string // Comma-separated resource names to exclude
+	ApplyExemptions bool
+	Parallelism     int
+	SkipCreate      bool   // Skip resource creation, use existing state
+	ProviderPath    string // Optional: path to local provider source
+	Clean           bool   // Destroy resources and clean up state after test
+}
+
+// RunV5UpgradeInit syncs v5 testdata and generates terraform configs
+func RunV5UpgradeInit(cfg *V5UpgradeConfig) error {
+	// Normalize versions
+	if cfg.FromVersion == "" {
+		cfg.FromVersion = DefaultFromVersion
+	}
+	if cfg.ToVersion == "" {
+		cfg.ToVersion = DefaultToVersion
+	}
+
+	// Load required environment variables
+	env, err := LoadEnv(EnvForInit)
+	if err != nil {
+		return err
+	}
+
+	// Parse resource filter if provided
+	var targetResources []string
+	if cfg.Resources != "" {
+		for _, r := range strings.Split(cfg.Resources, ",") {
+			targetResources = append(targetResources, strings.TrimSpace(r))
+		}
+	}
+
+	// Parse exclude filter if provided
+	excludeSet := make(map[string]bool)
+	if cfg.Exclude != "" {
+		for _, r := range strings.Split(cfg.Exclude, ",") {
+			excludeSet[strings.TrimSpace(r)] = true
+		}
+	}
+
+	// Get paths
+	repoRoot := getRepoRoot()
+	e2eV5Root := filepath.Join(repoRoot, "e2e-v5")
+	tfDir := filepath.Join(e2eV5Root, "tf")
+	testdataRoot := filepath.Join(e2eV5Root, "testdata")
+
+	// Check if testdata directory exists
+	if _, err := os.Stat(testdataRoot); os.IsNotExist(err) {
+		return fmt.Errorf("testdata directory not found at %s\nRun 'make generate-su-testdata' to create test fixtures", testdataRoot)
+	}
+
+	printHeader("V5 Upgrade Test Initialization")
+	printCyan("Provider versions: %s → %s", cfg.FromVersion, cfg.ToVersion)
+	fmt.Println()
+
+	if len(targetResources) > 0 {
+		printYellow("Filtering to specific resources: %s", strings.Join(targetResources, ", "))
+	}
+	if len(excludeSet) > 0 {
+		var excluded []string
+		for r := range excludeSet {
+			excluded = append(excluded, r)
+		}
+		printYellow("Excluding resources: %s", strings.Join(excluded, ", "))
+	}
+
+	// Create tf directory if it doesn't exist
+	if err := os.MkdirAll(tfDir, permDir); err != nil {
+		return fmt.Errorf("failed to create tf directory %s: %w", tfDir, err)
+	}
+
+	// Sync resource files from testdata
+	printYellow("Syncing resource files from testdata...")
+	fileCount := 0
+	var moduleNames []string
+
+	// Find all resource directories in testdata
+	entries, err := os.ReadDir(testdataRoot)
+	if err != nil {
+		return fmt.Errorf("failed to read testdata directory: %w", err)
+	}
+
+	// Filter to target resources if specified, and apply exclusions
+	var resourceDirs []os.DirEntry
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+
+		resourceName := entry.Name()
+
+		// Skip excluded resources
+		if excludeSet[resourceName] {
+			continue
+		}
+
+		// If specific resources requested, only include those
+		if len(targetResources) > 0 {
+			found := false
+			for _, target := range targetResources {
+				if resourceName == target {
+					found = true
+					break
+				}
+			}
+			if !found {
+				continue
+			}
+		}
+		resourceDirs = append(resourceDirs, entry)
+	}
+
+	if len(resourceDirs) == 0 {
+		if len(targetResources) > 0 {
+			return fmt.Errorf("no matching resources found in testdata for: %s", strings.Join(targetResources, ", "))
+		}
+		return fmt.Errorf("no resources found in testdata directory: %s", testdataRoot)
+	}
+
+	// versionSuffix is the normalized from-version used to find version-specific overrides.
+	// e.g. "5.1.0" → "_5_1_0"
+	versionSuffix := "_" + strings.ReplaceAll(cfg.FromVersion, ".", "_")
+
+	// Process each resource directory
+	for _, entry := range resourceDirs {
+		resourceName := entry.Name()
+		moduleNames = append(moduleNames, resourceName)
+
+		srcDir := filepath.Join(testdataRoot, resourceName)
+		dstDir := filepath.Join(tfDir, resourceName)
+
+		// Create/clean module directory
+		if err := os.RemoveAll(dstDir); err != nil {
+			return fmt.Errorf("failed to clean module directory %s: %w", dstDir, err)
+		}
+		if err := os.MkdirAll(dstDir, permDir); err != nil {
+			return fmt.Errorf("failed to create module directory %s: %w", dstDir, err)
+		}
+
+		copiedFiles, err := syncModuleFiles(srcDir, dstDir, versionSuffix)
+		if err != nil {
+			return err
+		}
+		fileCount += copiedFiles
+
+		// Generate versions.tf for the module with required_providers
+		// This is critical - without explicit source, Terraform defaults to hashicorp/cloudflare
+		versionsContent := `terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    cloudflare = {
+      source = "cloudflare/cloudflare"
+    }
+  }
+}
+`
+		versionsFile := filepath.Join(dstDir, "versions.tf")
+		if err := os.WriteFile(versionsFile, []byte(versionsContent), permFile); err != nil {
+			return fmt.Errorf("failed to write versions.tf for %s: %w", resourceName, err)
+		}
+		fileCount++
+
+		printSuccess("  %s/ (%d files)", resourceName, copiedFiles+1)
+	}
+
+	printSuccess("Synced %d files for %d modules", fileCount, len(moduleNames))
+	fmt.Println()
+
+	// Generate provider.tf with source version constraint
+	printYellow("Generating provider.tf with version %s...", cfg.FromVersion)
+	versionConstraint := ResolveFromVersion(cfg.FromVersion)
+	providerContent := GenerateProviderTF(versionConstraint)
+	providerFile := filepath.Join(tfDir, "provider.tf")
+	if err := os.WriteFile(providerFile, []byte(providerContent), permFile); err != nil {
+		return fmt.Errorf("failed to write provider.tf: %w", err)
+	}
+	printSuccess("Generated provider.tf")
+
+	// Generate backend.configured.hcl
+	printYellow("Generating backend configuration...")
+	backendContent := GenerateBackendConfiguredHCL(env.AccountID, cfg.FromVersion, cfg.ToVersion)
+	backendFile := filepath.Join(tfDir, "backend.configured.hcl")
+	if err := os.WriteFile(backendFile, []byte(backendContent), permFile); err != nil {
+		return fmt.Errorf("failed to write backend.configured.hcl: %w", err)
+	}
+	stateKey := GenerateStateKey(cfg.FromVersion, cfg.ToVersion)
+	printSuccess("Generated backend.configured.hcl (key: %s)", stateKey)
+
+	// Generate main.tf with module references
+	printYellow("Generating main.tf with module references...")
+	sort.Strings(moduleNames)
+	if err := validateModuleSpecificEnv(tfDir, moduleNames, env); err != nil {
+		return err
+	}
+	mainContent, err := generateMainTF(tfDir, moduleNames)
+	if err != nil {
+		return fmt.Errorf("failed to generate main.tf content: %w", err)
+	}
+	mainFile := filepath.Join(tfDir, "main.tf")
+	if err := os.WriteFile(mainFile, []byte(mainContent), permFile); err != nil {
+		return fmt.Errorf("failed to write main.tf: %w", err)
+	}
+	printSuccess("Generated main.tf with %d modules", len(moduleNames))
+
+	// Generate terraform.tfvars
+	printYellow("Generating terraform.tfvars...")
+	tfvarsContent := generateTFVars(env, cfg.FromVersion)
+	tfvarsFile := filepath.Join(tfDir, "terraform.tfvars")
+	if err := os.WriteFile(tfvarsFile, []byte(tfvarsContent), permFile); err != nil {
+		return fmt.Errorf("failed to write terraform.tfvars: %w", err)
+	}
+	printSuccess("Generated terraform.tfvars")
+
+	fmt.Println()
+	printHeader("Initialization Complete")
+	fmt.Println()
+
+	printYellow("Test configuration:")
+	printYellow("  From version: %s", cfg.FromVersion)
+	printYellow("  To version:   %s", cfg.ToVersion)
+	printYellow("  State key:    %s", stateKey)
+	printYellow("  Modules:      %d", len(moduleNames))
+	fmt.Println()
+
+	printYellow("Next steps:")
+	printYellow("  1. Run: e2e-runner v5-upgrade run --from-version %s --to-version %s", cfg.FromVersion, cfg.ToVersion)
+	printYellow("  2. Or with local provider: e2e-runner v5-upgrade run --from-version %s --provider ../provider", cfg.FromVersion)
+	fmt.Println()
+
+	return nil
+}
+
+// generateMainTF generates the main.tf content with module references.
+// It injects only variables that each module actually declares.
+func generateMainTF(tfDir string, moduleNames []string) (string, error) {
+	var sb strings.Builder
+	sb.WriteString("# Auto-generated main.tf for v5 upgrade tests\n")
+	sb.WriteString("# DO NOT EDIT - regenerated by 'e2e-runner v5-upgrade init'\n\n")
+
+	for _, name := range moduleNames {
+		moduleDir := filepath.Join(tfDir, name)
+		moduleVars, err := discoverModuleVariables(moduleDir)
+		if err != nil {
+			return "", fmt.Errorf("discover module variables for %s: %w", name, err)
+		}
+
+		sb.WriteString(fmt.Sprintf("module %q {\n  source = %q\n", name, "./"+name))
+
+		if moduleVars["cloudflare_account_id"] {
+			sb.WriteString("\n  cloudflare_account_id = var.cloudflare_account_id")
+		}
+		if moduleVars["cloudflare_zone_id"] {
+			sb.WriteString("\n  cloudflare_zone_id    = var.cloudflare_zone_id")
+		}
+		if moduleVars["cloudflare_domain"] {
+			sb.WriteString("\n  cloudflare_domain     = var.cloudflare_domain")
+		}
+		if moduleVars["from_version"] {
+			sb.WriteString("\n  from_version          = var.from_version")
+		}
+		if moduleVars["crowdstrike_client_id"] {
+			sb.WriteString("\n  crowdstrike_client_id     = var.crowdstrike_client_id")
+		}
+		if moduleVars["crowdstrike_client_secret"] {
+			sb.WriteString("\n  crowdstrike_client_secret = var.crowdstrike_client_secret")
+		}
+		if moduleVars["crowdstrike_api_url"] {
+			sb.WriteString("\n  crowdstrike_api_url       = var.crowdstrike_api_url")
+		}
+		if moduleVars["crowdstrike_customer_id"] {
+			sb.WriteString("\n  crowdstrike_customer_id   = var.crowdstrike_customer_id")
+		}
+
+		sb.WriteString("\n}\n\n")
+	}
+
+	return sb.String(), nil
+}
+
+// generateTFVars generates the terraform.tfvars content from environment
+func generateTFVars(env *E2EEnv, fromVersion string) string {
+	var sb strings.Builder
+	sb.WriteString("# Auto-generated terraform.tfvars for v5 upgrade tests\n")
+	sb.WriteString("# DO NOT EDIT - regenerated by 'e2e-runner v5-upgrade init'\n\n")
+
+	sb.WriteString(fmt.Sprintf("cloudflare_account_id = %q\n", env.AccountID))
+	sb.WriteString(fmt.Sprintf("cloudflare_zone_id    = %q\n", env.ZoneID))
+	sb.WriteString(fmt.Sprintf("cloudflare_domain     = %q\n", env.Domain))
+	sb.WriteString(fmt.Sprintf("from_version          = %q\n", fromVersion))
+	sb.WriteString(fmt.Sprintf("crowdstrike_client_id     = %q\n", env.CrowdstrikeClientID))
+	sb.WriteString(fmt.Sprintf("crowdstrike_client_secret = %q\n", env.CrowdstrikeClientSecret))
+	sb.WriteString(fmt.Sprintf("crowdstrike_api_url       = %q\n", env.CrowdstrikeAPIURL))
+	sb.WriteString(fmt.Sprintf("crowdstrike_customer_id   = %q\n", env.CrowdstrikeCustomerID))
+
+	return sb.String()
+}
+
+func validateModuleSpecificEnv(tfDir string, moduleNames []string, env *E2EEnv) error {
+	requiresCrowdstrike := false
+	for _, name := range moduleNames {
+		moduleDir := filepath.Join(tfDir, name)
+		moduleVars, err := discoverModuleVariables(moduleDir)
+		if err != nil {
+			return fmt.Errorf("failed to discover variables for module %s: %w", name, err)
+		}
+		if moduleVars["crowdstrike_client_id"] || moduleVars["crowdstrike_client_secret"] || moduleVars["crowdstrike_api_url"] || moduleVars["crowdstrike_customer_id"] {
+			requiresCrowdstrike = true
+			break
+		}
+	}
+
+	if !requiresCrowdstrike {
+		return nil
+	}
+
+	if env.CrowdstrikeClientID == "" {
+		return fmt.Errorf("CLOUDFLARE_CROWDSTRIKE_CLIENT_ID environment variable is required for selected resources")
+	}
+	if env.CrowdstrikeClientSecret == "" {
+		return fmt.Errorf("CLOUDFLARE_CROWDSTRIKE_CLIENT_SECRET environment variable is required for selected resources")
+	}
+	if env.CrowdstrikeAPIURL == "" {
+		return fmt.Errorf("CLOUDFLARE_CROWDSTRIKE_API_URL environment variable is required for selected resources")
+	}
+	if env.CrowdstrikeCustomerID == "" {
+		return fmt.Errorf("CLOUDFLARE_CROWDSTRIKE_CUSTOMER_ID environment variable is required for selected resources")
+	}
+
+	return nil
+}
+
+// syncModuleFiles copies the default .tf files from srcDir to dstDir, substituting
+// any file that has a version-specific override (e.g. page_rule_5_1_0.tf → page_rule.tf).
+// Version-specific files are never written to the destination directly.
+// Pass versionSuffix="" to always use the default files (i.e. for the target version).
+func syncModuleFiles(srcDir, dstDir, versionSuffix string) (int, error) {
+	allFiles, err := filepath.Glob(filepath.Join(srcDir, "*.tf"))
+	if err != nil {
+		return 0, fmt.Errorf("failed to glob tf files in %s: %w", srcDir, err)
+	}
+
+	// Build set of version-specific filenames so they are never copied directly.
+	versionedFileNames := make(map[string]bool)
+	if versionSuffix != "" {
+		for _, f := range allFiles {
+			base := filepath.Base(f)
+			name := strings.TrimSuffix(base, ".tf")
+			if strings.Contains(name, versionSuffix) {
+				versionedFileNames[base] = true
+			}
+		}
+	} else {
+		// No specific version: skip all versioned files (anything matching _N_N_N pattern).
+		for _, f := range allFiles {
+			base := filepath.Base(f)
+			name := strings.TrimSuffix(base, ".tf")
+			// A versioned file has the form <base>_<d>_<d>_<d> where d are digits.
+			// We detect this by checking whether the name contains a segment that
+			// looks like a version suffix (_\d+_\d+_\d+).
+			if isVersionedFileName(name) {
+				versionedFileNames[base] = true
+			}
+		}
+	}
+
+	copiedFiles := 0
+	for _, srcFile := range allFiles {
+		base := filepath.Base(srcFile)
+
+		// Skip version-specific files.
+		if versionedFileNames[base] {
+			continue
+		}
+
+		// When a versionSuffix is given, check for an override.
+		if versionSuffix != "" {
+			name := strings.TrimSuffix(base, ".tf")
+			overridePath := filepath.Join(srcDir, name+versionSuffix+".tf")
+			if _, err := os.Stat(overridePath); err == nil {
+				srcFile = overridePath
+			}
+		}
+
+		content, err := os.ReadFile(srcFile)
+		if err != nil {
+			return 0, fmt.Errorf("failed to read %s: %w", srcFile, err)
+		}
+		if err := os.WriteFile(filepath.Join(dstDir, base), content, permFile); err != nil {
+			return 0, fmt.Errorf("failed to write %s: %w", filepath.Join(dstDir, base), err)
+		}
+		copiedFiles++
+	}
+
+	return copiedFiles, nil
+}
+
+// isVersionedFileName returns true if the filename stem ends with a version suffix
+// of the form _<major>_<minor>_<patch> (e.g. "page_rule_5_1_0").
+func isVersionedFileName(name string) bool {
+	parts := strings.Split(name, "_")
+	if len(parts) < 3 {
+		return false
+	}
+	// Check if the last three segments are all numeric.
+	for _, p := range parts[len(parts)-3:] {
+		for _, c := range p {
+			if c < '0' || c > '9' {
+				return false
+			}
+		}
+		if len(p) == 0 {
+			return false
+		}
+	}
+	return true
+}
+
+// resyncForTargetVersion re-copies testdata files into the tf module directories
+// using the default (non-versioned) configs. This is called after the provider is
+// upgraded so that configs with version-specific syntax are replaced with the
+// current-provider-compatible equivalents before the post-upgrade plan runs.
+//
+// resourceDirs may be empty, in which case all subdirectories of testdataRoot are used.
+func resyncForTargetVersion(testdataRoot, tfDir string, resourceDirs []string) error {
+	// If no explicit resource list, derive it from the testdata directory.
+	if len(resourceDirs) == 0 {
+		entries, err := os.ReadDir(testdataRoot)
+		if err != nil {
+			return fmt.Errorf("failed to read testdata directory: %w", err)
+		}
+		for _, e := range entries {
+			if e.IsDir() {
+				resourceDirs = append(resourceDirs, e.Name())
+			}
+		}
+	}
+
+	printYellow("Resyncing configs to target-version syntax...")
+	resynced := 0
+	for _, resourceName := range resourceDirs {
+		srcDir := filepath.Join(testdataRoot, resourceName)
+		dstDir := filepath.Join(tfDir, resourceName)
+
+		// Only resync modules where a versioned override actually exists — no-op otherwise.
+		allFiles, err := filepath.Glob(filepath.Join(srcDir, "*.tf"))
+		if err != nil {
+			return fmt.Errorf("failed to glob tf files in %s: %w", srcDir, err)
+		}
+		hasVersionedFile := false
+		for _, f := range allFiles {
+			if isVersionedFileName(strings.TrimSuffix(filepath.Base(f), ".tf")) {
+				hasVersionedFile = true
+				break
+			}
+		}
+		if !hasVersionedFile {
+			continue
+		}
+
+		if _, err := syncModuleFiles(srcDir, dstDir, ""); err != nil {
+			return err
+		}
+		resynced++
+		printSuccess("  %s/ (resynced to default configs)", resourceName)
+	}
+	if resynced == 0 {
+		printYellow("  No version-specific configs to resync")
+	}
+	return nil
+}

--- a/internal/e2e-runner/v5_upgrade_version.go
+++ b/internal/e2e-runner/v5_upgrade_version.go
@@ -1,0 +1,166 @@
+// state_upgrader_version.go provides version management utilities for v5 upgrade tests.
+//
+// This file handles:
+//   - Resolving version strings (e.g., "latest" → appropriate constraint)
+//   - Generating Terraform version constraints
+//   - Generating R2 state keys based on version combinations
+package e2e
+
+import (
+	"fmt"
+	"strings"
+)
+
+// DefaultFromVersion is the default starting provider version for v5 upgrade tests
+const DefaultFromVersion = "5.5.0"
+
+// DefaultToVersion is the default target provider version
+const DefaultToVersion = "latest"
+
+// ResolveTargetVersion resolves a version string to a Terraform provider constraint.
+// For "latest", it returns a loose constraint that gets the latest published version.
+// For specific versions like "5.20.0", it returns a constraint matching that minor version.
+func ResolveTargetVersion(version string) (constraint string, isLatest bool) {
+	if version == "latest" || version == "" {
+		// Use loose constraint to get latest published v5 version
+		return "~> 5.0", true
+	}
+
+	// For specific versions, use a constraint that matches the minor version
+	// e.g., "5.20.0" → "~> 5.20"
+	parts := strings.Split(version, ".")
+	if len(parts) >= 2 {
+		return fmt.Sprintf("~> %s.%s", parts[0], parts[1]), false
+	}
+
+	// Fallback: use the version as-is with ~>
+	return fmt.Sprintf("~> %s", version), false
+}
+
+// ResolveFromVersion resolves the source version to a Terraform provider constraint.
+// This is more strict than target version - we want the exact minor version.
+func ResolveFromVersion(version string) string {
+	if version == "" {
+		version = DefaultFromVersion
+	}
+
+	// For source version, use exact minor version constraint
+	// e.g., "5.18.0" → "~> 5.18.0"
+	return fmt.Sprintf("~> %s", version)
+}
+
+// GenerateStateKey generates the R2 state key for a version combination.
+// Format: v5/{fromVersion}-{toVersion}-terraform.tfstate
+func GenerateStateKey(fromVersion, toVersion string) string {
+	if fromVersion == "" {
+		fromVersion = DefaultFromVersion
+	}
+	if toVersion == "" {
+		toVersion = DefaultToVersion
+	}
+	return fmt.Sprintf("v5/%s-%s-terraform.tfstate", fromVersion, toVersion)
+}
+
+// NormalizeVersion normalizes a version string for consistent key generation.
+// Removes 'v' prefix if present and ensures consistent format.
+func NormalizeVersion(version string) string {
+	version = strings.TrimPrefix(version, "v")
+	version = strings.TrimSpace(version)
+	if version == "" {
+		return "latest"
+	}
+	return version
+}
+
+// GenerateProviderTF generates the provider.tf content with the specified version constraint.
+func GenerateProviderTF(versionConstraint string) string {
+	return fmt.Sprintf(`terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    cloudflare = {
+      source  = "cloudflare/cloudflare"
+      version = "%s"
+    }
+    tls = {
+      source  = "hashicorp/tls"
+      version = "~> 4.0"
+    }
+  }
+
+  # Remote state backend (R2)
+  # Configuration provided via backend.configured.hcl
+  backend "s3" {}
+}
+
+# Uses CLOUDFLARE_API_KEY and CLOUDFLARE_EMAIL environment variables
+provider "cloudflare" {}
+
+# Common variables from environment
+variable "cloudflare_account_id" {
+  description = "Cloudflare account ID for resources"
+  type        = string
+}
+
+variable "cloudflare_zone_id" {
+  description = "Cloudflare zone ID for DNS records"
+  type        = string
+}
+
+variable "cloudflare_domain" {
+  description = "Cloudflare domain for testing"
+  type        = string
+}
+
+variable "from_version" {
+  description = "Provider version under test, used to namespace resource names"
+  type        = string
+}
+
+variable "crowdstrike_client_id" {
+  description = "CrowdStrike client ID for posture integration tests"
+  type        = string
+}
+
+variable "crowdstrike_client_secret" {
+  description = "CrowdStrike client secret for posture integration tests"
+  type        = string
+  sensitive   = true
+}
+
+variable "crowdstrike_api_url" {
+  description = "CrowdStrike API URL for posture integration tests"
+  type        = string
+}
+
+variable "crowdstrike_customer_id" {
+  description = "CrowdStrike customer ID for posture integration tests"
+  type        = string
+}
+`, versionConstraint)
+}
+
+// GenerateBackendConfiguredHCL generates the backend.configured.hcl content
+// with the actual account ID and state key.
+func GenerateBackendConfiguredHCL(accountID, fromVersion, toVersion string) string {
+	stateKey := GenerateStateKey(fromVersion, toVersion)
+	return fmt.Sprintf(`# Auto-generated backend configuration for v5 upgrade tests
+# From: %s → To: %s
+
+endpoint = "https://%s.r2.cloudflarestorage.com"
+
+bucket = "tf-migrate-e2e-state"
+key    = "%s"
+region = "auto"
+
+# Skip AWS-specific validations
+skip_credentials_validation = true
+skip_region_validation      = true
+skip_requesting_account_id  = true
+skip_metadata_api_check     = true
+skip_s3_checksum            = true
+
+# Use path-style access for R2
+force_path_style = true
+`, fromVersion, toVersion, accountID, stateKey)
+}

--- a/scripts/run-e2e-tests.sh
+++ b/scripts/run-e2e-tests.sh
@@ -2,6 +2,21 @@
 
 # run-e2e-tests
 # Wrapper script that builds and runs the e2e test runner
+#
+# Usage:
+#   # v4→v5 migration tests (default)
+#   ./scripts/run-e2e-tests.sh [OPTIONS]
+#
+#   # v5→v5 upgrade tests
+#   ./scripts/run-e2e-tests.sh v5-upgrade [OPTIONS]
+#
+# Examples:
+#   # Run v4→v5 migration tests
+#   ./scripts/run-e2e-tests.sh --apply-exemptions --uses-provider-state-upgrader
+#
+#   # Run v5→v5 upgrade tests
+#   ./scripts/run-e2e-tests.sh v5-upgrade --from-version 5.18.0 --provider ../provider --apply-exemptions
+#   ./scripts/run-e2e-tests.sh v5-upgrade --from-version 5.18.0 --provider ../provider --clean
 
 set -euo pipefail
 
@@ -17,5 +32,11 @@ echo "Building binaries..."
 make build-all
 echo ""
 
-# Run the e2e binary with all arguments forwarded
-exec ./bin/e2e-runner run "$@"
+# Check if first argument is "v5-upgrade" for v5→v5 tests
+if [[ "${1:-}" == "v5-upgrade" ]]; then
+    # Run v5-upgrade command with remaining arguments
+    exec ./bin/e2e-runner "$@"
+else
+    # Default: run v4→v5 migration tests
+    exec ./bin/e2e-runner run "$@"
+fi


### PR DESCRIPTION
V5 E2E Runner: New Features
- Added a dedicated v5 upgrade test workflow (v5-upgrade) to validate provider upgrades from one v5 version to another (for example 5.17.0/5.18.0 → latest local build), without using tf-migrate config transforms.
- Added version-scoped remote state keys (v5/{fromVersion}-{toVersion}-terraform.tfstate) to isolate runs and avoid cross-version state contamination.
- Added targeted cleanup command (v5-upgrade-clean) for full or module-specific cleanup against upgrade state keys.
- Added support for testing against a local provider binary/path with automatic dev_overrides setup.
- Improved destroy reliability by ensuring cleanup always:
  - rewrites provider.tf to target version,
  - runs terraform init -upgrade,
  - includes required auxiliary providers (for example hashicorp/tls) before destroy.
- Added targeted module execution for upgrade runs (--resources) and module exclusion support (--exclude) for faster triage.
- Added drift-aware reporting for v5 upgrade runs with:
  - initial drift check after provider upgrade,
  - post-apply stability check,
  - categorized output (material drift, computed refreshes, exempted drift).
- Added support for v5-specific drift exemptions loaded from e2e-v5/ (separate from legacy e2e/ exemption configs).
- Added more robust handling for stale/unsafe targeted state in upgrade plans (auto-prune/retry path for “managed by newer provider version” scenarios).
- Improved cleanup UX by writing full cleanup logs to e2e-v5/tmp/*.log and avoiding noisy terminal dumps.


**TESTED RUNS**

1. 5.18.0 -> latest
2. 5.17.0 -> latest


Both runs succeeded. Some drift, to be analyzed
