### PR TITLE
Bug Fix for session_duration + Drift Exemptions

### DIFF
--- a/e2e/drift-exemptions/dns_record.yaml
+++ b/e2e/drift-exemptions/dns_record.yaml
@@ -1,0 +1,21 @@
+# Drift Exemptions for dns_record resource
+
+version: 1
+
+exemptions:
+  # DNS record name case normalization in v5
+  # The v5 provider normalizes DNS record names to uppercase for certain
+  # record types (like CNAME/TXT with underscore prefixes). This causes
+  # a one-time drift where lowercase names become uppercase.
+  # This is expected provider behavior, not a migration issue.
+  - name: "dns_name_case_normalization"
+    description: "DNS record names are normalized to uppercase by the v5 provider for certain record types. This is expected provider behavior that resolves after apply."
+    resource_types:
+      - "cloudflare_dns_record"
+    patterns:
+      - '~ name.*=.*"_[a-f0-9]+.*" -> "_[A-F0-9]+'
+    enabled: true
+
+settings:
+  apply_exemptions: true
+  verbose_exemptions: false

--- a/e2e/drift-exemptions/zero_trust_access_application.yaml
+++ b/e2e/drift-exemptions/zero_trust_access_application.yaml
@@ -1,0 +1,26 @@
+# Drift Exemptions for zero_trust_access_application resource
+
+version: 1
+
+exemptions:
+  # Inline policy normalization in v5
+  # When reusable policies are referenced by ID in the application's policies array,
+  # the v5 provider normalizes them to only store 'id' and 'precedence'. The other
+  # fields (decision, name, include, exclude, require) are intentionally cleared
+  # because the full policy definition lives in the separate access_policy resource.
+  # This is expected behavior, not a migration issue.
+  - name: "inline_policy_normalization"
+    description: "Inline policies are normalized to only id/precedence when referencing reusable policies. The full policy definition is in the separate cloudflare_zero_trust_access_policy resource. This is expected v5 behavior."
+    resource_types:
+      - "cloudflare_zero_trust_access_application"
+    patterns:
+      - '- decision.*=.*-> null'
+      - '- exclude.*=.*-> null'
+      - '- include.*=.*-> null'
+      - '- name.*=.*-> null'
+      - '- require.*=.*-> null'
+    enabled: true
+
+settings:
+  apply_exemptions: true
+  verbose_exemptions: false

--- a/e2e/drift-exemptions/zero_trust_access_policy.yaml
+++ b/e2e/drift-exemptions/zero_trust_access_policy.yaml
@@ -3,19 +3,17 @@
 version: 1
 
 exemptions:
-  # session_duration was a valid v4 policy attribute but is removed in v5.
-  # tf-migrate correctly drops it from the migrated config. The API then
-  # normalizes it to the default "24h". If the v4 config used a non-default
-  # value (e.g. "18h"), the first v5 plan shows a change back to "24h".
-  # This is a one-time drift that resolves after the first terraform apply.
+  # NOTE: session_duration_normalization exemption removed as the bug is fixed.
+  # tf-migrate now correctly preserves session_duration during migration.
+  # The exemption is kept here (disabled) for historical reference.
   - name: "session_duration_normalization"
-    description: "session_duration was removed from v5 access policies. The API normalizes it to '24h' (default). One-time drift that resolves after apply."
+    description: "DEPRECATED: tf-migrate now preserves session_duration. This exemption is no longer needed."
     resource_types:
       - "cloudflare_zero_trust_access_policy"
     patterns:
       - '~ session_duration\s*='
       - 'session_duration.*->.*"24h"'
-    enabled: true
+    enabled: false
 
 settings:
   apply_exemptions: true

--- a/integration/v4_to_v5/testdata/zero_trust_access_policy/expected/zero_trust_access_policy.tf
+++ b/integration/v4_to_v5/testdata/zero_trust_access_policy/expected/zero_trust_access_policy.tf
@@ -124,9 +124,10 @@ resource "cloudflare_zero_trust_access_policy" "bugs2006_everyone" {
 
 # Basic test cases
 resource "cloudflare_zero_trust_access_policy" "example" {
-  account_id = var.cloudflare_account_id
-  name       = "${local.name_prefix}-example-policy"
-  decision   = "allow"
+  account_id       = var.cloudflare_account_id
+  name             = "${local.name_prefix}-example-policy"
+  decision         = "allow"
+  session_duration = "24h"
 
 
   approval_groups = [{
@@ -142,9 +143,10 @@ moved {
 }
 
 resource "cloudflare_zero_trust_access_policy" "complex" {
-  account_id = var.cloudflare_account_id
-  name       = "${local.name_prefix}-complex-policy"
-  decision   = "allow"
+  account_id       = var.cloudflare_account_id
+  name             = "${local.name_prefix}-complex-policy"
+  decision         = "allow"
+  session_duration = "24h"
 
 
 
@@ -178,9 +180,10 @@ resource "cloudflare_zero_trust_access_policy" "map_example" {
     }
   }
 
-  account_id = var.cloudflare_account_id
-  name       = "${local.name_prefix}-map-${each.key}-policy"
-  decision   = each.value.decision
+  account_id       = var.cloudflare_account_id
+  name             = "${local.name_prefix}-map-${each.key}-policy"
+  decision         = each.value.decision
+  session_duration = "24h"
 
   include = [{ email = { email = "@example.com" } }]
 }
@@ -194,9 +197,10 @@ moved {
 resource "cloudflare_zero_trust_access_policy" "set_example" {
   for_each = toset(["alpha", "beta", "gamma", "delta", "epsilon"])
 
-  account_id = var.cloudflare_account_id
-  name       = "${local.name_prefix}-set-${each.key}"
-  decision   = "allow"
+  account_id       = var.cloudflare_account_id
+  name             = "${local.name_prefix}-set-${each.key}"
+  decision         = "allow"
+  session_duration = "24h"
 
   include = [{ email = { email = "@example.com" } }]
 }
@@ -210,9 +214,10 @@ moved {
 resource "cloudflare_zero_trust_access_policy" "counted" {
   count = 3
 
-  account_id = var.cloudflare_account_id
-  name       = "${local.name_prefix}-counted-${count.index}"
-  decision   = "allow"
+  account_id       = var.cloudflare_account_id
+  name             = "${local.name_prefix}-counted-${count.index}"
+  decision         = "allow"
+  session_duration = "24h"
 
   include = [{ ip = { ip = "10.0.${count.index}.0/24" } }]
 }
@@ -226,9 +231,10 @@ moved {
 resource "cloudflare_zero_trust_access_policy" "conditional_enabled" {
   count = local.enable_test ? 1 : 0
 
-  account_id = var.cloudflare_account_id
-  name       = "${local.name_prefix}-conditional-enabled"
-  decision   = "allow"
+  account_id       = var.cloudflare_account_id
+  name             = "${local.name_prefix}-conditional-enabled"
+  decision         = "allow"
+  session_duration = "24h"
 
   include = [{ everyone = {} }]
 }
@@ -241,9 +247,10 @@ moved {
 resource "cloudflare_zero_trust_access_policy" "conditional_disabled" {
   count = local.enable_demo ? 1 : 0
 
-  account_id = var.cloudflare_account_id
-  name       = "${local.name_prefix}-conditional-disabled"
-  decision   = "deny"
+  account_id       = var.cloudflare_account_id
+  name             = "${local.name_prefix}-conditional-disabled"
+  decision         = "deny"
+  session_duration = "24h"
 
   include = [{ everyone = {} }]
 }
@@ -255,9 +262,10 @@ moved {
 
 # Pattern Group 6: Terraform Functions
 resource "cloudflare_zero_trust_access_policy" "with_functions" {
-  account_id = var.cloudflare_account_id
-  name       = join("-", [local.name_prefix, "functions", "test"])
-  decision   = "allow"
+  account_id       = var.cloudflare_account_id
+  name             = join("-", [local.name_prefix, "functions", "test"])
+  decision         = "allow"
+  session_duration = "24h"
 
   include = [{ email = { email = "function1@example.com" } },
   { email = { email = "function2@example.com" } }]
@@ -270,9 +278,10 @@ moved {
 
 # Pattern Group 7: Lifecycle Meta-Arguments
 resource "cloudflare_zero_trust_access_policy" "with_lifecycle" {
-  account_id = var.cloudflare_account_id
-  name       = "${local.name_prefix}-lifecycle-test"
-  decision   = "allow"
+  account_id       = var.cloudflare_account_id
+  name             = "${local.name_prefix}-lifecycle-test"
+  decision         = "allow"
+  session_duration = "24h"
 
   lifecycle {
     create_before_destroy = true
@@ -288,9 +297,10 @@ moved {
 }
 
 resource "cloudflare_zero_trust_access_policy" "with_prevent_destroy" {
-  account_id = var.cloudflare_account_id
-  name       = "${local.name_prefix}-prevent-destroy"
-  decision   = "allow"
+  account_id       = var.cloudflare_account_id
+  name             = "${local.name_prefix}-prevent-destroy"
+  decision         = "allow"
+  session_duration = "24h"
 
   lifecycle {
     prevent_destroy = false
@@ -306,9 +316,10 @@ moved {
 
 # Minimal resource (only required fields)
 resource "cloudflare_zero_trust_access_policy" "minimal" {
-  account_id = var.cloudflare_account_id
-  name       = "${local.name_prefix}-minimal"
-  decision   = "allow"
+  account_id       = var.cloudflare_account_id
+  name             = "${local.name_prefix}-minimal"
+  decision         = "allow"
+  session_duration = "24h"
 
   include = [{ everyone = {} }]
 }
@@ -320,9 +331,10 @@ moved {
 
 # Maximal resource (all optional fields populated)
 resource "cloudflare_zero_trust_access_policy" "maximal" {
-  account_id = var.cloudflare_account_id
-  name       = "${local.name_prefix}-maximal"
-  decision   = "allow"
+  account_id       = var.cloudflare_account_id
+  name             = "${local.name_prefix}-maximal"
+  decision         = "allow"
+  session_duration = "24h"
 
 
 
@@ -349,9 +361,10 @@ moved {
 
 # Policy with common_name
 resource "cloudflare_zero_trust_access_policy" "with_common_name" {
-  account_id = var.cloudflare_account_id
-  name       = "${local.name_prefix}-common-name"
-  decision   = "allow"
+  account_id       = var.cloudflare_account_id
+  name             = "${local.name_prefix}-common-name"
+  decision         = "allow"
+  session_duration = "24h"
 
   include = [{ common_name = { common_name = "device1.example.com" } }]
 }
@@ -363,9 +376,10 @@ moved {
 
 # Policy with common_names overflow array
 resource "cloudflare_zero_trust_access_policy" "with_common_names" {
-  account_id = var.cloudflare_account_id
-  name       = "${local.name_prefix}-common-names"
-  decision   = "allow"
+  account_id       = var.cloudflare_account_id
+  name             = "${local.name_prefix}-common-names"
+  decision         = "allow"
+  session_duration = "24h"
 
   include = [{ common_name = { common_name = "device2.example.com" } },
   { common_name = { common_name = "device3.example.com" } }]
@@ -378,9 +392,10 @@ moved {
 
 # Policy with connection_rules ssh structure (BUGS-2012)
 resource "cloudflare_zero_trust_access_policy" "with_connection_rules" {
-  account_id = var.cloudflare_account_id
-  name       = "${local.name_prefix}-connection-rules"
-  decision   = "allow"
+  account_id       = var.cloudflare_account_id
+  name             = "${local.name_prefix}-connection-rules"
+  decision         = "allow"
+  session_duration = "24h"
 
 
   connection_rules = {
@@ -399,9 +414,10 @@ moved {
 
 # Policy with auth_method
 resource "cloudflare_zero_trust_access_policy" "with_auth_method" {
-  account_id = var.cloudflare_account_id
-  name       = "${local.name_prefix}-auth-method"
-  decision   = "allow"
+  account_id       = var.cloudflare_account_id
+  name             = "${local.name_prefix}-auth-method"
+  decision         = "allow"
+  session_duration = "24h"
 
   include = [{ auth_method = { auth_method = "swk" } }]
 }
@@ -413,9 +429,10 @@ moved {
 
 # Policy with login_method
 resource "cloudflare_zero_trust_access_policy" "with_login_method" {
-  account_id = var.cloudflare_account_id
-  name       = "${local.name_prefix}-login-method"
-  decision   = "allow"
+  account_id       = var.cloudflare_account_id
+  name             = "${local.name_prefix}-login-method"
+  decision         = "allow"
+  session_duration = "24h"
 
   include = [{ login_method = { id = "otp" } },
   { login_method = { id = "warp" } }]
@@ -428,9 +445,10 @@ moved {
 
 # Policy with any_valid_service_token
 resource "cloudflare_zero_trust_access_policy" "with_service_token" {
-  account_id = var.cloudflare_account_id
-  name       = "${local.name_prefix}-service-token"
-  decision   = "allow"
+  account_id       = var.cloudflare_account_id
+  name             = "${local.name_prefix}-service-token"
+  decision         = "allow"
+  session_duration = "24h"
 
   include = [{ any_valid_service_token = {} }]
 }
@@ -442,9 +460,10 @@ moved {
 
 # Deny policy
 resource "cloudflare_zero_trust_access_policy" "deny_policy" {
-  account_id = var.cloudflare_account_id
-  name       = "${local.name_prefix}-deny"
-  decision   = "deny"
+  account_id       = var.cloudflare_account_id
+  name             = "${local.name_prefix}-deny"
+  decision         = "deny"
+  session_duration = "24h"
 
   include = [{ ip = { ip = "198.51.100.0/24" } }]
 }
@@ -456,9 +475,10 @@ moved {
 
 # Bypass policy
 resource "cloudflare_zero_trust_access_policy" "bypass_policy" {
-  account_id = var.cloudflare_account_id
-  name       = "${local.name_prefix}-bypass"
-  decision   = "bypass"
+  account_id       = var.cloudflare_account_id
+  name             = "${local.name_prefix}-bypass"
+  decision         = "bypass"
+  session_duration = "24h"
 
   include = [{ ip = { ip = "192.0.2.0/24" } }]
 }
@@ -471,9 +491,10 @@ moved {
 # TKT-002: include/exclude/require block → attribute list conversion
 # TKT-005: email_domain from list to {domain = ...} object
 resource "cloudflare_zero_trust_access_policy" "email_domain_policy" {
-  account_id = var.cloudflare_account_id
-  name       = "${local.name_prefix}-email-domain"
-  decision   = "allow"
+  account_id       = var.cloudflare_account_id
+  name             = "${local.name_prefix}-email-domain"
+  decision         = "allow"
+  session_duration = "18h"
 
   include = [{ email_domain = { domain = "cloudflare.com" } }]
 }
@@ -485,9 +506,10 @@ moved {
 
 # TKT-006: any_valid_service_token from bool to empty object {}
 resource "cloudflare_zero_trust_access_policy" "any_service_token_policy" {
-  account_id = var.cloudflare_account_id
-  name       = "${local.name_prefix}-any-service-token"
-  decision   = "non_identity"
+  account_id       = var.cloudflare_account_id
+  name             = "${local.name_prefix}-any-service-token"
+  decision         = "non_identity"
+  session_duration = "18h"
 
   include = [{ any_valid_service_token = {} }]
 }
@@ -500,9 +522,10 @@ moved {
 # TKT-006: any_valid_service_token = false should be omitted
 # decision = "allow" because non_identity + email is invalid in the API
 resource "cloudflare_zero_trust_access_policy" "no_service_token_policy" {
-  account_id = var.cloudflare_account_id
-  name       = "${local.name_prefix}-no-service-token"
-  decision   = "allow"
+  account_id       = var.cloudflare_account_id
+  name             = "${local.name_prefix}-no-service-token"
+  decision         = "allow"
+  session_duration = "18h"
 
   include = [{ email_domain = { domain = "cloudflare.com" } }]
 }
@@ -525,9 +548,10 @@ moved {
 }
 
 resource "cloudflare_zero_trust_access_policy" "service_token_policy" {
-  account_id = var.cloudflare_account_id
-  name       = "${local.name_prefix}-service-token-ref"
-  decision   = "non_identity"
+  account_id       = var.cloudflare_account_id
+  name             = "${local.name_prefix}-service-token-ref"
+  decision         = "non_identity"
+  session_duration = "18h"
 
   include = [{ service_token = { token_id = cloudflare_zero_trust_access_service_token.test_token.id } }]
 }
@@ -549,9 +573,10 @@ moved {
 }
 
 resource "cloudflare_zero_trust_access_policy" "multi_service_token_policy" {
-  account_id = var.cloudflare_account_id
-  name       = "${local.name_prefix}-multi-service-token"
-  decision   = "non_identity"
+  account_id       = var.cloudflare_account_id
+  name             = "${local.name_prefix}-multi-service-token"
+  decision         = "non_identity"
+  session_duration = "18h"
 
   include = [{ service_token = { token_id = cloudflare_zero_trust_access_service_token.test_token.id } },
   { service_token = { token_id = cloudflare_zero_trust_access_service_token.test_token_2.id } }]
@@ -564,9 +589,10 @@ moved {
 
 # TKT-005: multiple email domains — each becomes a separate include entry
 resource "cloudflare_zero_trust_access_policy" "multi_email_domain_policy" {
-  account_id = var.cloudflare_account_id
-  name       = "${local.name_prefix}-multi-email-domain"
-  decision   = "allow"
+  account_id       = var.cloudflare_account_id
+  name             = "${local.name_prefix}-multi-email-domain"
+  decision         = "allow"
+  session_duration = "18h"
 
   include = [{ email_domain = { domain = "cloudflare.com" } },
   { email_domain = { domain = "example.com" } }]
@@ -580,9 +606,10 @@ moved {
 # TKT-002 + TKT-004 + TKT-005 + TKT-006: Combined real-world policy
 # (mirrors research team's actual access_policies.tf)
 resource "cloudflare_zero_trust_access_policy" "combined_research_team_policy" {
-  account_id = var.cloudflare_account_id
-  name       = "${local.name_prefix}-combined"
-  decision   = "non_identity"
+  account_id       = var.cloudflare_account_id
+  name             = "${local.name_prefix}-combined"
+  decision         = "non_identity"
+  session_duration = "18h"
 
   include = [{ service_token = { token_id = cloudflare_zero_trust_access_service_token.test_token.id } },
   { service_token = { token_id = cloudflare_zero_trust_access_service_token.test_token_2.id } }]

--- a/internal/resources/zero_trust_access_policy/v4_to_v5.go
+++ b/internal/resources/zero_trust_access_policy/v4_to_v5.go
@@ -104,9 +104,8 @@ func (m *V4ToV5Migrator) TransformConfig(ctx *transform.Context, block *hclwrite
 	// If already v5-named: no rename, no moved block — just apply attribute conversions below.
 
 	// 2. Simple field operations
-	// Remove deprecated fields
-	// session_duration is not valid for policies (only for applications)
-	tfhcl.RemoveAttributes(body, "application_id", "precedence", "zone_id", "session_duration")
+	// Remove deprecated fields that are not valid in v5
+	tfhcl.RemoveAttributes(body, "application_id", "precedence", "zone_id")
 
 	// Convert approval_group block to approval_groups attribute array
 	// In v4: approval_group { approvals_needed = 1 }

--- a/internal/resources/zero_trust_access_policy/v4_to_v5_test.go
+++ b/internal/resources/zero_trust_access_policy/v4_to_v5_test.go
@@ -42,7 +42,7 @@ moved {
 }`,
 		},
 		{
-			Name: "policy with deprecated fields removed (zone_id, precedence, session_duration)",
+			Name: "policy with deprecated fields removed (zone_id, precedence), session_duration preserved",
 			Input: `
 resource "cloudflare_access_policy" "test" {
   account_id       = "account-123"
@@ -58,9 +58,10 @@ resource "cloudflare_access_policy" "test" {
 }`,
 			Expected: `
 resource "cloudflare_zero_trust_access_policy" "test" {
-  account_id = "account-123"
-  name       = "Test Policy"
-  decision   = "allow"
+  account_id       = "account-123"
+  name             = "Test Policy"
+  decision         = "allow"
+  session_duration = "24h"
 
   include = [{ everyone = {} }]
 }

--- a/internal/verifydrift/exemptions/drift-exemptions/dns_record.yaml
+++ b/internal/verifydrift/exemptions/drift-exemptions/dns_record.yaml
@@ -1,0 +1,21 @@
+# Drift Exemptions for dns_record resource
+
+version: 1
+
+exemptions:
+  # DNS record name case normalization in v5
+  # The v5 provider normalizes DNS record names to uppercase for certain
+  # record types (like CNAME/TXT with underscore prefixes). This causes
+  # a one-time drift where lowercase names become uppercase.
+  # This is expected provider behavior, not a migration issue.
+  - name: "dns_name_case_normalization"
+    description: "DNS record names are normalized to uppercase by the v5 provider for certain record types. This is expected provider behavior that resolves after apply."
+    resource_types:
+      - "cloudflare_dns_record"
+    patterns:
+      - '~ name.*=.*"_[a-f0-9]+.*" -> "_[A-F0-9]+'
+    enabled: true
+
+settings:
+  apply_exemptions: true
+  verbose_exemptions: false

--- a/internal/verifydrift/exemptions/drift-exemptions/zero_trust_access_application.yaml
+++ b/internal/verifydrift/exemptions/drift-exemptions/zero_trust_access_application.yaml
@@ -1,0 +1,26 @@
+# Drift Exemptions for zero_trust_access_application resource
+
+version: 1
+
+exemptions:
+  # Inline policy normalization in v5
+  # When reusable policies are referenced by ID in the application's policies array,
+  # the v5 provider normalizes them to only store 'id' and 'precedence'. The other
+  # fields (decision, name, include, exclude, require) are intentionally cleared
+  # because the full policy definition lives in the separate access_policy resource.
+  # This is expected behavior, not a migration issue.
+  - name: "inline_policy_normalization"
+    description: "Inline policies are normalized to only id/precedence when referencing reusable policies. The full policy definition is in the separate cloudflare_zero_trust_access_policy resource. This is expected v5 behavior."
+    resource_types:
+      - "cloudflare_zero_trust_access_application"
+    patterns:
+      - '- decision.*=.*-> null'
+      - '- exclude.*=.*-> null'
+      - '- include.*=.*-> null'
+      - '- name.*=.*-> null'
+      - '- require.*=.*-> null'
+    enabled: true
+
+settings:
+  apply_exemptions: true
+  verbose_exemptions: false

--- a/internal/verifydrift/exemptions/drift-exemptions/zero_trust_access_policy.yaml
+++ b/internal/verifydrift/exemptions/drift-exemptions/zero_trust_access_policy.yaml
@@ -3,19 +3,17 @@
 version: 1
 
 exemptions:
-  # session_duration was a valid v4 policy attribute but is removed in v5.
-  # tf-migrate correctly drops it from the migrated config. The API then
-  # normalizes it to the default "24h". If the v4 config used a non-default
-  # value (e.g. "18h"), the first v5 plan shows a change back to "24h".
-  # This is a one-time drift that resolves after the first terraform apply.
+  # NOTE: session_duration_normalization exemption removed as the bug is fixed.
+  # tf-migrate now correctly preserves session_duration during migration.
+  # The exemption is kept here (disabled) for historical reference.
   - name: "session_duration_normalization"
-    description: "session_duration was removed from v5 access policies. The API normalizes it to '24h' (default). One-time drift that resolves after apply."
+    description: "DEPRECATED: tf-migrate now preserves session_duration. This exemption is no longer needed."
     resource_types:
       - "cloudflare_zero_trust_access_policy"
     patterns:
       - '~ session_duration\s*='
       - 'session_duration.*->.*"24h"'
-    enabled: true
+    enabled: false
 
 settings:
   apply_exemptions: true


### PR DESCRIPTION
### Summary

This PR fixes a critical bug where tf-migrate was incorrectly removing `session_duration` from access policies, causing policy compliance checks to fail. It also adds missing drift exemptions for expected v5 provider behaviors.

### Changes

#### 1. Fix: Preserve `session_duration` during migration (`d1adc42`)

**Bug:** The migration was incorrectly removing `session_duration` from `cloudflare_zero_trust_access_policy` resources based on outdated information.

**Impact:** 
- v4 configs with `session_duration = "18h"` (or any non-default value) were being migrated without the attribute
- The API would default to `session_duration = "24h"` 
- This caused policy compliance checks to fail (e.g., `"session_duration" must be less than or equal to 18h`)

**Fix:** 
- Removed `session_duration` from the list of attributes to delete during migration
- Updated unit and integration tests to expect `session_duration` to be preserved

**Verification:**
- Provider docs confirm `session_duration` is valid in v5
- Provider schema includes `session_duration` (lines 149, 155 in schema.go)
- State migration preserves `session_duration` (transform.go line 35)

---

#### 2. Chore: Disable obsolete drift exemption (`da20b49`)

The `session_duration_normalization` drift exemption is no longer needed since the bug is fixed.

- Disabled the exemption (rather than removing) for historical reference
- Updated description to indicate it's deprecated

---

#### 3. Fix: Add drift exemptions for expected v5 behaviors (`a4a32c6`)

Added drift exemptions for two expected v5 provider behaviors that were causing false positives in `verify-drift`:

**a) zero_trust_access_application - Inline policy normalization**
- When reusable policies are referenced by ID in an application's `policies` array, v5 normalizes them to only store `id` and `precedence`
- Other fields (`decision`, `name`, `include`, `exclude`, `require`) are intentionally cleared
- This is expected behavior - the full policy definition lives in the separate policy resource

**b) dns_record - DNS name case normalization**
- v5 normalizes DNS record names to uppercase for certain record types (e.g., CNAME/TXT with underscore prefixes)
- This causes one-time drift that resolves after apply

---

### Files Changed

- `internal/resources/zero_trust_access_policy/v4_to_v5.go` - Stop removing `session_duration`
- `internal/resources/zero_trust_access_policy/v4_to_v5_test.go` - Update test expectations
- `integration/v4_to_v5/testdata/zero_trust_access_policy/expected/*.tf` - Update expected output
- `e2e/drift-exemptions/zero_trust_access_policy.yaml` - Disable obsolete exemption
- `e2e/drift-exemptions/zero_trust_access_application.yaml` - New exemption for policy normalization
- `e2e/drift-exemptions/dns_record.yaml` - New exemption for name casing
- `internal/verifydrift/exemptions/drift-exemptions/*.yaml` - Synced copies

---

### Testing

- All unit tests pass
- All integration tests pass
- Manual verification confirms `session_duration` is now preserved correctly

---

### Customer Impact

**Before:** Customers with `session_duration` values other than "24h" would see policy check failures after migration.

**After:** `session_duration` is correctly preserved during migration, maintaining policy compliance.

---

