### PR TITLE
feat: add cloudflare_worker_secret migration support

### DIFF
--- a/cmd/tf-migrate/version_constraint_test.go
+++ b/cmd/tf-migrate/version_constraint_test.go
@@ -1,0 +1,237 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/go-hclog"
+)
+
+func TestUpdateProviderVersionConstraint(t *testing.T) {
+	tests := []struct {
+		name          string
+		input         string
+		targetVersion string
+		expected      string
+		shouldUpdate  bool
+	}{
+		{
+			name: "replace simple version constraint",
+			input: `terraform {
+  required_providers {
+    cloudflare = {
+      source  = "cloudflare/cloudflare"
+      version = "~> 4.0"
+    }
+  }
+}`,
+			targetVersion: "5.19.0-beta.4",
+			expected: `terraform {
+  required_providers {
+    cloudflare = {
+      source  = "cloudflare/cloudflare"
+      version = "5.19.0-beta.4"
+    }
+  }
+}`,
+			shouldUpdate: true,
+		},
+		{
+			name: "replace complex version constraint",
+			input: `terraform {
+  required_providers {
+    cloudflare = {
+      source  = "cloudflare/cloudflare"
+      version = ">= 4.0, < 5.0"
+    }
+  }
+}`,
+			targetVersion: "5.19.0-beta.4",
+			expected: `terraform {
+  required_providers {
+    cloudflare = {
+      source  = "cloudflare/cloudflare"
+      version = "5.19.0-beta.4"
+    }
+  }
+}`,
+			shouldUpdate: true,
+		},
+		{
+			name: "replace version with different spacing",
+			input: `terraform {
+  required_providers {
+    cloudflare = {
+      source = "cloudflare/cloudflare"
+      version = "~> 4.0"
+    }
+  }
+}`,
+			targetVersion: "5.19.0-beta.4",
+			expected: `terraform {
+  required_providers {
+    cloudflare = {
+      source = "cloudflare/cloudflare"
+      version = "5.19.0-beta.4"
+    }
+  }
+}`,
+			shouldUpdate: true,
+		},
+		{
+			name: "add version when not exists",
+			input: `terraform {
+  required_providers {
+    cloudflare = {
+      source = "cloudflare/cloudflare"
+    }
+  }
+}`,
+			targetVersion: "5.19.0-beta.4",
+			expected: `terraform {
+  required_providers {
+    cloudflare = {
+      source = "cloudflare/cloudflare"
+      version = "5.19.0-beta.4"
+    }
+  }
+}`,
+			shouldUpdate: true, // We add version if not exists
+		},
+		{
+			name: "do not modify other providers",
+			input: `terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+    cloudflare = {
+      source  = "cloudflare/cloudflare"
+      version = "~> 4.0"
+    }
+  }
+}`,
+			targetVersion: "5.19.0-beta.4",
+			expected: `terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+    cloudflare = {
+      source  = "cloudflare/cloudflare"
+      version = "5.19.0-beta.4"
+    }
+  }
+}`,
+			shouldUpdate: true,
+		},
+		{
+			name: "handle multiline provider block",
+			input: `terraform {
+  required_providers {
+    cloudflare = {
+      source  = "cloudflare/cloudflare"
+      version = "~> 4.0"
+    }
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}`,
+			targetVersion: "5.19.0-beta.4",
+			expected: `terraform {
+  required_providers {
+    cloudflare = {
+      source  = "cloudflare/cloudflare"
+      version = "5.19.0-beta.4"
+    }
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}`,
+			shouldUpdate: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create temp directory
+			tempDir := t.TempDir()
+
+			// Write input file
+			tfFile := filepath.Join(tempDir, "main.tf")
+			err := os.WriteFile(tfFile, []byte(tt.input), 0644)
+			if err != nil {
+				t.Fatalf("Failed to write test file: %v", err)
+			}
+
+			// Create lock file to bypass version check
+			lockFile := filepath.Join(tempDir, ".terraform.lock.hcl")
+			lockContent := `provider "registry.terraform.io/cloudflare/cloudflare" {
+  version     = "4.52.5"
+  constraints = "~> 4.0"
+}
+`
+			err = os.WriteFile(lockFile, []byte(lockContent), 0644)
+			if err != nil {
+				t.Fatalf("Failed to write lock file: %v", err)
+			}
+
+			// Create config
+			cfg := config{
+				configDir:             tempDir,
+				sourceVersion:         "v4",
+				targetVersion:         "v5",
+				targetProviderVersion: tt.targetVersion,
+				skipVersionCheck:      true,
+			}
+
+			// Create logger
+			log := hclog.New(&hclog.LoggerOptions{
+				Level:  hclog.Error,
+				Output: os.Stderr,
+			})
+
+			// Call the function
+			err = updateProviderVersionConstraint(log, cfg, nil)
+			if err != nil {
+				t.Fatalf("updateProviderVersionConstraint failed: %v", err)
+			}
+
+			// Read the result
+			result, err := os.ReadFile(tfFile)
+			if err != nil {
+				t.Fatalf("Failed to read result file: %v", err)
+			}
+
+			if tt.shouldUpdate {
+				if strings.TrimSpace(string(result)) != strings.TrimSpace(tt.expected) {
+					t.Errorf("Version constraint not updated correctly.\nExpected:\n%s\n\nGot:\n%s", tt.expected, string(result))
+				}
+
+				// Verify the version constraint doesn't contain both old and new versions
+				resultStr := string(result)
+				if strings.Contains(resultStr, "~> 4.0") && strings.Contains(resultStr, tt.targetVersion) {
+					t.Errorf("Version constraint contains both old and new versions: %s", resultStr)
+				}
+
+				// Verify only the target version is present
+				if !strings.Contains(resultStr, `version = "`+tt.targetVersion+`"`) {
+					t.Errorf("Version constraint doesn't contain target version %q: %s", tt.targetVersion, resultStr)
+				}
+			} else {
+				// Should not have modified the file
+				if strings.TrimSpace(string(result)) != strings.TrimSpace(tt.input) {
+					t.Errorf("File was modified when it shouldn't have been.\nExpected:\n%s\n\nGot:\n%s", tt.input, string(result))
+				}
+			}
+		})
+	}
+}

--- a/integration/v4_to_v5/testdata/workers_secret/expected/workers_secret.tf
+++ b/integration/v4_to_v5/testdata/workers_secret/expected/workers_secret.tf
@@ -1,0 +1,46 @@
+# Test both v4 resource name variants
+
+
+# Plural form (preferred in v4)
+resource "cloudflare_workers_secret" "plural_secret" {
+  name        = "PLURAL_SECRET"
+  script_name = "my-worker"
+  secret_text = "plural-secret-value"
+  # MIGRATION WARNING: MIGRATION REQUIRED: Add account_id attribute (required in v5)
+}
+
+
+# With dispatch namespace
+resource "cloudflare_workers_secret" "with_namespace" {
+  name               = "NAMESPACE_SECRET"
+  script_name        = "my-worker"
+  dispatch_namespace = "my-namespace"
+  secret_text        = "namespace-secret-value"
+  # MIGRATION WARNING: MIGRATION REQUIRED: Add account_id attribute (required in v5)
+}
+
+# Singular form (deprecated in v4)
+resource "cloudflare_workers_secret" "singular_secret" {
+  name        = "SINGULAR_SECRET"
+  script_name = "my-worker"
+  secret_text = "singular-secret-value"
+  # MIGRATION WARNING: MIGRATION REQUIRED: Add account_id attribute (required in v5)
+}
+
+moved {
+  from = cloudflare_worker_secret.singular_secret
+  to   = cloudflare_workers_secret.singular_secret
+}
+
+# With account_id (should not generate warning)
+resource "cloudflare_workers_secret" "with_account" {
+  account_id  = var.account_id
+  name        = "WITH_ACCOUNT"
+  script_name = "my-worker"
+  secret_text = "secret-with-account"
+}
+
+moved {
+  from = cloudflare_worker_secret.with_account
+  to   = cloudflare_workers_secret.with_account
+}

--- a/integration/v4_to_v5/testdata/workers_secret/input/workers_secret.tf
+++ b/integration/v4_to_v5/testdata/workers_secret/input/workers_secret.tf
@@ -1,0 +1,31 @@
+# Test both v4 resource name variants
+
+# Singular form (deprecated in v4)
+resource "cloudflare_worker_secret" "singular_secret" {
+  name        = "SINGULAR_SECRET"
+  script_name = "my-worker"
+  secret      = "singular-secret-value"
+}
+
+# Plural form (preferred in v4)
+resource "cloudflare_workers_secret" "plural_secret" {
+  name        = "PLURAL_SECRET"
+  script_name = "my-worker"
+  secret      = "plural-secret-value"
+}
+
+# With account_id (should not generate warning)
+resource "cloudflare_worker_secret" "with_account" {
+  account_id  = var.account_id
+  name        = "WITH_ACCOUNT"
+  script_name = "my-worker"
+  secret      = "secret-with-account"
+}
+
+# With dispatch namespace
+resource "cloudflare_workers_secret" "with_namespace" {
+  name               = "NAMESPACE_SECRET"
+  script_name        = "my-worker"
+  secret             = "namespace-secret-value"
+  dispatch_namespace = "my-namespace"
+}

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -61,6 +61,7 @@ import (
 	"github.com/cloudflare/tf-migrate/internal/resources/workers_kv"
 	"github.com/cloudflare/tf-migrate/internal/resources/workers_kv_namespace"
 	"github.com/cloudflare/tf-migrate/internal/resources/workers_script"
+	"github.com/cloudflare/tf-migrate/internal/resources/workers_secret"
 	"github.com/cloudflare/tf-migrate/internal/resources/zero_trust_access_application"
 	"github.com/cloudflare/tf-migrate/internal/resources/zero_trust_access_group"
 	"github.com/cloudflare/tf-migrate/internal/resources/zero_trust_access_identity_provider"
@@ -157,6 +158,7 @@ func RegisterAllMigrations() {
 	worker_route.NewV4ToV5Migrator()
 	workers_custom_domain.NewV4ToV5Migrator()
 	workers_kv.NewV4ToV5Migrator()
+	workers_secret.NewV4ToV5Migrator()
 	workers_kv_namespace.NewV4ToV5Migrator()
 	workers_script.NewV4ToV5Migrator()
 	workers_for_platforms_dispatch_namespace.NewV4ToV5Migrator()

--- a/internal/resources/workers_secret/README.md
+++ b/internal/resources/workers_secret/README.md
@@ -1,0 +1,101 @@
+# Workers Secret Migration Guide (v4 → v5)
+
+## Overview
+
+The `cloudflare_worker_secret` and `cloudflare_workers_secret` resources from v4 have been consolidated into a single `cloudflare_workers_secret` resource in v5.
+
+## Changes
+
+| Aspect | v4 | v5 | Change |
+|--------|----|----|--------|
+| Resource name (singular) | `cloudflare_worker_secret` | `cloudflare_workers_secret` | **Renamed** |
+| Resource name (plural) | `cloudflare_workers_secret` | `cloudflare_workers_secret` | No change |
+| `secret` attribute | `secret` | `secret_text` | **Renamed** |
+| `account_id` | Optional | Required | **Now required** |
+| `name` | Required | Required | No change |
+| `script_name` | Required | Required | No change |
+| `dispatch_namespace` | N/A | Optional | New in v5 |
+
+## Migration Behavior
+
+### Singular Form (`cloudflare_worker_secret`)
+
+The resource type is renamed and a `moved` block is generated:
+
+```hcl
+# v4
+resource "cloudflare_worker_secret" "my_secret" {
+  name        = "MY_SECRET"
+  script_name = "my-worker"
+  secret      = "super-secret-value"
+}
+
+# v5
+resource "cloudflare_workers_secret" "my_secret" {
+  name         = "MY_SECRET"
+  script_name  = "my-worker"
+  secret_text  = "super-secret-value"
+  # MIGRATION REQUIRED: Add account_id attribute (required in v5)
+}
+
+moved {
+  from = cloudflare_worker_secret.my_secret
+  to   = cloudflare_workers_secret.my_secret
+}
+```
+
+### Plural Form (`cloudflare_workers_secret`)
+
+Only the attribute is renamed (no `moved` block needed):
+
+```hcl
+# v4
+resource "cloudflare_workers_secret" "my_secret" {
+  name        = "MY_SECRET"
+  script_name = "my-worker"
+  secret      = "super-secret-value"
+}
+
+# v5
+resource "cloudflare_workers_secret" "my_secret" {
+  name         = "MY_SECRET"
+  script_name  = "my-worker"
+  secret_text  = "super-secret-value"
+  # MIGRATION REQUIRED: Add account_id attribute (required in v5)
+}
+```
+
+## Important: Required Account ID
+
+The v5 provider requires `account_id` to be specified on the resource. If your v4 configuration doesn't have it, you'll need to add it manually after migration:
+
+```hcl
+resource "cloudflare_workers_secret" "my_secret" {
+  account_id  = "your-account-id"  # <-- Add this
+  name        = "MY_SECRET"
+  script_name = "my-worker"
+  secret_text = "super-secret-value"
+}
+```
+
+The migration tool will add a warning comment if `account_id` is missing.
+
+## Testing
+
+### Unit Tests
+
+```bash
+go test ./internal/resources/workers_secret -v
+```
+
+### Integration Tests
+
+```bash
+TEST_RESOURCE=workers_secret go test -v -run TestSingleResource ./integration/v4_to_v5/
+```
+
+### E2E Tests
+
+```bash
+./scripts/run-e2e-tests.sh --resources workers_secret --apply-exemptions
+```

--- a/internal/resources/workers_secret/v4_to_v5.go
+++ b/internal/resources/workers_secret/v4_to_v5.go
@@ -1,0 +1,95 @@
+package workers_secret
+
+import (
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclwrite"
+
+	"github.com/cloudflare/tf-migrate/internal"
+	"github.com/cloudflare/tf-migrate/internal/transform"
+	tfhcl "github.com/cloudflare/tf-migrate/internal/transform/hcl"
+)
+
+// V4ToV5Migrator handles migration of worker secrets from v4 to v5
+type V4ToV5Migrator struct{}
+
+func NewV4ToV5Migrator() transform.ResourceTransformer {
+	migrator := &V4ToV5Migrator{}
+	// Register BOTH v4 resource names:
+	//   - cloudflare_worker_secret: singular form (requires type rename + moved block)
+	//   - cloudflare_workers_secret: plural form (in-place attr rename only)
+	internal.RegisterMigrator("cloudflare_worker_secret", "v4", "v5", migrator)
+	internal.RegisterMigrator("cloudflare_workers_secret", "v4", "v5", migrator)
+	return migrator
+}
+
+func (m *V4ToV5Migrator) GetResourceType() string {
+	// Return the NEW (v5) resource name
+	return "cloudflare_workers_secret"
+}
+
+func (m *V4ToV5Migrator) CanHandle(resourceType string) bool {
+	// Handle both the singular and plural v4 names
+	return resourceType == "cloudflare_worker_secret" || resourceType == "cloudflare_workers_secret"
+}
+
+func (m *V4ToV5Migrator) Preprocess(content string) string {
+	// No preprocessing needed
+	return content
+}
+
+// GetResourceRename implements the ResourceRenamer interface
+func (m *V4ToV5Migrator) GetResourceRename() ([]string, string) {
+	return []string{"cloudflare_worker_secret", "cloudflare_workers_secret"}, "cloudflare_workers_secret"
+}
+
+func (m *V4ToV5Migrator) TransformConfig(ctx *transform.Context, block *hclwrite.Block) (*transform.TransformResult, error) {
+	resourceType := tfhcl.GetResourceType(block)
+	resourceName := tfhcl.GetResourceName(block)
+	body := block.Body()
+
+	// Check if this is the singular form (needs rename + moved block)
+	wasSingular := resourceType == "cloudflare_worker_secret"
+
+	// Rename resource type if using singular form
+	if wasSingular {
+		tfhcl.RenameResourceType(block, "cloudflare_worker_secret", "cloudflare_workers_secret")
+	}
+
+	// Rename attribute: secret → secret_text
+	// v4 used "secret" attribute, v5 uses "secret_text"
+	tfhcl.RenameAttribute(body, "secret", "secret_text")
+
+	// Check if account_id is missing - add warning if so
+	// v5 requires account_id, v4 didn't
+	if body.GetAttribute("account_id") == nil {
+		ctx.Diagnostics = append(ctx.Diagnostics, &hcl.Diagnostic{
+			Severity: hcl.DiagWarning,
+			Summary:  "Missing required field: account_id",
+			Detail: `The 'account_id' field is required in v5 but was not present in v4.
+
+Please add the account_id attribute to avoid plan errors:
+  account_id = "your-account-id"`,
+		})
+
+		// Add a warning comment in the HCL
+		tfhcl.AppendWarningComment(body, "MIGRATION REQUIRED: Add account_id attribute (required in v5)")
+	}
+
+	// Generate moved block if the resource was renamed (singular → plural)
+	if wasSingular {
+		from := "cloudflare_worker_secret." + resourceName
+		to := "cloudflare_workers_secret." + resourceName
+		movedBlock := tfhcl.CreateMovedBlock(from, to)
+
+		return &transform.TransformResult{
+			Blocks:         []*hclwrite.Block{block, movedBlock},
+			RemoveOriginal: true,
+		}, nil
+	}
+
+	// Plural form - no moved block needed, just attribute rename
+	return &transform.TransformResult{
+		Blocks:         []*hclwrite.Block{block},
+		RemoveOriginal: false,
+	}, nil
+}

--- a/internal/resources/workers_secret/v4_to_v5_test.go
+++ b/internal/resources/workers_secret/v4_to_v5_test.go
@@ -1,0 +1,146 @@
+package workers_secret
+
+import (
+	"testing"
+
+	"github.com/cloudflare/tf-migrate/internal/testhelpers"
+)
+
+func TestV4ToV5Transformation(t *testing.T) {
+	migrator := NewV4ToV5Migrator()
+
+	t.Run("ConfigTransformation", func(t *testing.T) {
+		tests := []testhelpers.ConfigTestCase{
+			{
+				Name: "singular_v4_name",
+				Input: `
+resource "cloudflare_worker_secret" "my_secret" {
+  name        = "MY_SECRET"
+  script_name = "my-worker"
+  secret      = "super-secret-value"
+}`,
+				Expected: `resource "cloudflare_workers_secret" "my_secret" {
+  name         = "MY_SECRET"
+  script_name  = "my-worker"
+  secret_text  = "super-secret-value"
+  # MIGRATION WARNING: MIGRATION REQUIRED: Add account_id attribute (required in v5)
+}
+
+moved {
+  from = cloudflare_worker_secret.my_secret
+  to   = cloudflare_workers_secret.my_secret
+}`,
+			},
+			{
+				Name: "plural_v4_name",
+				Input: `
+resource "cloudflare_workers_secret" "my_secret" {
+  name        = "MY_SECRET"
+  script_name = "my-worker"
+  secret      = "super-secret-value"
+}`,
+				Expected: `resource "cloudflare_workers_secret" "my_secret" {
+  name         = "MY_SECRET"
+  script_name  = "my-worker"
+  secret_text  = "super-secret-value"
+  # MIGRATION WARNING: MIGRATION REQUIRED: Add account_id attribute (required in v5)
+}`,
+			},
+			{
+				Name: "with_account_id",
+				Input: `
+resource "cloudflare_worker_secret" "my_secret" {
+  account_id  = "f037e56e89293a057740de681ac9abbe"
+  name        = "MY_SECRET"
+  script_name = "my-worker"
+  secret      = "super-secret-value"
+}`,
+				Expected: `resource "cloudflare_workers_secret" "my_secret" {
+  account_id   = "f037e56e89293a057740de681ac9abbe"
+  name         = "MY_SECRET"
+  script_name  = "my-worker"
+  secret_text  = "super-secret-value"
+}
+
+moved {
+  from = cloudflare_worker_secret.my_secret
+  to   = cloudflare_workers_secret.my_secret
+}`,
+			},
+			{
+				Name: "with_dispatch_namespace",
+				Input: `
+resource "cloudflare_worker_secret" "my_secret" {
+  name               = "MY_SECRET"
+  script_name        = "my-worker"
+  secret             = "super-secret-value"
+  dispatch_namespace = "my-namespace"
+}`,
+				Expected: `resource "cloudflare_workers_secret" "my_secret" {
+  name                = "MY_SECRET"
+  script_name         = "my-worker"
+  dispatch_namespace  = "my-namespace"
+  secret_text         = "super-secret-value"
+  # MIGRATION WARNING: MIGRATION REQUIRED: Add account_id attribute (required in v5)
+}
+
+moved {
+  from = cloudflare_worker_secret.my_secret
+  to   = cloudflare_workers_secret.my_secret
+}`,
+			},
+			{
+				Name: "multiple_secrets",
+				Input: `
+resource "cloudflare_worker_secret" "secret1" {
+  name        = "SECRET_ONE"
+  script_name = "worker-one"
+  secret      = "first-secret"
+}
+
+resource "cloudflare_workers_secret" "secret2" {
+  name        = "SECRET_TWO"
+  script_name = "worker-two"
+  secret      = "second-secret"
+}`,
+				// Note: Block ordering is non-deterministic, test individually
+				Expected: `resource "cloudflare_workers_secret" "secret2" {
+  name         = "SECRET_TWO"
+  script_name  = "worker-two"
+  secret_text  = "second-secret"
+  # MIGRATION WARNING: MIGRATION REQUIRED: Add account_id attribute (required in v5)
+}
+
+resource "cloudflare_workers_secret" "secret1" {
+  name         = "SECRET_ONE"
+  script_name  = "worker-one"
+  secret_text  = "first-secret"
+  # MIGRATION WARNING: MIGRATION REQUIRED: Add account_id attribute (required in v5)
+}
+
+moved {
+  from = cloudflare_worker_secret.secret1
+  to   = cloudflare_workers_secret.secret1
+}`,
+			},
+			{
+				Name: "plural_with_account_id_no_warning",
+				Input: `
+resource "cloudflare_workers_secret" "my_secret" {
+  account_id  = "f037e56e89293a057740de681ac9abbe"
+  name        = "MY_SECRET"
+  script_name = "my-worker"
+  secret      = "super-secret-value"
+}`,
+				Expected: `resource "cloudflare_workers_secret" "my_secret" {
+  account_id   = "f037e56e89293a057740de681ac9abbe"
+  name         = "MY_SECRET"
+  script_name  = "my-worker"
+  secret_text  = "super-secret-value"
+}`,
+			},
+		}
+
+		testhelpers.RunConfigTransformTests(t, tests, migrator)
+	})
+}


### PR DESCRIPTION
- Handle both cloudflare_worker_secret (singular) and cloudflare_workers_secret (plural) v4 names
- Rename resource type for singular form: cloudflare_worker_secret → cloudflare_workers_secret
- Rename attribute: secret → secret_text
- Generate moved block for resource type rename
- Add warning comment for missing account_id (required in v5)
- Include unit tests and integration test fixtures