### PR TITLE
PR Description: Atlantis-Friendly Migration Improvements + Preflight Checks

### DIFF
--- a/cmd/tf-migrate/main.go
+++ b/cmd/tf-migrate/main.go
@@ -257,6 +257,30 @@ func runMigration(log hclog.Logger, cfg config) error {
 		fmt.Println()
 	}
 
+	// Run pre-migration scan to classify resources and detect issues.
+	if cfg.configDir != "" {
+		report, scanErr := runPreMigrationScan(log, cfg)
+		if scanErr != nil {
+			log.Warn("Pre-migration scan failed", "error", scanErr)
+		} else {
+			printPreflightReport(report, cfg)
+
+			// If there are warnings about conflicting moved blocks and we're in
+			// interactive mode, give the user a chance to abort.
+			if len(report.Warnings) > 0 && !cfg.skipPhaseCheck {
+				fmt.Print("Proceed with migration? [Y/n]: ")
+				var answer string
+				if _, err := fmt.Scanln(&answer); err == nil {
+					answer = strings.ToLower(strings.TrimSpace(answer))
+					if answer == "n" || answer == "no" {
+						fmt.Println("Migration aborted. Please resolve the warnings above and re-run tf-migrate.")
+						return nil
+					}
+				}
+			}
+		}
+	}
+
 	// --yes skips straight to full migration (used by e2e runner and CI).
 	if cfg.skipPhaseCheck {
 		return runFullMigration(log, cfg)
@@ -465,6 +489,16 @@ func updateProviderVersionConstraint(log hclog.Logger, cfg config, diags hcl.Dia
 
 	step := 1
 
+	// Remind users to apply with v4 first if they haven't already.
+	// This normalizes state for resources like cloudflare_ruleset where the v5
+	// provider's UpgradeResourceState has edge cases with older v4 state formats.
+	fmt.Printf("  %d. BEFORE upgrading: ensure you have run 'terraform apply' with\n", step)
+	fmt.Printf("     provider v%s on your current v4 config to normalize state.\n", minimumProviderVersion)
+	fmt.Println("     This prevents state deserialization errors during the v5 upgrade")
+	fmt.Println("     (especially for resources like cloudflare_ruleset).")
+	fmt.Println()
+	step++
+
 	// If there were any actionable warnings (DiagWarning), remind the user
 	// to address them before proceeding.
 	hasActionableWarnings := false
@@ -484,6 +518,15 @@ func updateProviderVersionConstraint(log hclog.Logger, cfg config, diags hcl.Dia
 	fmt.Printf("  %d. Regenerate the lock file locally:\n", step)
 	fmt.Printf("       cd %s\n", cfg.configDir)
 	fmt.Println("       terraform init -upgrade -backend=false")
+	fmt.Println()
+	step++
+
+	// Note about provider version and MoveState support
+	fmt.Printf("  %d. Verify the provider version supports MoveState for your resources.\n", step)
+	fmt.Printf("     tf-migrate set the version to %s. If you see errors about\n", targetVersion)
+	fmt.Println("     'Missing resource schema' or 'no schema available' during plan/apply,")
+	fmt.Println("     try upgrading to the latest beta release:")
+	fmt.Println("       https://github.com/cloudflare/terraform-provider-cloudflare/releases")
 	fmt.Println()
 	step++
 

--- a/cmd/tf-migrate/preflight.go
+++ b/cmd/tf-migrate/preflight.go
@@ -1,0 +1,356 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclwrite"
+
+	"github.com/cloudflare/tf-migrate/internal/transform"
+)
+
+// resourceClassification describes how a resource will be handled during migration.
+type resourceClassification int
+
+const (
+	// classAutoMigrated means the resource has a transformer and will be fully auto-migrated.
+	classAutoMigrated resourceClassification = iota
+	// classRenamed means the resource will be renamed and a moved block generated.
+	classRenamed
+	// classManualIntervention means the resource has a transformer but requires manual steps.
+	classManualIntervention
+	// classUnsupported means no transformer is registered for this resource type.
+	classUnsupported
+)
+
+// scannedResource holds information about a resource found during pre-migration scanning.
+type scannedResource struct {
+	File         string
+	ResourceType string
+	ResourceName string
+	Class        resourceClassification
+	OldType      string // only set for classRenamed
+	NewType      string // only set for classRenamed
+	Detail       string // human-readable detail for manual intervention / unsupported
+}
+
+// existingMovedBlock represents a hand-written moved block found in the user's config.
+type existingMovedBlock struct {
+	File     string
+	FromType string
+	FromName string
+	ToType   string
+	ToName   string
+}
+
+// preflightReport is the result of a pre-migration scan.
+type preflightReport struct {
+	Resources   []scannedResource
+	MovedBlocks []existingMovedBlock
+	Warnings    []string
+}
+
+// runPreMigrationScan scans all .tf files and classifies resources and detects
+// existing moved blocks. It prints a summary and returns warnings for any issues.
+func runPreMigrationScan(log hclog.Logger, cfg config) (*preflightReport, error) {
+	files, err := findTerraformFilesWithRecursion(cfg.configDir, cfg.recursive)
+	if err != nil {
+		return nil, fmt.Errorf("failed to find terraform files: %w", err)
+	}
+
+	providers := getProviders(cfg.resourcesToMigrate...)
+	report := &preflightReport{}
+
+	// Build rename map from all migrators (same logic as applyGlobalPostprocessing)
+	migrators := providers.GetAllMigrators(cfg.sourceVersion, cfg.targetVersion, cfg.resourcesToMigrate...)
+	renames := make(map[string]string) // old type -> new type
+	for _, migrator := range migrators {
+		if renamer, ok := migrator.(transform.ResourceRenamer); ok {
+			oldTypes, newType := renamer.GetResourceRename()
+			for _, oldType := range oldTypes {
+				if oldType != newType {
+					renames[oldType] = newType
+				}
+			}
+		}
+	}
+
+	for _, file := range files {
+		content, err := os.ReadFile(file)
+		if err != nil {
+			log.Warn("Failed to read file during pre-migration scan", "file", file, "error", err)
+			continue
+		}
+
+		parsed, diags := hclwrite.ParseConfig(content, filepath.Base(file), hcl.InitialPos)
+		if diags.HasErrors() {
+			log.Warn("Failed to parse file during pre-migration scan", "file", file, "error", diags)
+			continue
+		}
+
+		relFile := filepath.Base(file)
+
+		for _, block := range parsed.Body().Blocks() {
+			switch block.Type() {
+			case "resource":
+				if len(block.Labels()) < 2 {
+					continue
+				}
+				sr := classifyResource(block, relFile, providers, renames, cfg)
+				if sr != nil {
+					report.Resources = append(report.Resources, *sr)
+				}
+
+			case "moved":
+				mb := parseMovedBlock(block, relFile)
+				if mb != nil {
+					report.MovedBlocks = append(report.MovedBlocks, *mb)
+				}
+			}
+		}
+	}
+
+	// Check for conflicting moved blocks
+	report.Warnings = detectMovedBlockConflicts(report, renames)
+
+	return report, nil
+}
+
+// classifyResource determines how a resource will be handled during migration.
+func classifyResource(block *hclwrite.Block, file string, providers transform.MigrationProvider, renames map[string]string, cfg config) *scannedResource {
+	resourceType := block.Labels()[0]
+	resourceName := block.Labels()[1]
+
+	// Only scan cloudflare resources
+	if !strings.HasPrefix(resourceType, "cloudflare_") {
+		return nil
+	}
+
+	migrator := providers.GetMigrator(resourceType, cfg.sourceVersion, cfg.targetVersion)
+	if migrator == nil {
+		return &scannedResource{
+			File:         file,
+			ResourceType: resourceType,
+			ResourceName: resourceName,
+			Class:        classUnsupported,
+			Detail:       "no transformer registered -- manual migration required",
+		}
+	}
+
+	// Check if this resource will be renamed
+	if newType, ok := renames[resourceType]; ok {
+		return &scannedResource{
+			File:         file,
+			ResourceType: resourceType,
+			ResourceName: resourceName,
+			Class:        classRenamed,
+			OldType:      resourceType,
+			NewType:      newType,
+		}
+	}
+
+	// Resource has a transformer but no rename -- config-only changes
+	return &scannedResource{
+		File:         file,
+		ResourceType: resourceType,
+		ResourceName: resourceName,
+		Class:        classAutoMigrated,
+	}
+}
+
+// parseMovedBlock extracts from/to information from a moved block.
+func parseMovedBlock(block *hclwrite.Block, file string) *existingMovedBlock {
+	body := block.Body()
+
+	fromAttr := body.GetAttribute("from")
+	toAttr := body.GetAttribute("to")
+	if fromAttr == nil || toAttr == nil {
+		return nil
+	}
+
+	fromStr := extractTraversalString(fromAttr)
+	toStr := extractTraversalString(toAttr)
+	if fromStr == "" || toStr == "" {
+		return nil
+	}
+
+	fromParts := strings.SplitN(fromStr, ".", 2)
+	toParts := strings.SplitN(toStr, ".", 2)
+
+	// Only care about cloudflare resources
+	if !strings.HasPrefix(fromStr, "cloudflare_") && !strings.HasPrefix(toStr, "cloudflare_") {
+		return nil
+	}
+
+	mb := &existingMovedBlock{
+		File: file,
+	}
+	if len(fromParts) == 2 {
+		mb.FromType = fromParts[0]
+		mb.FromName = fromParts[1]
+	}
+	if len(toParts) == 2 {
+		mb.ToType = toParts[0]
+		mb.ToName = toParts[1]
+	}
+
+	return mb
+}
+
+// extractTraversalString extracts the string representation of a traversal attribute
+// (e.g., "cloudflare_access_application.admin_api" from `from = cloudflare_access_application.admin_api`).
+func extractTraversalString(attr *hclwrite.Attribute) string {
+	tokens := attr.Expr().BuildTokens(nil)
+	var parts []string
+	for _, tok := range tokens {
+		s := strings.TrimSpace(string(tok.Bytes))
+		if s != "" {
+			parts = append(parts, s)
+		}
+	}
+	return strings.Join(parts, "")
+}
+
+// detectMovedBlockConflicts checks for hand-written moved blocks that may conflict
+// with what tf-migrate would generate.
+func detectMovedBlockConflicts(report *preflightReport, renames map[string]string) []string {
+	var warnings []string
+
+	for _, mb := range report.MovedBlocks {
+		addr := mb.FromType + "." + mb.FromName
+
+		// Check if the from-type is a v4 name that tf-migrate would rename
+		if newType, ok := renames[mb.FromType]; ok {
+			if mb.ToType == newType {
+				// User's moved block matches what tf-migrate would generate -- duplicate
+				warnings = append(warnings, fmt.Sprintf(
+					"Pre-existing moved block in %s: %s → %s.%s\n"+
+						"  tf-migrate will generate this moved block automatically.\n"+
+						"  Consider removing it to avoid duplicates.",
+					mb.File, addr, mb.ToType, mb.ToName))
+			} else {
+				// User's moved block targets a different type than expected
+				warnings = append(warnings, fmt.Sprintf(
+					"Conflicting moved block in %s: %s → %s.%s\n"+
+						"  tf-migrate would rename %s to %s, not %s.\n"+
+						"  Please remove or correct this moved block before proceeding.",
+					mb.File, addr, mb.ToType, mb.ToName,
+					mb.FromType, newType, mb.ToType))
+			}
+		}
+
+		// Check if from-type doesn't exist in v5 provider at all and has no transformer
+		if _, ok := renames[mb.FromType]; !ok {
+			// Not a known rename -- check if it's even a cloudflare type
+			if strings.HasPrefix(mb.FromType, "cloudflare_") {
+				// Check if this type has any migrator registered
+				found := false
+				for _, r := range report.Resources {
+					if r.ResourceType == mb.FromType {
+						found = true
+						break
+					}
+				}
+				if !found {
+					// The moved block references a type that has no resources in config
+					// This could be a stale moved block or a cross-module reference
+					warnings = append(warnings, fmt.Sprintf(
+						"Moved block in %s references %s which has no matching resource in config.\n"+
+							"  Verify this moved block is still needed.",
+						mb.File, addr))
+				}
+			}
+		}
+	}
+
+	return warnings
+}
+
+// printPreflightReport prints the pre-migration scan results to stdout.
+func printPreflightReport(report *preflightReport, cfg config) {
+	if len(report.Resources) == 0 && len(report.MovedBlocks) == 0 {
+		return
+	}
+
+	var renamed, autoMigrated, manual, unsupported []scannedResource
+	for _, r := range report.Resources {
+		switch r.Class {
+		case classRenamed:
+			renamed = append(renamed, r)
+		case classAutoMigrated:
+			autoMigrated = append(autoMigrated, r)
+		case classManualIntervention:
+			manual = append(manual, r)
+		case classUnsupported:
+			unsupported = append(unsupported, r)
+		}
+	}
+
+	fmt.Println()
+	fmt.Println("Pre-migration scan:")
+	fmt.Printf("  %d Cloudflare resource(s) found\n", len(report.Resources))
+	fmt.Println()
+
+	if len(renamed) > 0 {
+		fmt.Printf("  Resources with type rename + moved block (%d):\n", len(renamed))
+		for _, r := range renamed {
+			fmt.Printf("    %s.%s → %s.%s\n", r.OldType, r.ResourceName, r.NewType, r.ResourceName)
+		}
+		fmt.Println()
+		fmt.Println("  IMPORTANT: Moved blocks require the v5 provider to support MoveState for")
+		fmt.Println("  each resource. Ensure you use the provider version set by tf-migrate")
+		fmt.Println("  (including beta releases if applicable).")
+		fmt.Println()
+	}
+
+	if len(autoMigrated) > 0 && cfg.verbose {
+		fmt.Printf("  Resources with config-only changes (%d):\n", len(autoMigrated))
+		for _, r := range autoMigrated {
+			fmt.Printf("    %s.%s\n", r.ResourceType, r.ResourceName)
+		}
+		fmt.Println()
+	} else if len(autoMigrated) > 0 {
+		fmt.Printf("  %d resource(s) with config-only changes (no rename)\n", len(autoMigrated))
+	}
+
+	if len(manual) > 0 {
+		fmt.Printf("  ⚠ Resources requiring manual intervention (%d):\n", len(manual))
+		for _, r := range manual {
+			fmt.Printf("    %s.%s: %s\n", r.ResourceType, r.ResourceName, r.Detail)
+		}
+		fmt.Println()
+	}
+
+	if len(unsupported) > 0 {
+		fmt.Printf("  ⚠ Unsupported resources -- no transformer registered (%d):\n", len(unsupported))
+		for _, r := range unsupported {
+			fmt.Printf("    %s.%s\n", r.ResourceType, r.ResourceName)
+		}
+		fmt.Println("  These resources must be migrated manually. Check the v5 migration guide:")
+		fmt.Println("  https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/guides/version-5-upgrade")
+		fmt.Println()
+	}
+
+	if len(report.MovedBlocks) > 0 {
+		fmt.Printf("  Existing moved blocks found (%d):\n", len(report.MovedBlocks))
+		for _, mb := range report.MovedBlocks {
+			fmt.Printf("    %s: %s.%s → %s.%s\n", mb.File, mb.FromType, mb.FromName, mb.ToType, mb.ToName)
+		}
+		fmt.Println()
+	}
+
+	// Print warnings
+	if len(report.Warnings) > 0 {
+		fmt.Println("  ⚠ Warnings:")
+		for _, w := range report.Warnings {
+			for _, line := range strings.Split(w, "\n") {
+				fmt.Printf("    %s\n", line)
+			}
+			fmt.Println()
+		}
+	}
+}

--- a/cmd/tf-migrate/preflight_test.go
+++ b/cmd/tf-migrate/preflight_test.go
@@ -1,0 +1,308 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/hashicorp/go-hclog"
+
+	"github.com/cloudflare/tf-migrate/internal/registry"
+)
+
+func init() {
+	// Ensure all resource migrations are registered for tests
+	registry.RegisterAllMigrations()
+}
+
+func TestRunPreMigrationScan_ClassifiesResources(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Write a .tf file with a mix of resource types
+	content := `
+resource "cloudflare_access_application" "admin_api" {
+  account_id = "abc123"
+  name       = "Admin API"
+  type       = "self_hosted"
+}
+
+resource "cloudflare_ruleset" "rate_limit" {
+  zone_id = "abc123"
+  name    = "Rate Limit"
+  kind    = "zone"
+  phase   = "http_ratelimit"
+}
+
+resource "cloudflare_dns_record" "root_a" {
+  zone_id = "abc123"
+  name    = "example.com"
+  type    = "A"
+  value   = "192.0.2.1"
+}
+
+resource "aws_s3_bucket" "logs" {
+  bucket = "my-logs"
+}
+`
+	err := os.WriteFile(filepath.Join(tmpDir, "main.tf"), []byte(content), 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	log := hclog.NewNullLogger()
+	cfg := config{
+		configDir:     tmpDir,
+		sourceVersion: "v4",
+		targetVersion: "v5",
+	}
+
+	report, err := runPreMigrationScan(log, cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Should NOT include the aws_s3_bucket (not a cloudflare resource)
+	for _, r := range report.Resources {
+		if r.ResourceType == "aws_s3_bucket" {
+			t.Error("Non-cloudflare resource should not be included in scan")
+		}
+	}
+
+	// Should find cloudflare resources
+	if len(report.Resources) == 0 {
+		t.Fatal("Expected to find cloudflare resources")
+	}
+
+	// Check that access_application is classified as renamed
+	found := false
+	for _, r := range report.Resources {
+		if r.ResourceType == "cloudflare_access_application" {
+			found = true
+			if r.Class != classRenamed {
+				t.Errorf("Expected access_application to be classRenamed, got %d", r.Class)
+			}
+			if r.NewType != "cloudflare_zero_trust_access_application" {
+				t.Errorf("Expected new type cloudflare_zero_trust_access_application, got %s", r.NewType)
+			}
+		}
+	}
+	if !found {
+		t.Error("Expected to find cloudflare_access_application in scan results")
+	}
+}
+
+func TestRunPreMigrationScan_DetectsMovedBlocks(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Write a main.tf with a resource
+	mainContent := `
+resource "cloudflare_access_application" "admin_api" {
+  account_id = "abc123"
+  name       = "Admin API"
+}
+`
+	err := os.WriteFile(filepath.Join(tmpDir, "main.tf"), []byte(mainContent), 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Write a moved.tf with hand-written moved blocks
+	movedContent := `
+moved {
+  from = cloudflare_access_application.admin_api
+  to   = cloudflare_zero_trust_access_application.admin_api
+}
+
+moved {
+  from = cloudflare_record.root_a
+  to   = cloudflare_dns_record.root_a
+}
+`
+	err = os.WriteFile(filepath.Join(tmpDir, "moved.tf"), []byte(movedContent), 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	log := hclog.NewNullLogger()
+	cfg := config{
+		configDir:     tmpDir,
+		sourceVersion: "v4",
+		targetVersion: "v5",
+	}
+
+	report, err := runPreMigrationScan(log, cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(report.MovedBlocks) != 2 {
+		t.Fatalf("Expected 2 moved blocks, got %d", len(report.MovedBlocks))
+	}
+
+	// Should have a warning about the duplicate moved block for access_application
+	if len(report.Warnings) == 0 {
+		t.Error("Expected warnings about pre-existing moved blocks")
+	}
+
+	foundDuplicateWarning := false
+	for _, w := range report.Warnings {
+		if contains(w, "tf-migrate will generate this moved block automatically") {
+			foundDuplicateWarning = true
+		}
+	}
+	if !foundDuplicateWarning {
+		t.Errorf("Expected warning about duplicate moved block, got warnings: %v", report.Warnings)
+	}
+}
+
+func TestDetectMovedBlockConflicts_DuplicateMovedBlock(t *testing.T) {
+	renames := map[string]string{
+		"cloudflare_access_application": "cloudflare_zero_trust_access_application",
+	}
+
+	report := &preflightReport{
+		MovedBlocks: []existingMovedBlock{
+			{
+				File:     "moved.tf",
+				FromType: "cloudflare_access_application",
+				FromName: "admin_api",
+				ToType:   "cloudflare_zero_trust_access_application",
+				ToName:   "admin_api",
+			},
+		},
+	}
+
+	warnings := detectMovedBlockConflicts(report, renames)
+	if len(warnings) != 1 {
+		t.Fatalf("Expected 1 warning, got %d: %v", len(warnings), warnings)
+	}
+	if !contains(warnings[0], "tf-migrate will generate this moved block automatically") {
+		t.Errorf("Unexpected warning: %s", warnings[0])
+	}
+}
+
+func TestDetectMovedBlockConflicts_ConflictingTarget(t *testing.T) {
+	renames := map[string]string{
+		"cloudflare_access_application": "cloudflare_zero_trust_access_application",
+	}
+
+	report := &preflightReport{
+		MovedBlocks: []existingMovedBlock{
+			{
+				File:     "moved.tf",
+				FromType: "cloudflare_access_application",
+				FromName: "admin_api",
+				ToType:   "cloudflare_wrong_type",
+				ToName:   "admin_api",
+			},
+		},
+	}
+
+	warnings := detectMovedBlockConflicts(report, renames)
+	if len(warnings) != 1 {
+		t.Fatalf("Expected 1 warning, got %d: %v", len(warnings), warnings)
+	}
+	if !contains(warnings[0], "Conflicting moved block") {
+		t.Errorf("Expected conflicting moved block warning, got: %s", warnings[0])
+	}
+}
+
+func TestDetectMovedBlockConflicts_NoConflict(t *testing.T) {
+	renames := map[string]string{
+		"cloudflare_access_application": "cloudflare_zero_trust_access_application",
+	}
+
+	// A moved block for a non-renamed resource (no conflict)
+	report := &preflightReport{
+		MovedBlocks: []existingMovedBlock{
+			{
+				File:     "moved.tf",
+				FromType: "cloudflare_custom_resource",
+				FromName: "example",
+				ToType:   "cloudflare_custom_resource_v2",
+				ToName:   "example",
+			},
+		},
+		Resources: []scannedResource{
+			{
+				ResourceType: "cloudflare_custom_resource",
+				ResourceName: "example",
+			},
+		},
+	}
+
+	warnings := detectMovedBlockConflicts(report, renames)
+	if len(warnings) != 0 {
+		t.Errorf("Expected no warnings, got %d: %v", len(warnings), warnings)
+	}
+}
+
+func TestClassifyResource_UnsupportedResource(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Write a .tf file with a made-up cloudflare resource type
+	content := `
+resource "cloudflare_nonexistent_resource" "test" {
+  name = "test"
+}
+`
+	err := os.WriteFile(filepath.Join(tmpDir, "main.tf"), []byte(content), 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	log := hclog.NewNullLogger()
+	cfg := config{
+		configDir:     tmpDir,
+		sourceVersion: "v4",
+		targetVersion: "v5",
+	}
+
+	report, err := runPreMigrationScan(log, cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(report.Resources) != 1 {
+		t.Fatalf("Expected 1 resource, got %d", len(report.Resources))
+	}
+	if report.Resources[0].Class != classUnsupported {
+		t.Errorf("Expected classUnsupported, got %d", report.Resources[0].Class)
+	}
+}
+
+func TestRunPreMigrationScan_EmptyDirectory(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	log := hclog.NewNullLogger()
+	cfg := config{
+		configDir:     tmpDir,
+		sourceVersion: "v4",
+		targetVersion: "v5",
+	}
+
+	report, err := runPreMigrationScan(log, cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(report.Resources) != 0 {
+		t.Errorf("Expected 0 resources, got %d", len(report.Resources))
+	}
+	if len(report.MovedBlocks) != 0 {
+		t.Errorf("Expected 0 moved blocks, got %d", len(report.MovedBlocks))
+	}
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && searchString(s, substr)
+}
+
+func searchString(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/integration/v4_to_v5/testdata/zero_trust_access_policy/expected/zero_trust_access_policy.tf
+++ b/integration/v4_to_v5/testdata/zero_trust_access_policy/expected/zero_trust_access_policy.tf
@@ -79,20 +79,6 @@ resource "cloudflare_zero_trust_access_application" "test_app" {
   http_only_cookie_attribute = "false"
 }
 
-resource "cloudflare_access_policy" "app_scoped_policy" {
-  account_id       = var.cloudflare_account_id
-  application_id   = cloudflare_zero_trust_access_application.test_app.id
-  name             = "${local.name_prefix}-app-scoped"
-  decision         = "non_identity"
-  precedence       = 1
-  session_duration = "18h"
-
-  include {
-    service_token = [
-      cloudflare_zero_trust_access_service_token.test_token.id,
-    ]
-  }
-}
 
 # ============================================================================
 # BUGS-2006: Already-v5-named resources with block syntax not converted
@@ -605,6 +591,13 @@ resource "cloudflare_zero_trust_access_policy" "combined_research_team_policy" {
 moved {
   from = cloudflare_access_policy.combined_research_team_policy
   to   = cloudflare_zero_trust_access_policy.combined_research_team_policy
+}
+
+removed {
+  from = cloudflare_access_policy.app_scoped_policy
+  lifecycle {
+    destroy = false
+  }
 }
 
 # BUGS-2007: nested and list selector migrations

--- a/internal/resources/zero_trust_access_policy/v4_to_v5.go
+++ b/internal/resources/zero_trust_access_policy/v4_to_v5.go
@@ -62,6 +62,9 @@ func (m *V4ToV5Migrator) TransformConfig(ctx *transform.Context, block *hclwrite
 	// These cannot be automatically migrated - they use a different API endpoint
 	// and must be converted to inline policies in cloudflare_zero_trust_access_application
 	if originalResourceType == "cloudflare_access_policy" && body.GetAttribute("application_id") != nil {
+		// Generate a removed block for Atlantis-friendly state cleanup
+		removedBlock := tfhcl.CreateRemovedBlock("cloudflare_access_policy." + resourceName)
+
 		ctx.Diagnostics = append(ctx.Diagnostics, &hcl.Diagnostic{
 			Severity: hcl.DiagWarning,
 			Summary:  "Application-scoped access policy cannot be automatically migrated",
@@ -69,17 +72,18 @@ func (m *V4ToV5Migrator) TransformConfig(ctx *transform.Context, block *hclwrite
 				"Resource cloudflare_access_policy.%s has 'application_id' and cannot be automatically migrated to v5.\n\n"+
 					"Application-scoped policies use a different API endpoint than account-level policies. "+
 					"In v5, these must be converted to inline policies within cloudflare_zero_trust_access_application.\n\n"+
+					"A 'removed' block has been generated to drop this resource from state without destroying it.\n\n"+
 					"Manual steps required:\n"+
-					"1. Remove this resource from state: terraform state rm cloudflare_access_policy.%s\n"+
-					"2. Add the policy inline in the application's 'policies' attribute\n"+
+					"1. Review the generated 'removed' block\n"+
+					"2. Add this policy inline in the application's 'policies' attribute\n"+
 					"3. Run terraform apply\n\n"+
 					"See: https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/guides/version-5-upgrade#cloudflare_access_policy",
-				resourceName, resourceName),
+				resourceName),
 		})
-		// Return original block unchanged, no moved block
+		// Return removed block and remove original resource from config
 		return &transform.TransformResult{
-			Blocks:         []*hclwrite.Block{block},
-			RemoveOriginal: false,
+			Blocks:         []*hclwrite.Block{removedBlock},
+			RemoveOriginal: true,
 		}, nil
 	}
 

--- a/internal/resources/zero_trust_access_policy/v4_to_v5_test.go
+++ b/internal/resources/zero_trust_access_policy/v4_to_v5_test.go
@@ -680,21 +680,32 @@ resource "cloudflare_access_policy" "test" {
 		t.Fatalf("TransformConfig returned error: %v", err)
 	}
 
-	// Should return the original block unchanged (no transformation, no moved block)
+	// Should return a removed block and RemoveOriginal should be true
 	if result == nil {
 		t.Fatal("Expected non-nil result")
 	}
 	if len(result.Blocks) != 1 {
-		t.Errorf("Expected 1 block (original only), got %d", len(result.Blocks))
+		t.Errorf("Expected 1 block (removed block), got %d", len(result.Blocks))
 	}
-	if result.RemoveOriginal {
-		t.Error("Expected RemoveOriginal to be false")
+	if !result.RemoveOriginal {
+		t.Error("Expected RemoveOriginal to be true")
 	}
 
-	// Block should still be cloudflare_access_policy (not renamed)
-	labels := result.Blocks[0].Labels()
-	if len(labels) < 1 || labels[0] != "cloudflare_access_policy" {
-		t.Errorf("Expected resource type to remain 'cloudflare_access_policy', got %v", labels)
+	// Block should be a "removed" block
+	if result.Blocks[0].Type() != "removed" {
+		t.Errorf("Expected block type 'removed', got '%s'", result.Blocks[0].Type())
+	}
+
+	// The removed block should have the correct "from" attribute
+	removedBody := result.Blocks[0].Body()
+	fromAttr := removedBody.GetAttribute("from")
+	if fromAttr == nil {
+		t.Error("Expected removed block to have 'from' attribute")
+	} else {
+		fromExpr := string(fromAttr.Expr().BuildTokens(nil).Bytes())
+		if !strings.Contains(fromExpr, "cloudflare_access_policy.test") {
+			t.Errorf("Expected 'from' to reference cloudflare_access_policy.test, got: %s", fromExpr)
+		}
 	}
 
 	// Should have a warning diagnostic

--- a/internal/resources/zero_trust_split_tunnel/v4_to_v5.go
+++ b/internal/resources/zero_trust_split_tunnel/v4_to_v5.go
@@ -37,12 +37,14 @@ func (m *V4ToV5Migrator) Preprocess(content string) string {
 	return content
 }
 
-// TransformConfig does nothing - removal is handled by ProcessCrossResourceConfigMigration.
+// TransformConfig generates a removed block for Atlantis-friendly state cleanup.
 // The device profile migrator calls ProcessCrossResourceConfigMigration which merges
-// split tunnels into profiles and removes the split_tunnel blocks.
-// We return RemoveOriginal=false because the cross-resource handler manages removal.
+// split tunnels into profiles and removes the split_tunnel blocks from config.
 func (m *V4ToV5Migrator) TransformConfig(ctx *transform.Context, block *hclwrite.Block) (*transform.TransformResult, error) {
 	resourceName := tfhcl.GetResourceName(block)
+
+	// Generate removed block for Atlantis-friendly state cleanup
+	removedBlock := tfhcl.CreateRemovedBlock("cloudflare_split_tunnel." + resourceName)
 
 	// Add warning about resource removal
 	ctx.Diagnostics = append(ctx.Diagnostics, &hcl.Diagnostic{
@@ -55,13 +57,12 @@ Split tunnel configuration is now managed directly within device profile resourc
   - cloudflare_zero_trust_device_custom_profile.exclude/include
 
 The migrator will attempt to merge split_tunnel entries into associated device profiles.
-After migration, remove the old state:
-  terraform state rm cloudflare_split_tunnel.` + resourceName,
+A 'removed' block has been generated to drop this resource from state without destroying it.`,
 	})
 
-	// Don't mark for removal - ProcessCrossResourceConfigMigration handles it
+	// Return removed block - ProcessCrossResourceConfigMigration handles config removal
 	return &transform.TransformResult{
-		Blocks:         nil,
+		Blocks:         []*hclwrite.Block{removedBlock},
 		RemoveOriginal: false,
 	}, nil
 }


### PR DESCRIPTION
This PR makes the Cloudflare Terraform v4→v5 migration **Atlantis-friendly** by replacing manual `terraform state rm` instructions with automatically-generated `removed {}` blocks. It also introduces a **pre-migration scanning feature** that detects potential issues before migration starts.

### Changes

#### 1. `zero_trust_access_policy` - Generate `removed` blocks for application-scoped policies

**Problem:** Application-scoped access policies (with `application_id`) cannot be automatically migrated to v5 - they must be converted to inline policies within `cloudflare_zero_trust_access_application`. The previous implementation only warned users to manually run `terraform state rm`, which doesn't work in Atlantis.

**Solution:** 
- Generate a `removed {}` block automatically:
  ```hcl
  removed {
    from = cloudflare_access_policy.<name>
    lifecycle {
      destroy = false
    }
  }
  ```
- Remove the original resource from config (`RemoveOriginal: true`)
- Update warning message to mention the generated block

**User-facing change:**
```
Before: "Remove this resource from state: terraform state rm cloudflare_access_policy.xxx"
After:  "A 'removed' block has been generated to drop this resource from state without destroying it."
```

---

#### 2. `zero_trust_split_tunnel` - Generate `removed` blocks for merged resources

**Problem:** The `cloudflare_split_tunnel` resource is removed in v5 and merged into device profile resources. Previously users were instructed to run `terraform state rm` manually.

**Solution:**
- Generate `removed {}` blocks for each split_tunnel resource
- Keep `RemoveOriginal: false` since `ProcessCrossResourceConfigMigration` handles config removal

---

#### 3. Preflight Check - Pre-migration scanning and conflict detection

**New Feature:** A pre-migration scan runs before migration to classify resources and detect issues.

**Capabilities:**
- **Resource Classification:**
  - `Renamed` - Will get a moved block (e.g., `cloudflare_access_application` → `cloudflare_zero_trust_access_application`)
  - `Config-only` - Attribute/block changes only
  - `Unsupported` - No transformer available

- **Moved Block Conflict Detection:**
  - **Duplicates:** Warn if user already wrote a moved block that tf-migrate would generate
  - **Conflicts:** Warn if user's moved block targets a different type than expected
  - **Stale blocks:** Warn if moved block references non-existent resources

- **Interactive Prompt:** If warnings are found in interactive mode, users can abort and fix issues.

**Example Output:**
```
Pre-migration scan:
  15 Cloudflare resource(s) found

  Resources with type rename + moved block (5):
    cloudflare_access_application.admin_api → cloudflare_zero_trust_access_application.admin_api
    ...

  8 resource(s) with config-only changes (no rename)

  ⚠ Warnings:
    Pre-existing moved block in moved.tf: cloudflare_access_application.admin_api → cloudflare_zero_trust_access_application.admin_api
      tf-migrate will generate this moved block automatically.
      Consider removing it to avoid duplicates.

Proceed with migration? [Y/n]:
```

---

#### 4. Improved "Next Steps" Output

Added helpful reminders to the post-migration instructions:
1. Remind users to apply with v4 first to normalize state (prevents `cloudflare_ruleset` deserialization errors)
2. Note about provider version and MoveState support with link to beta releases

---

### Testing

- All existing tests pass
- Added 7 new tests for preflight functionality:
  - `TestRunPreMigrationScan_ClassifiesResources`
  - `TestRunPreMigrationScan_DetectsMovedBlocks`
  - `TestDetectMovedBlockConflicts_DuplicateMovedBlock`
  - `TestDetectMovedBlockConflicts_ConflictingTarget`
  - `TestDetectMovedBlockConflicts_NoConflict`
  - `TestClassifyResource_UnsupportedResource`
  - `TestRunPreMigrationScan_EmptyDirectory`

### Migration Impact

| Before | After |
|--------|-------|
| Users had to run `terraform state rm` manually | `removed {}` blocks generated automatically |
| Atlantis users couldn't migrate split_tunnel or app-scoped policies | Atlantis-friendly - no manual state commands needed |
| No visibility into what would happen before migration | Clear pre-migration report with resource classification |
| Conflicting moved blocks caused failures during migration | Conflicts detected and reported before migration starts |

### Files Changed

- `internal/resources/zero_trust_access_policy/v4_to_v5.go` - Generate removed blocks
- `internal/resources/zero_trust_access_policy/v4_to_v5_test.go` - Update tests
- `internal/resources/zero_trust_split_tunnel/v4_to_v5.go` - Generate removed blocks
- `cmd/tf-migrate/preflight.go` - New preflight scan feature
- `cmd/tf-migrate/preflight_test.go` - Preflight tests
- `cmd/tf-migrate/main.go` - Integration and improved messaging
- `integration/v4_to_v5/testdata/zero_trust_access_policy/expected/*.tf` - Update expected output

---

