### PR TITLE
feat: add minimum provider version check for v4→v5 migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,24 @@ A CLI tool for automatically migrating Terraform configurations between differen
 |----------------|----------------|
 | Cloudflare Provider v4 | Cloudflare Provider v5 |
 
+### Prerequisites
+
+#### Minimum Provider Version (v4 → v5 only)
+
+For v4 to v5 migrations, you must be running **Cloudflare Provider v4.52.5 or higher** before running tf-migrate. This version introduced critical state migration capabilities required for a successful upgrade.
+
+The tool checks for this in the following order:
+1. **`.terraform.lock.hcl`** — The installed provider version (most reliable)
+2. **`required_providers` block** — The version constraint in your `.tf` files (fallback)
+
+If neither is found, or if the version is below 4.52.5, the migration will be blocked with instructions on how to upgrade.
+
+To bypass this check (e.g., for testing or CI), use `--skip-version-check`:
+
+```bash
+tf-migrate migrate --source-version v4 --target-version v5 --skip-version-check
+```
+
 ### Supported Resources (v4 → v5)
 
 <details>
@@ -495,6 +513,7 @@ This is the most common mistake when migrating an Atlantis workspace. Always reg
 | `--no-backup` | `false` | Skip creating backup files (alias for `--backup=false`) |
 | `--recursive` | `false` | Recursively process subdirectories |
 | `--skip-phase-check` | `false` | Skip the phased migration confirmation prompt and run the full migration directly (for CI/non-interactive use) |
+| `--skip-version-check` | `false` | Skip the minimum provider version check (for testing/CI only). Only applies to v4→v5 migrations. |
 | `--target-provider-version` | _(auto-detected)_ | Explicit provider version to write into `required_providers` (e.g. `5.19.0-beta.3`). Bypasses the GitHub API lookup — useful in CI or air-gapped environments where the API is unreachable. |
 | `-v` / `--verbose` | `false` | Show verbose output: per-file progress, rename tables, and all diagnostics |
 | `-q` / `--quiet` | `false` | Suppress warnings, only show errors |

--- a/cmd/tf-migrate/main.go
+++ b/cmd/tf-migrate/main.go
@@ -43,6 +43,7 @@ type config struct {
 	recursive             bool
 	logLevel              string
 	skipPhaseCheck        bool // skip phased migration prompt and run full migration directly (for CI/e2e)
+	skipVersionCheck      bool // skip minimum provider version check (for testing)
 
 	// Diagnostic output options
 	quiet   bool // Suppress warnings, only show errors
@@ -170,6 +171,7 @@ Uses the global flags --config-dir and --resources to determine what to migrate.
 	var noBackup bool
 	cmd.Flags().BoolVar(&noBackup, "no-backup", false, "Skip creating backup files before migration (alias for --backup=false)")
 	cmd.Flags().BoolVar(&cfg.skipPhaseCheck, "skip-phase-check", false, "Skip the phased migration confirmation prompt and run the full migration directly (for CI/non-interactive use)")
+	cmd.Flags().BoolVar(&cfg.skipVersionCheck, "skip-version-check", false, "Skip the minimum provider version check (for testing/CI only)")
 	cmd.PreRun = func(cmd *cobra.Command, args []string) {
 		if noBackup {
 			cfg.backup = false
@@ -234,6 +236,11 @@ Exit code 1: unexpected drift requires attention.`,
 func runMigration(log hclog.Logger, cfg config) error {
 	err := validateVersions(cfg)
 	if err != nil {
+		return err
+	}
+
+	// Check that the installed provider version meets minimum requirements
+	if err := checkMinimumProviderVersion(cfg); err != nil {
 		return err
 	}
 

--- a/cmd/tf-migrate/main.go
+++ b/cmd/tf-migrate/main.go
@@ -158,6 +158,12 @@ Uses the global flags --config-dir and --resources to determine what to migrate.
 				fmt.Println("\n DRY RUN MODE - No changes will be made")
 			}
 
+			// Check minimum provider version early to provide clear error without help output
+			if err := checkMinimumProviderVersion(*cfg); err != nil {
+				cmd.SilenceUsage = true
+				return err
+			}
+
 			return runMigration(log, *cfg)
 		},
 	}
@@ -236,11 +242,6 @@ Exit code 1: unexpected drift requires attention.`,
 func runMigration(log hclog.Logger, cfg config) error {
 	err := validateVersions(cfg)
 	if err != nil {
-		return err
-	}
-
-	// Check that the installed provider version meets minimum requirements
-	if err := checkMinimumProviderVersion(cfg); err != nil {
 		return err
 	}
 

--- a/cmd/tf-migrate/version_check.go
+++ b/cmd/tf-migrate/version_check.go
@@ -1,0 +1,283 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclwrite"
+)
+
+// minimumProviderVersion is the minimum Cloudflare provider version required
+// for v4 to v5 migrations. This version introduced critical state migration
+// capabilities needed for tf-migrate to work correctly.
+const minimumProviderVersion = "4.52.5"
+
+// checkMinimumProviderVersion verifies that the installed Cloudflare provider
+// version meets the minimum requirement (4.52.5) for v4 to v5 migrations.
+// It checks the lock file first, then falls back to required_providers.
+func checkMinimumProviderVersion(cfg config) error {
+	// Skip check if explicitly disabled (for testing/CI)
+	if cfg.skipVersionCheck {
+		return nil
+	}
+
+	// Only apply this check for v4 to v5 migrations
+	if cfg.sourceVersion != "v4" || cfg.targetVersion != "v5" {
+		return nil
+	}
+
+	// First, try to get the version from the lock file (most reliable)
+	version, err := parseVersionFromLockFile(cfg.configDir)
+	if err == nil {
+		if version == "" {
+			return fmt.Errorf("no Cloudflare provider found in .terraform.lock.hcl")
+		}
+		if err := verifyVersionMeetsMinimum(version); err != nil {
+			return err
+		}
+		return nil
+	}
+
+	// Lock file doesn't exist or couldn't be parsed, try required_providers
+	versionConstraint, constraintSource, err := parseVersionFromRequiredProviders(cfg)
+	if err == nil && versionConstraint != "" {
+		// Check if the constraint could possibly allow a version >= 4.52.5
+		if !constraintCouldAllowMinVersion(versionConstraint) {
+			return fmt.Errorf("Cloudflare provider version constraint %q in %s may allow versions below the required %s\n\nPlease update your required_providers to require at least %s, run 'terraform init', then re-run tf-migrate",
+				versionConstraint, constraintSource, minimumProviderVersion, minimumProviderVersion)
+		}
+		// Constraint might be OK, but we can't verify without a lock file
+		return fmt.Errorf("Could not verify the installed Cloudflare provider version.\nNo .terraform.lock.hcl found in %s.\n\nThe v4 to v5 migration requires Cloudflare provider v%s or higher.\nPlease run 'terraform init' in your configuration directory first, then re-run tf-migrate.",
+			cfg.configDir, minimumProviderVersion)
+	}
+
+	// Neither lock file nor required_providers found
+	return fmt.Errorf("Could not verify the installed Cloudflare provider version.\nNo .terraform.lock.hcl or required_providers block found in %s.\n\nThe v4 to v5 migration requires Cloudflare provider v%s or higher.\nPlease ensure you have a terraform block with required_providers, run 'terraform init', then re-run tf-migrate.",
+		cfg.configDir, minimumProviderVersion)
+}
+
+// parseVersionFromLockFile reads .terraform.lock.hcl and extracts the
+// installed Cloudflare provider version.
+// Returns empty string if the cloudflare provider is not in the lock file.
+func parseVersionFromLockFile(configDir string) (string, error) {
+	lockFilePath := filepath.Join(configDir, ".terraform.lock.hcl")
+
+	content, err := os.ReadFile(lockFilePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", fmt.Errorf("lock file not found")
+		}
+		return "", fmt.Errorf("failed to read lock file: %w", err)
+	}
+
+	parsed, diags := hclwrite.ParseConfig(content, ".terraform.lock.hcl", hcl.InitialPos)
+	if diags.HasErrors() {
+		return "", fmt.Errorf("failed to parse lock file: %s", diags.Error())
+	}
+
+	for _, block := range parsed.Body().Blocks() {
+		if block.Type() != "provider" {
+			continue
+		}
+
+		labels := block.Labels()
+		if len(labels) == 0 {
+			continue
+		}
+
+		// Check for registry.terraform.io/cloudflare/cloudflare
+		// or just cloudflare/cloudflare (older formats)
+		providerLabel := labels[0]
+		if providerLabel == "registry.terraform.io/cloudflare/cloudflare" ||
+			providerLabel == "cloudflare/cloudflare" {
+
+			versionAttr := block.Body().GetAttribute("version")
+			if versionAttr == nil {
+				continue
+			}
+
+			versionStr := string(versionAttr.Expr().BuildTokens(nil).Bytes())
+			// Remove quotes from the version string
+			versionStr = strings.Trim(versionStr, ` "`)
+			return versionStr, nil
+		}
+	}
+
+	return "", nil
+}
+
+// parseVersionFromRequiredProviders scans all .tf files for the required_providers
+// block and extracts the cloudflare provider version constraint.
+// Returns the version constraint string and the file path where it was found.
+func parseVersionFromRequiredProviders(cfg config) (versionConstraint, sourceFile string, err error) {
+	files, err := findTerraformFilesWithRecursion(cfg.configDir, cfg.recursive)
+	if err != nil {
+		return "", "", err
+	}
+
+	for _, file := range files {
+		content, err := os.ReadFile(file)
+		if err != nil {
+			continue
+		}
+
+		parsed, diags := hclwrite.ParseConfig(content, filepath.Base(file), hcl.InitialPos)
+		if diags.HasErrors() {
+			continue
+		}
+
+		for _, block := range parsed.Body().Blocks() {
+			if block.Type() != "terraform" {
+				continue
+			}
+
+			for _, inner := range block.Body().Blocks() {
+				if inner.Type() != "required_providers" {
+					continue
+				}
+
+				cfAttr := inner.Body().GetAttribute("cloudflare")
+				if cfAttr == nil {
+					continue
+				}
+
+				// Extract the version from the cloudflare attribute
+				attrStr := string(cfAttr.BuildTokens(nil).Bytes())
+				if !strings.Contains(attrStr, "cloudflare/cloudflare") {
+					continue
+				}
+
+				// Look for version = "..." pattern
+				re := regexp.MustCompile(`version\s*=\s*"([^"]+)"`)
+				matches := re.FindStringSubmatch(attrStr)
+				if len(matches) > 1 {
+					return matches[1], file, nil
+				}
+			}
+		}
+	}
+
+	return "", "", fmt.Errorf("no required_providers block with cloudflare provider found")
+}
+
+// verifyVersionMeetsMinimum compares a version string against the minimum required.
+// Versions must be in MAJOR.MINOR.PATCH format.
+func verifyVersionMeetsMinimum(version string) error {
+	if compareVersions(version, minimumProviderVersion) < 0 {
+		return fmt.Errorf("Cloudflare provider version %s is below the minimum required %s.\n\nPlease upgrade your provider to at least v%s before migrating:\n  1. Update your required_providers version constraint to \">= %s\"\n  2. Run: terraform init -upgrade\n  3. Run: terraform apply (to ensure state is compatible)\n  4. Re-run tf-migrate",
+			version, minimumProviderVersion, minimumProviderVersion, minimumProviderVersion)
+	}
+	return nil
+}
+
+// compareVersions compares two version strings in MAJOR.MINOR.PATCH format.
+// Returns:
+//
+//	-1 if v1 < v2
+//	 0 if v1 == v2
+//	 1 if v1 > v2
+func compareVersions(v1, v2 string) int {
+	parts1 := strings.Split(v1, ".")
+	parts2 := strings.Split(v2, ".")
+
+	// Ensure we have at least 3 parts for both
+	for len(parts1) < 3 {
+		parts1 = append(parts1, "0")
+	}
+	for len(parts2) < 3 {
+		parts2 = append(parts2, "0")
+	}
+
+	for i := 0; i < 3; i++ {
+		n1, _ := strconv.Atoi(parts1[i])
+		n2, _ := strconv.Atoi(parts2[i])
+
+		if n1 < n2 {
+			return -1
+		}
+		if n1 > n2 {
+			return 1
+		}
+	}
+
+	return 0
+}
+
+// constraintCouldAllowMinVersion checks if a version constraint could possibly
+// allow a version >= 4.52.5. This is a simplified check for common constraint formats.
+// Returns true if the constraint MIGHT allow a sufficient version, false if
+// it definitely doesn't.
+func constraintCouldAllowMinVersion(constraint string) bool {
+	constraint = strings.TrimSpace(constraint)
+
+	// Extract version numbers from various constraint patterns
+	// Patterns: ~> 4.0, >= 4.0, = 4.0, 4.0, < 5.0, etc.
+	// Note: In raw string literals (`), backslashes are literal, so `\s` is correct for whitespace
+	re := regexp.MustCompile(`^(?:>=?|<=?|~>|=)?\s*(\d+)(?:\.(\d+))?(?:\.(\d+))?`)
+	matches := re.FindStringSubmatch(constraint)
+
+	if len(matches) == 0 {
+		// Unparseable constraint, assume it might be OK (will need lock file check)
+		return true
+	}
+
+	major, _ := strconv.Atoi(matches[1])
+	minor := 0
+	patch := 0
+
+	if len(matches) > 2 && matches[2] != "" {
+		minor, _ = strconv.Atoi(matches[2])
+	}
+	if len(matches) > 3 && matches[3] != "" {
+		patch, _ = strconv.Atoi(matches[3])
+	}
+
+	// Build the version string from the extracted components
+	extractedVersion := fmt.Sprintf("%d.%d.%d", major, minor, patch)
+
+	// If constraint starts with ~>, it's pessimistic and only allows patch updates
+	// for the specified minor version, or minor updates within the same major.
+	// Examples: ~> 4.52 allows 4.52.x and 4.53.0+ but not 5.0.0
+	//           ~> 4.0 allows 4.0.x through 4.99.99 but not 5.0.0
+	if strings.HasPrefix(constraint, "~>") {
+		// For ~>, the version must be >= the specified version
+		// If ~> 4.52, we need at least 4.52.0, but if the constraint is ~> 4.49,
+		// we still need 4.52.5, so we check if the minimum is possible
+		return compareVersions(extractedVersion, minimumProviderVersion) <= 0 ||
+			(major == 4 && minor >= 52)
+	}
+
+	// For >= constraints, check if the lower bound is sufficient
+	if strings.HasPrefix(constraint, ">=") {
+		return compareVersions(extractedVersion, minimumProviderVersion) >= 0
+	}
+
+	// For > constraints: allows versions strictly greater than extractedVersion.
+	// If extractedVersion >= minimum, then extractedVersion+1 >= minimum too.
+	// If extractedVersion < minimum, we need to check if minimum > extractedVersion.
+	// For practical purposes, "> X" where X is any reasonable version will allow
+	// versions >= 4.52.5 (e.g., > 4.52.4 allows 4.52.5+, > 4.0 allows 4.52.5+, etc.)
+	// Only fail if extractedVersion is absurdly high (>= 999.0.0)
+	if strings.HasPrefix(constraint, ">") && !strings.HasPrefix(constraint, ">=") {
+		return compareVersions(extractedVersion, "999.0.0") < 0
+	}
+
+	// For = constraints: exact version must be >= minimum
+	if strings.HasPrefix(constraint, "=") {
+		return compareVersions(extractedVersion, minimumProviderVersion) >= 0
+	}
+
+	// For exact version without operator (e.g., "4.52.5")
+	if regexp.MustCompile(`^\d`).MatchString(constraint) {
+		return compareVersions(extractedVersion, minimumProviderVersion) >= 0
+	}
+
+	// For other constraints (<=, <, !=), we can't easily determine
+	// without full constraint parsing, so assume it might be OK
+	return true
+}

--- a/cmd/tf-migrate/version_check_test.go
+++ b/cmd/tf-migrate/version_check_test.go
@@ -1,0 +1,300 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCompareVersions(t *testing.T) {
+	tests := []struct {
+		name     string
+		v1       string
+		v2       string
+		expected int
+	}{
+		{"equal versions", "4.52.5", "4.52.5", 0},
+		{"greater major", "5.0.0", "4.52.5", 1},
+		{"less major", "3.9.9", "4.52.5", -1},
+		{"greater minor", "4.53.0", "4.52.5", 1},
+		{"less minor", "4.51.9", "4.52.5", -1},
+		{"greater patch", "4.52.6", "4.52.5", 1},
+		{"less patch", "4.52.4", "4.52.5", -1},
+		{"different lengths v1 shorter", "4.52", "4.52.5", -1},
+		{"different lengths v2 shorter", "4.52.5", "4.52", 1},
+		{"exact minimum", "4.52.5", minimumProviderVersion, 0},
+		{"just below minimum", "4.52.4", minimumProviderVersion, -1},
+		{"just above minimum", "4.52.6", minimumProviderVersion, 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := compareVersions(tt.v1, tt.v2)
+			if result != tt.expected {
+				t.Errorf("compareVersions(%q, %q) = %d, want %d", tt.v1, tt.v2, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestConstraintCouldAllowMinVersion(t *testing.T) {
+	tests := []struct {
+		name       string
+		constraint string
+		expected   bool
+	}{
+		// Exact versions
+		{"exact version above min", "4.53.0", true},
+		{"exact version at min", "4.52.5", true},
+		{"exact version below min", "4.52.4", false},
+		{"exact version old major", "4.49.0", false},
+
+		// >= constraints
+		{"greater than or equal above min", ">= 4.53.0", true},
+		{"greater than or equal at min", ">= 4.52.5", true},
+		{"greater than or equal below min", ">= 4.52.0", false},
+		{"greater than or equal old major", ">= 4.0.0", false},
+
+		// ~> constraints (pessimistic)
+		{"pessimistic recent", "~> 4.52", true},
+		{"pessimistic exact", "~> 4.52.5", true},
+		{"pessimistic old", "~> 4.49", true},     // Could be updated to 4.52.5+
+		{"pessimistic very old", "~> 4.0", true}, // Could be updated
+
+		// < constraints - ambiguous, allow
+		{"less than", "< 5.0.0", true},
+
+		// <= constraints - ambiguous, allow
+		{"less than or equal", "<= 5.0.0", true},
+
+		// > constraints
+		{"greater than below min", "> 4.52.0", true}, // > 4.52.0 allows 4.52.5+
+		{"greater than at min", "> 4.52.5", true},
+
+		// = constraints
+		{"equals at min", "= 4.52.5", true},
+		{"equals below min", "= 4.52.4", false},
+
+		// Unparseable - should default to true
+		{"unparseable constraint", "invalid", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := constraintCouldAllowMinVersion(tt.constraint)
+			if result != tt.expected {
+				t.Errorf("constraintCouldAllowMinVersion(%q) = %v, want %v", tt.constraint, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestParseVersionFromLockFile(t *testing.T) {
+	tempDir := t.TempDir()
+
+	// Test with valid lock file
+	lockContent := `# This file is maintained automatically by "terraform init".
+provider "registry.terraform.io/cloudflare/cloudflare" {
+  version     = "4.52.5"
+  constraints = "~> 4.0"
+  hashes = [
+    "h1:+rfzF+16ZcWZWnTyW/p1HHTzYbPKX8Zt2nIFtR/+f+E=",
+  ]
+}
+`
+	lockFile := filepath.Join(tempDir, ".terraform.lock.hcl")
+	err := os.WriteFile(lockFile, []byte(lockContent), 0644)
+	if err != nil {
+		t.Fatalf("Failed to write lock file: %v", err)
+	}
+
+	version, err := parseVersionFromLockFile(tempDir)
+	if err != nil {
+		t.Fatalf("parseVersionFromLockFile failed: %v", err)
+	}
+	if version != "4.52.5" {
+		t.Errorf("Expected version 4.52.5, got %s", version)
+	}
+
+	// Test with lock file without cloudflare provider
+	lockContentNoCF := `# This file is maintained automatically by "terraform init".
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.0.0"
+  constraints = "~> 5.0"
+}
+`
+	tempDir2 := t.TempDir()
+	lockFile2 := filepath.Join(tempDir2, ".terraform.lock.hcl")
+	err = os.WriteFile(lockFile2, []byte(lockContentNoCF), 0644)
+	if err != nil {
+		t.Fatalf("Failed to write lock file: %v", err)
+	}
+
+	version, err = parseVersionFromLockFile(tempDir2)
+	if err != nil {
+		t.Fatalf("parseVersionFromLockFile failed: %v", err)
+	}
+	if version != "" {
+		t.Errorf("Expected empty version, got %s", version)
+	}
+
+	// Test with no lock file
+	tempDir3 := t.TempDir()
+	_, err = parseVersionFromLockFile(tempDir3)
+	if err == nil {
+		t.Error("Expected error for missing lock file, got nil")
+	}
+}
+
+func TestParseVersionFromRequiredProviders(t *testing.T) {
+	tempDir := t.TempDir()
+
+	// Test with required_providers in main.tf
+	tfContent := `terraform {
+  required_providers {
+    cloudflare = {
+      source  = "cloudflare/cloudflare"
+      version = "~> 4.52"
+    }
+  }
+}
+`
+	tfFile := filepath.Join(tempDir, "main.tf")
+	err := os.WriteFile(tfFile, []byte(tfContent), 0644)
+	if err != nil {
+		t.Fatalf("Failed to write tf file: %v", err)
+	}
+
+	cfg := config{configDir: tempDir, recursive: false}
+	constraint, source, err := parseVersionFromRequiredProviders(cfg)
+	if err != nil {
+		t.Fatalf("parseVersionFromRequiredProviders failed: %v", err)
+	}
+	if constraint != "~> 4.52" {
+		t.Errorf("Expected constraint '~> 4.52', got %s", constraint)
+	}
+	if source != tfFile {
+		t.Errorf("Expected source %s, got %s", tfFile, source)
+	}
+
+	// Test with no required_providers
+	tempDir2 := t.TempDir()
+	tfContentNoReq := `resource "aws_instance" "example" {
+  ami           = "ami-12345678"
+  instance_type = "t2.micro"
+}
+`
+	tfFile2 := filepath.Join(tempDir2, "main.tf")
+	err = os.WriteFile(tfFile2, []byte(tfContentNoReq), 0644)
+	if err != nil {
+		t.Fatalf("Failed to write tf file: %v", err)
+	}
+
+	cfg2 := config{configDir: tempDir2, recursive: false}
+	_, _, err = parseVersionFromRequiredProviders(cfg2)
+	if err == nil {
+		t.Error("Expected error for missing required_providers, got nil")
+	}
+}
+
+func TestCheckMinimumProviderVersion(t *testing.T) {
+	// Test v4-v5 migration with skip flag
+	cfg := config{
+		sourceVersion:    "v4",
+		targetVersion:    "v5",
+		skipVersionCheck: true,
+		configDir:        "/tmp",
+	}
+	err := checkMinimumProviderVersion(cfg)
+	if err != nil {
+		t.Errorf("Expected no error with skipVersionCheck, got %v", err)
+	}
+
+	// Test non-v4-v5 migration (should skip check)
+	cfg2 := config{
+		sourceVersion:    "v5",
+		targetVersion:    "v5",
+		skipVersionCheck: false,
+		configDir:        "/tmp",
+	}
+	err = checkMinimumProviderVersion(cfg2)
+	if err != nil {
+		t.Errorf("Expected no error for v5-v5 migration, got %v", err)
+	}
+
+	// Test v4-v5 migration with no lock file and no required_providers
+	tempDir := t.TempDir()
+	cfg3 := config{
+		sourceVersion:    "v4",
+		targetVersion:    "v5",
+		skipVersionCheck: false,
+		configDir:        tempDir,
+		recursive:        false,
+	}
+	err = checkMinimumProviderVersion(cfg3)
+	if err == nil {
+		t.Error("Expected error for missing lock file and required_providers, got nil")
+	}
+
+	// Test v4-v5 migration with lock file having sufficient version
+	tempDir4 := t.TempDir()
+	lockContent := `provider "registry.terraform.io/cloudflare/cloudflare" {
+  version = "4.52.5"
+}
+`
+	lockFile := filepath.Join(tempDir4, ".terraform.lock.hcl")
+	os.WriteFile(lockFile, []byte(lockContent), 0644)
+	cfg4 := config{
+		sourceVersion:    "v4",
+		targetVersion:    "v5",
+		skipVersionCheck: false,
+		configDir:        tempDir4,
+	}
+	err = checkMinimumProviderVersion(cfg4)
+	if err != nil {
+		t.Errorf("Expected no error with sufficient version, got %v", err)
+	}
+
+	// Test v4-v5 migration with lock file having insufficient version
+	tempDir5 := t.TempDir()
+	lockContentOld := `provider "registry.terraform.io/cloudflare/cloudflare" {
+  version = "4.49.0"
+}
+`
+	lockFile5 := filepath.Join(tempDir5, ".terraform.lock.hcl")
+	os.WriteFile(lockFile5, []byte(lockContentOld), 0644)
+	cfg5 := config{
+		sourceVersion:    "v4",
+		targetVersion:    "v5",
+		skipVersionCheck: false,
+		configDir:        tempDir5,
+	}
+	err = checkMinimumProviderVersion(cfg5)
+	if err == nil {
+		t.Error("Expected error for old version, got nil")
+	}
+}
+
+func TestVerifyVersionMeetsMinimum(t *testing.T) {
+	// Test with sufficient version
+	err := verifyVersionMeetsMinimum("4.52.5")
+	if err != nil {
+		t.Errorf("Expected no error for version 4.52.5, got %v", err)
+	}
+
+	err = verifyVersionMeetsMinimum("5.0.0")
+	if err != nil {
+		t.Errorf("Expected no error for version 5.0.0, got %v", err)
+	}
+
+	// Test with insufficient version
+	err = verifyVersionMeetsMinimum("4.52.4")
+	if err == nil {
+		t.Error("Expected error for version 4.52.4, got nil")
+	}
+
+	err = verifyVersionMeetsMinimum("4.49.0")
+	if err == nil {
+		t.Error("Expected error for version 4.49.0, got nil")
+	}
+}

--- a/integration/test_runner.go
+++ b/integration/test_runner.go
@@ -120,6 +120,7 @@ func (r *TestRunner) runMigration(dir string) error {
 	// Use --skip-phase-check to run the full migration directly.
 	// Integration tests validate the final v5 output, not the intermediate
 	// phase-1 state — phased migration is covered separately in phased_migration_test.go.
+	// Use --skip-version-check because test fixtures don't have lock files or required_providers.
 	args := []string{
 		"migrate",
 		"--config-dir", dir,
@@ -127,6 +128,7 @@ func (r *TestRunner) runMigration(dir string) error {
 		"--target-version", r.TargetVersion,
 		"--backup=false",
 		"--skip-phase-check",
+		"--skip-version-check",
 	}
 
 	migrateCmd := exec.Command(r.BinaryPath, args...)

--- a/integration/v4_to_v5/phased_migration_test.go
+++ b/integration/v4_to_v5/phased_migration_test.go
@@ -65,6 +65,7 @@ func TestPhasedMigration_ZoneSettingsOverride(t *testing.T) {
 			"--source-version", "v4",
 			"--target-version", "v5",
 			"--backup=false",
+			"--skip-version-check",
 		)
 		migrateCmd.Dir = dir
 		cmdOut, err := migrateCmd.CombinedOutput()
@@ -115,6 +116,7 @@ func TestPhasedMigration_ZoneSettingsOverride(t *testing.T) {
 			"--target-version", "v5",
 			"--backup=false",
 			"--skip-phase-check",
+			"--skip-version-check",
 		)
 		migrateCmd.Dir = dir
 		cmdOut, err := migrateCmd.CombinedOutput()
@@ -141,7 +143,7 @@ func TestPhasedMigration_ZoneSettingsOverride(t *testing.T) {
 		// Phase 1
 		p1 := exec.Command(binaryPath,
 			"migrate", "--config-dir", dir,
-			"--source-version", "v4", "--target-version", "v5", "--backup=false",
+			"--source-version", "v4", "--target-version", "v5", "--backup=false", "--skip-version-check",
 		)
 		p1.Dir = dir
 		_, err := p1.CombinedOutput()
@@ -150,7 +152,7 @@ func TestPhasedMigration_ZoneSettingsOverride(t *testing.T) {
 		// Phase 2 — confirm with "y"
 		p2 := exec.Command(binaryPath,
 			"migrate", "--config-dir", dir,
-			"--source-version", "v4", "--target-version", "v5", "--backup=false",
+			"--source-version", "v4", "--target-version", "v5", "--backup=false", "--skip-version-check",
 		)
 		p2.Dir = dir
 		p2.Stdin = strings.NewReader("y\n")
@@ -177,7 +179,7 @@ func TestPhasedMigration_ZoneSettingsOverride(t *testing.T) {
 
 		p1 := exec.Command(binaryPath,
 			"migrate", "--config-dir", dir,
-			"--source-version", "v4", "--target-version", "v5", "--backup=false",
+			"--source-version", "v4", "--target-version", "v5", "--backup=false", "--skip-version-check",
 		)
 		p1.Dir = dir
 		_, err := p1.CombinedOutput()
@@ -187,7 +189,7 @@ func TestPhasedMigration_ZoneSettingsOverride(t *testing.T) {
 
 		p2 := exec.Command(binaryPath,
 			"migrate", "--config-dir", dir,
-			"--source-version", "v4", "--target-version", "v5", "--backup=false",
+			"--source-version", "v4", "--target-version", "v5", "--backup=false", "--skip-version-check",
 		)
 		p2.Dir = dir
 		p2.Stdin = strings.NewReader("n\n")
@@ -215,7 +217,7 @@ func TestPhasedMigration_ZoneSettingsOverride(t *testing.T) {
 
 		migrateCmd := exec.Command(binaryPath,
 			"migrate", "--config-dir", dir,
-			"--source-version", "v4", "--target-version", "v5", "--backup=false",
+			"--source-version", "v4", "--target-version", "v5", "--backup=false", "--skip-version-check",
 		)
 		migrateCmd.Dir = dir
 		cmdOut, err := migrateCmd.CombinedOutput()


### PR DESCRIPTION
**Description:**

This PR adds validation to ensure users are running Cloudflare Provider **v4.52.5 or higher** before attempting v4→v5 migrations. This version introduced critical state migration capabilities required for tf-migrate to work correctly.

### Problem

Users could attempt to migrate from older v4 provider versions that lack necessary state migration support, leading to migration failures or incomplete state transitions. We needed a way to block migrations and guide users to upgrade first.

### Solution

Add a pre-migration version check that:
1. Reads `.terraform.lock.hcl` to get the exact installed provider version (primary)
2. Falls back to parsing `required_providers` version constraints in `.tf` files
3. Blocks migration with clear, actionable error messages if version < 4.52.5
4. Provides `--skip-version-check` flag for testing/CI scenarios

### Changes

#### New Files
- `cmd/tf-migrate/version_check.go` - Core version check logic with semver comparison
- `cmd/tf-migrate/version_check_test.go` - Unit tests for version parsing and comparison

#### Modified Files
- `cmd/tf-migrate/main.go` - Add `skipVersionCheck` config, CLI flag, and integrate version check into migration flow
- `integration/test_runner.go` - Update to use `--skip-version-check` for test fixtures
- `integration/v4_to_v5/phased_migration_test.go` - Update tests to skip version check
- `README.md` - Document prerequisites section and new `--skip-version-check` flag

### Example Error Output

```
Error: Cloudflare provider version 4.49.0 is below the minimum required 4.52.5.

Please upgrade your provider to at least v4.52.5 before migrating:
  1. Update your required_providers version constraint to ">= 4.52.5"
  2. Run: terraform init -upgrade
  3. Run: terraform apply (to ensure state is compatible)
  4. Re-run tf-migrate
```

### Testing

- All existing tests pass
- New unit tests cover version comparison, constraint parsing, and check logic
- Integration tests updated to use `--skip-version-check` (test fixtures don't have lock files)
- Manual testing verified:
  - Migration blocked when provider < 4.52.5
  - Clean error output (no help text clutter)
  - Migration proceeds normally when version check passes
  - `--skip-version-check` bypasses the check as expected

### Migration Path Impact

| Path | Version Check |
|------|---------------|
| v4 → v5 | ✅ Enforced |
| v5 → v5 | ❌ Skipped (not applicable) |

### Usage

```bash
# Normal migration - version check enforced
tf-migrate migrate --source-version v4 --target-version v5

# Skip version check (for testing/CI)
tf-migrate migrate --source-version v4 --target-version v5 --skip-version-check
```

---

**Commits:**
- `24755ea` feat: add minimum provider version check for v4→v5 migrations
- `08d13c2` fix: suppress help output for version check errors

---

