### PR TITLE
fix: zero trust list with same v5 name in v4

### DIFF
--- a/integration/v4_to_v5/testdata/account_roles_datasource/input/account_roles.tf
+++ b/integration/v4_to_v5/testdata/account_roles_datasource/input/account_roles.tf
@@ -19,8 +19,8 @@ locals {
 # Reference roles by name in a resource
 resource "cloudflare_account_member" "example" {
   account_id = var.cloudflare_account_id
-  email      = "user@example.com"
-  roles = [
+  email_address      = "user@example.com"
+  role_ids = [
     local.account_member_roles["Administrator"].id,
   ]
 }

--- a/integration/v4_to_v5/testdata/zero_trust_list/expected/zero_trust_list.tf
+++ b/integration/v4_to_v5/testdata/zero_trust_list/expected/zero_trust_list.tf
@@ -109,7 +109,58 @@ locals {
 
 
 
-# Total: 26 base resources + 3 from for_each map + 4 from for_each set + 3 from count = 36 instances
+# ============================================================================
+# BUGS-2009: Already-v5-named resources with v4 block syntax
+# These resources already have the v5 name but items_with_description blocks
+# are still in v4 block syntax — tf-migrate must still convert them.
+# ============================================================================
+
+# 27. Already v5-named: simple items array
+resource "cloudflare_zero_trust_list" "bugs2009_simple" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix} BUGS-2009 Simple"
+  type       = "IP"
+  items = [{
+    description = null
+    value       = "10.0.0.1"
+    }, {
+    description = null
+    value       = "10.0.0.2"
+  }]
+}
+
+# 28. Already v5-named: items_with_description blocks
+resource "cloudflare_zero_trust_list" "bugs2009_blocks" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix} BUGS-2009 Blocks"
+  type       = "DOMAIN"
+
+
+  items = [{
+    description = "First block"
+    value       = "bugs2009-block1.cf-tf-test.com"
+    }, {
+    description = "Second block"
+    value       = "bugs2009-block2.cf-tf-test.com"
+  }]
+}
+
+# 29. Already v5-named: mixed items and blocks
+resource "cloudflare_zero_trust_list" "bugs2009_mixed" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix} BUGS-2009 Mixed"
+  type       = "EMAIL"
+
+  items = [{
+    description = "Support email"
+    value       = "bugs2009-support@cf-tf-test.com"
+    }, {
+    description = null
+    value       = "bugs2009-admin@cf-tf-test.com"
+  }]
+}
+
+# Total: 26 base resources + 3 from for_each map + 4 from for_each set + 3 from count + 3 BUGS-2009 = 39 instances
 
 # 1. Minimal resource - only required fields
 resource "cloudflare_zero_trust_list" "minimal" {

--- a/integration/v4_to_v5/testdata/zero_trust_list/input/zero_trust_list.tf
+++ b/integration/v4_to_v5/testdata/zero_trust_list/input/zero_trust_list.tf
@@ -65,7 +65,7 @@ locals {
 # 1. Minimal resource - only required fields
 resource "cloudflare_teams_list" "minimal" {
   account_id = local.common_account_id
-  name = "${local.name_prefix} Minimal List"
+  name       = "${local.name_prefix} Minimal List"
   type       = "IP"
   items      = ["192.168.1.1"]
 }
@@ -92,7 +92,7 @@ resource "cloudflare_teams_list" "maximal" {
 # 3. Empty list - edge case
 resource "cloudflare_teams_list" "empty" {
   account_id  = var.cloudflare_account_id
-  name = "${local.name_prefix} Empty List"
+  name        = "${local.name_prefix} Empty List"
   type        = "URL"
   description = "Empty list for testing"
   items       = []
@@ -101,7 +101,7 @@ resource "cloudflare_teams_list" "empty" {
 # 4. Basic IP list with simple items array
 resource "cloudflare_teams_list" "ip_list" {
   account_id = var.cloudflare_account_id
-  name = "${local.name_prefix} IP Allowlist"
+  name       = "${local.name_prefix} IP Allowlist"
   type       = "IP"
   items      = ["192.168.1.1", "192.168.1.2", "10.0.0.0/8"]
 }
@@ -109,7 +109,7 @@ resource "cloudflare_teams_list" "ip_list" {
 # 5. Domain list with items_with_description blocks
 resource "cloudflare_teams_list" "domain_list" {
   account_id  = var.cloudflare_account_id
-  name = "${local.name_prefix} Allowed Domains"
+  name        = "${local.name_prefix} Allowed Domains"
   type        = "DOMAIN"
   description = "Company approved domains"
 
@@ -132,7 +132,7 @@ resource "cloudflare_teams_list" "domain_list" {
 # 6. Mixed list with both items and items_with_description
 resource "cloudflare_teams_list" "email_list" {
   account_id = var.cloudflare_account_id
-  name = "${local.name_prefix} VIP Emails"
+  name       = "${local.name_prefix} VIP Emails"
   type       = "EMAIL"
   items      = ["admin@cf-tf-test.com", "security@cf-tf-test.com"]
 
@@ -201,7 +201,7 @@ resource "cloudflare_teams_list" "conditional_enabled" {
   count = var.enable_security_lists ? 1 : 0
 
   account_id  = var.cloudflare_account_id
-  name = "${local.name_prefix} Security List - Enabled"
+  name        = "${local.name_prefix} Security List - Enabled"
   type        = "DOMAIN"
   description = "This list is conditionally created"
   items       = ["secure.cf-tf-test.com", "protected.cf-tf-test.com"]
@@ -212,7 +212,7 @@ resource "cloudflare_teams_list" "conditional_disabled" {
   count = var.enable_security_lists ? 0 : 1
 
   account_id  = var.cloudflare_account_id
-  name = "${local.name_prefix} Security List - Disabled"
+  name        = "${local.name_prefix} Security List - Disabled"
   type        = "DOMAIN"
   description = "This list is conditionally not created"
   items       = ["insecure.cf-tf-test.com"]
@@ -247,7 +247,7 @@ resource "cloudflare_teams_list" "with_interpolation" {
 # 21. Resource with lifecycle block
 resource "cloudflare_teams_list" "with_lifecycle" {
   account_id  = var.cloudflare_account_id
-  name = "${local.name_prefix} Protected List"
+  name        = "${local.name_prefix} Protected List"
   type        = "IP"
   description = "List with lifecycle settings"
   items       = ["203.0.113.0/24"]
@@ -261,13 +261,13 @@ resource "cloudflare_teams_list" "with_lifecycle" {
 # 22. Resource with prevent_destroy (set to false for testing)
 resource "cloudflare_teams_list" "with_prevent_destroy" {
   account_id  = var.cloudflare_account_id
-  name = "${local.name_prefix} Important List"
+  name        = "${local.name_prefix} Important List"
   type        = "DOMAIN"
   description = "Critical list"
   items       = ["critical.cf-tf-test.com"]
 
   lifecycle {
-    prevent_destroy = false  # Set to false for testing
+    prevent_destroy = false # Set to false for testing
   }
 }
 
@@ -278,7 +278,7 @@ resource "cloudflare_teams_list" "with_prevent_destroy" {
 # 23. URL list with only items_with_description
 resource "cloudflare_teams_list" "url_list" {
   account_id = var.cloudflare_account_id
-  name = "${local.name_prefix} Blocked URLs"
+  name       = "${local.name_prefix} Blocked URLs"
   type       = "URL"
 
   items_with_description {
@@ -295,7 +295,7 @@ resource "cloudflare_teams_list" "url_list" {
 # 24. SERIAL type list
 resource "cloudflare_teams_list" "serial_list" {
   account_id  = var.cloudflare_account_id
-  name = "${local.name_prefix} Certificate Serials"
+  name        = "${local.name_prefix} Certificate Serials"
   type        = "SERIAL"
   description = "Revoked certificate serial numbers"
   items       = ["1234567890ABCDEF", "FEDCBA0987654321"]
@@ -309,10 +309,10 @@ resource "cloudflare_teams_list" "serial_list" {
 # 25. List with special characters and various IP formats
 resource "cloudflare_teams_list" "complex_ips" {
   account_id  = var.cloudflare_account_id
-  name = "${local.name_prefix} Complex IP List"
+  name        = "${local.name_prefix} Complex IP List"
   type        = "IP"
   description = "Various IP formats"
-  items       = [
+  items = [
     "172.16.0.0/12",
     "192.168.0.0/16",
     "203.0.113.0/24"
@@ -327,14 +327,58 @@ resource "cloudflare_teams_list" "complex_ips" {
 # 26. EMAIL type with complex addresses
 resource "cloudflare_teams_list" "complex_emails" {
   account_id  = var.cloudflare_account_id
-  name = "${local.name_prefix} Complex Email List"
+  name        = "${local.name_prefix} Complex Email List"
   type        = "EMAIL"
   description = "Emails with various formats"
-  items       = [
+  items = [
     "user+tag@cf-tf-test.com",
     "user.name@subdomain.cf-tf-test.com",
     "admin@test.cf-tf-test.com"
   ]
 }
 
-# Total: 26 base resources + 3 from for_each map + 4 from for_each set + 3 from count = 36 instances
+# ============================================================================
+# BUGS-2009: Already-v5-named resources with v4 block syntax
+# These resources already have the v5 name but items_with_description blocks
+# are still in v4 block syntax — tf-migrate must still convert them.
+# ============================================================================
+
+# 27. Already v5-named: simple items array
+resource "cloudflare_zero_trust_list" "bugs2009_simple" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix} BUGS-2009 Simple"
+  type       = "IP"
+  items      = ["10.0.0.1", "10.0.0.2"]
+}
+
+# 28. Already v5-named: items_with_description blocks
+resource "cloudflare_zero_trust_list" "bugs2009_blocks" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix} BUGS-2009 Blocks"
+  type       = "DOMAIN"
+
+  items_with_description {
+    value       = "bugs2009-block1.cf-tf-test.com"
+    description = "First block"
+  }
+
+  items_with_description {
+    value       = "bugs2009-block2.cf-tf-test.com"
+    description = "Second block"
+  }
+}
+
+# 29. Already v5-named: mixed items and blocks
+resource "cloudflare_zero_trust_list" "bugs2009_mixed" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix} BUGS-2009 Mixed"
+  type       = "EMAIL"
+  items      = ["bugs2009-admin@cf-tf-test.com"]
+
+  items_with_description {
+    value       = "bugs2009-support@cf-tf-test.com"
+    description = "Support email"
+  }
+}
+
+# Total: 26 base resources + 3 from for_each map + 4 from for_each set + 3 from count + 3 BUGS-2009 = 39 instances

--- a/internal/resources/zero_trust_list/v4_to_v5.go
+++ b/internal/resources/zero_trust_list/v4_to_v5.go
@@ -19,7 +19,10 @@ func NewV4ToV5Migrator() transform.ResourceTransformer {
 		oldType: "cloudflare_teams_list",
 		newType: "cloudflare_zero_trust_list",
 	}
+	// Register the OLD (v4) resource name: cloudflare_teams_list
 	internal.RegisterMigrator("cloudflare_teams_list", "v4", "v5", migrator)
+	// Also register the NEW (v5) resource name so already-renamed resources are still processed (BUGS-2009)
+	internal.RegisterMigrator("cloudflare_zero_trust_list", "v4", "v5", migrator)
 	return migrator
 }
 
@@ -28,7 +31,10 @@ func (m *V4ToV5Migrator) GetResourceType() string {
 }
 
 func (m *V4ToV5Migrator) CanHandle(resourceType string) bool {
-	return resourceType == m.oldType
+	// Accept both the OLD (v4) name and the NEW (v5) name.
+	// The v5 name is needed when a resource was already renamed (e.g. by a prior
+	// partial migration) but its items_with_description blocks were not yet converted (BUGS-2009).
+	return resourceType == m.oldType || resourceType == m.newType
 }
 
 // Preprocess - no preprocessing needed, transformation happens in TransformConfig
@@ -39,7 +45,8 @@ func (m *V4ToV5Migrator) Preprocess(content string) string {
 // GetResourceRename implements the ResourceRenamer interface
 // This allows the migration tool to collect all resource renames and apply them globally
 func (m *V4ToV5Migrator) GetResourceRename() ([]string, string) {
-	return []string{"cloudflare_teams_list"}, "cloudflare_zero_trust_list"
+	// Both cloudflare_teams_list and cloudflare_zero_trust_list were valid v4 names
+	return []string{"cloudflare_teams_list", "cloudflare_zero_trust_list"}, "cloudflare_zero_trust_list"
 }
 
 func (m *V4ToV5Migrator) TransformConfig(ctx *transform.Context, block *hclwrite.Block) (*transform.TransformResult, error) {
@@ -48,7 +55,10 @@ func (m *V4ToV5Migrator) TransformConfig(ctx *transform.Context, block *hclwrite
 	resourceName := tfhcl.GetResourceName(block)
 
 	// Rename cloudflare_teams_list to cloudflare_zero_trust_list
-	tfhcl.RenameResourceType(block, "cloudflare_teams_list", "cloudflare_zero_trust_list")
+	// Skip when already v5-named (resource was renamed in a prior migration run).
+	if originalResourceType == "cloudflare_teams_list" {
+		tfhcl.RenameResourceType(block, "cloudflare_teams_list", "cloudflare_zero_trust_list")
+	}
 
 	body := block.Body()
 
@@ -64,11 +74,11 @@ func (m *V4ToV5Migrator) TransformConfig(ctx *transform.Context, block *hclwrite
 		true,                     // blocksFirst (to match API order)
 	)
 
-	// Generate moved block for resource rename
-	_, newType := m.GetResourceRename()
-	if originalResourceType != newType {
+	// Generate moved block only when renaming from v4 name.
+	// If already v5-named: no rename, no moved block — just apply items transformations above.
+	if originalResourceType == "cloudflare_teams_list" {
 		from := originalResourceType + "." + resourceName
-		to := newType + "." + resourceName
+		to := m.newType + "." + resourceName
 		movedBlock := tfhcl.CreateMovedBlock(from, to)
 
 		return &transform.TransformResult{
@@ -82,4 +92,3 @@ func (m *V4ToV5Migrator) TransformConfig(ctx *transform.Context, block *hclwrite
 		RemoveOriginal: false,
 	}, nil
 }
-

--- a/internal/resources/zero_trust_list/v4_to_v5_test.go
+++ b/internal/resources/zero_trust_list/v4_to_v5_test.go
@@ -315,3 +315,119 @@ moved {
 		testhelpers.RunConfigTransformTests(t, tests, migrator)
 	})
 }
+
+// TestV4ToV5Transformation_AlreadyV5Named tests the scenario from BUGS-2009:
+// The user has already run tf-migrate once (or manually renamed resources),
+// so the resource type is already "cloudflare_zero_trust_list" (v5 name),
+// but items_with_description blocks are still in v4 block syntax.
+// tf-migrate must still convert the blocks even when the resource name is already v5.
+func TestV4ToV5Transformation_AlreadyV5Named(t *testing.T) {
+	migrator := NewV4ToV5Migrator()
+
+	tests := []testhelpers.ConfigTestCase{
+		{
+			Name: "v5-named resource with simple items array",
+			Input: `
+resource "cloudflare_zero_trust_list" "already_v5_simple" {
+  account_id = "abc123"
+  name       = "Already V5 Simple"
+  type       = "IP"
+  items      = ["10.0.0.1", "10.0.0.2"]
+}`,
+			Expected: `
+resource "cloudflare_zero_trust_list" "already_v5_simple" {
+  account_id = "abc123"
+  name       = "Already V5 Simple"
+  type       = "IP"
+
+  items = [{
+    description = null
+    value       = "10.0.0.1"
+    }, {
+    description = null
+    value       = "10.0.0.2"
+  }]
+}`,
+		},
+		{
+			Name: "v5-named resource with items_with_description blocks",
+			Input: `
+resource "cloudflare_zero_trust_list" "already_v5_blocks" {
+  account_id = "abc123"
+  name       = "Already V5 Blocks"
+  type       = "DOMAIN"
+
+  items_with_description {
+    value       = "example.com"
+    description = "Example domain"
+  }
+
+  items_with_description {
+    value       = "test.com"
+    description = "Test domain"
+  }
+}`,
+			Expected: `
+resource "cloudflare_zero_trust_list" "already_v5_blocks" {
+  account_id = "abc123"
+  name       = "Already V5 Blocks"
+  type       = "DOMAIN"
+
+  items = [{
+    description = "Example domain"
+    value       = "example.com"
+    }, {
+    description = "Test domain"
+    value       = "test.com"
+  }]
+}`,
+		},
+		{
+			Name: "v5-named resource with mixed items and blocks",
+			Input: `
+resource "cloudflare_zero_trust_list" "already_v5_mixed" {
+  account_id = "abc123"
+  name       = "Already V5 Mixed"
+  type       = "EMAIL"
+  items      = ["admin@example.com"]
+
+  items_with_description {
+    value       = "support@example.com"
+    description = "Support email"
+  }
+}`,
+			Expected: `
+resource "cloudflare_zero_trust_list" "already_v5_mixed" {
+  account_id = "abc123"
+  name       = "Already V5 Mixed"
+  type       = "EMAIL"
+
+  items = [{
+    description = "Support email"
+    value       = "support@example.com"
+    }, {
+    description = null
+    value       = "admin@example.com"
+  }]
+}`,
+		},
+		{
+			Name: "v5-named resource with empty items array",
+			Input: `
+resource "cloudflare_zero_trust_list" "already_v5_empty" {
+  account_id = "abc123"
+  name       = "Already V5 Empty"
+  type       = "IP"
+  items      = []
+}`,
+			Expected: `
+resource "cloudflare_zero_trust_list" "already_v5_empty" {
+  account_id = "abc123"
+  name       = "Already V5 Empty"
+  type       = "IP"
+}`,
+		},
+	}
+
+	testhelpers.RunConfigTransformTests(t, tests, migrator)
+}


### PR DESCRIPTION
```
========================================
✓ E2E Test Complete!
========================================

Summary:

  Step 1: v4 terraform apply
    Status: ✓ SUCCESS

  Step 2: Migration (v4 → v5)
    Status: ✓ SUCCESS

  Step 3: v5 plan (before apply)
    Status: ✓ SUCCESS - Drift matched exemptions
    Result: 71 material changes (71 matched exemptions, 0 unmatched)
    Terraform: Plan: 17 to import, 7 to add, 67 to change, 0 to destroy.

  Step 4: v5 terraform apply
    Status: ✓ SUCCESS

  Step 5: v5 plan (after apply)
    Status: ✓ SUCCESS - Stable state achieved
    Result: 11 material changes matched exemptions (0 unmatched)

Logs saved to:
  - /Users/vaishak/cf-repos/github/tf-migrate/e2e/tmp
 ```