### PR TITLE
feat: add --exclude flag and change --recursive default to false

### DIFF
--- a/cmd/tf-migrate/main.go
+++ b/cmd/tf-migrate/main.go
@@ -41,9 +41,10 @@ type config struct {
 	dryRun                bool
 	backup                bool
 	recursive             bool
+	exclude               []string // directories to exclude from migration (relative to configDir)
 	logLevel              string
 	skipPhaseCheck        bool // skip phased migration prompt and run full migration directly (for CI/e2e)
-	skipVersionCheck      bool // skip minimum provider version check (for testing)
+	skipVersionCheck      bool // skip minimum provider version check (for testing/CI only)
 
 	// Diagnostic output options
 	quiet   bool // Suppress warnings, only show errors
@@ -170,7 +171,8 @@ Uses the global flags --config-dir and --resources to determine what to migrate.
 
 	cmd.Flags().StringVar(&cfg.outputDir, "output-dir", "", "Output directory for migrated configuration files (default: in-place)")
 	cmd.Flags().BoolVar(&cfg.backup, "backup", true, "Create backup of original files before migration")
-	cmd.Flags().BoolVar(&cfg.recursive, "recursive", true, "Recursively process subdirectories (useful for module structures)")
+	cmd.Flags().BoolVar(&cfg.recursive, "recursive", false, "Recursively process subdirectories (useful for module structures)")
+	cmd.Flags().StringSliceVar(&cfg.exclude, "exclude", []string{}, "Directories to exclude from migration (relative to config-dir, can be specified multiple times)")
 	cmd.Flags().StringVar(&cfg.targetProviderVersion, "target-provider-version", "", "Explicit provider version to set in required_providers (e.g. 5.19.0-beta.3); skips GitHub API lookup")
 
 	// --no-backup is a convenience alias for --backup=false
@@ -410,7 +412,7 @@ func updateProviderVersionConstraint(log hclog.Logger, cfg config, diags hcl.Dia
 		log.Debug("Provider version fetched from GitHub API", "version", targetVersion)
 	}
 
-	files, err := findTerraformFilesWithRecursion(cfg.configDir, cfg.recursive)
+	files, err := findTerraformFilesWithRecursion(cfg.configDir, cfg.recursive, cfg.exclude)
 	if err != nil {
 		return err
 	}
@@ -613,7 +615,7 @@ func printVersionFetchFailure(cfg config, diags hcl.Diagnostics) {
 // commented-out resource blocks from a previous phase-1 run, identified by
 // the phaseOneCommentPrefix marker.
 func findFilesWithPhaseOneComments(cfg config) []string {
-	files, err := findTerraformFilesWithRecursion(cfg.configDir, cfg.recursive)
+	files, err := findTerraformFilesWithRecursion(cfg.configDir, cfg.recursive, cfg.exclude)
 	if err != nil {
 		return nil
 	}
@@ -653,7 +655,7 @@ func confirmPhaseOneApplied(cfg config) (bool, error) {
 // detectPhaseOneResources scans all .tf files and returns a map of
 // filename → resource addresses for resources whose migrator implements PhaseOneTransformer.
 func detectPhaseOneResources(log hclog.Logger, cfg config) (map[string][]string, error) {
-	files, err := findTerraformFilesWithRecursion(cfg.configDir, cfg.recursive)
+	files, err := findTerraformFilesWithRecursion(cfg.configDir, cfg.recursive, cfg.exclude)
 	if err != nil {
 		return nil, err
 	}
@@ -959,7 +961,7 @@ func processConfigFiles(log hclog.Logger, p *pipeline.Pipeline, cfg config) (map
 		cfg.outputDir = cfg.configDir
 	}
 
-	files, err := findTerraformFilesWithRecursion(cfg.configDir, cfg.recursive)
+	files, err := findTerraformFilesWithRecursion(cfg.configDir, cfg.recursive, cfg.exclude)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to list .tf files: %w", err)
 	}
@@ -1326,10 +1328,10 @@ func regexReplaceSkippingMovedBlocks(content, pattern, replacement string) strin
 }
 
 func findTerraformFiles(dir string) ([]string, error) {
-	return findTerraformFilesWithRecursion(dir, false)
+	return findTerraformFilesWithRecursion(dir, false, nil)
 }
 
-func findTerraformFilesWithRecursion(dir string, recursive bool) ([]string, error) {
+func findTerraformFilesWithRecursion(dir string, recursive bool, exclude []string) ([]string, error) {
 	var files []string
 
 	entries, err := os.ReadDir(dir)
@@ -1340,8 +1342,12 @@ func findTerraformFilesWithRecursion(dir string, recursive bool) ([]string, erro
 	for _, entry := range entries {
 		path := filepath.Join(dir, entry.Name())
 		if entry.IsDir() && recursive {
+			// Check if this directory should be excluded
+			if shouldExclude(entry.Name(), exclude) {
+				continue
+			}
 			// Recursively search subdirectories
-			subFiles, err := findTerraformFilesWithRecursion(path, recursive)
+			subFiles, err := findTerraformFilesWithRecursion(path, recursive, exclude)
 			if err != nil {
 				// Log the error but continue processing other directories
 				continue
@@ -1353,6 +1359,21 @@ func findTerraformFilesWithRecursion(dir string, recursive bool) ([]string, erro
 	}
 
 	return files, nil
+}
+
+// shouldExclude checks if a directory name matches any of the exclusion patterns
+func shouldExclude(dirName string, exclude []string) bool {
+	for _, pattern := range exclude {
+		// Support both exact match and wildcard patterns
+		if matched, _ := filepath.Match(pattern, dirName); matched {
+			return true
+		}
+		// Also check for exact match
+		if pattern == dirName {
+			return true
+		}
+	}
+	return false
 }
 
 func validateVersions(c config) error {

--- a/cmd/tf-migrate/preflight.go
+++ b/cmd/tf-migrate/preflight.go
@@ -57,7 +57,7 @@ type preflightReport struct {
 // runPreMigrationScan scans all .tf files and classifies resources and detects
 // existing moved blocks. It prints a summary and returns warnings for any issues.
 func runPreMigrationScan(log hclog.Logger, cfg config) (*preflightReport, error) {
-	files, err := findTerraformFilesWithRecursion(cfg.configDir, cfg.recursive)
+	files, err := findTerraformFilesWithRecursion(cfg.configDir, cfg.recursive, cfg.exclude)
 	if err != nil {
 		return nil, fmt.Errorf("failed to find terraform files: %w", err)
 	}

--- a/cmd/tf-migrate/version_check.go
+++ b/cmd/tf-migrate/version_check.go
@@ -115,7 +115,7 @@ func parseVersionFromLockFile(configDir string) (string, error) {
 // block and extracts the cloudflare provider version constraint.
 // Returns the version constraint string and the file path where it was found.
 func parseVersionFromRequiredProviders(cfg config) (versionConstraint, sourceFile string, err error) {
-	files, err := findTerraformFilesWithRecursion(cfg.configDir, cfg.recursive)
+	files, err := findTerraformFilesWithRecursion(cfg.configDir, cfg.recursive, cfg.exclude)
 	if err != nil {
 		return "", "", err
 	}


### PR DESCRIPTION
### Description

This PR introduces a new `--exclude` flag for the `migrate` command and changes the default behavior of `--recursive` to improve safety and flexibility when migrating Terraform configurations.

### Changes

#### 1. New `--exclude` Flag
- **Purpose:** Exclude specific directories from the migration process
- **Format:** Relative to `--config-dir` (directory names only, not full paths)
- **Multiple values supported:** 
  - Multiple flags: `--exclude dir1 --exclude dir2`
  - Comma-separated: `--exclude "dir1,dir2"`
- **Wildcard support:** `--exclude "test-*"`
- **Example:**
  ```bash
  tf-migrate migrate --config-dir ./terraform --recursive \
    --exclude modules \
    --exclude .terraform \
    --exclude "test-*"
  ```

#### 2. Changed `--recursive` Default
- **Before:** `--recursive` defaulted to `true`
- **After:** `--recursive` defaults to `false`
- **Rationale:** 
  - Principle of least surprise - only process the directory specified
  - Prevents accidental migration of nested modules or vendored code
  - Users opt-in explicitly when they need recursion

#### 3. Implementation Details
- Added `shouldExclude()` helper function supporting exact match and glob patterns
- Updated `findTerraformFilesWithRecursion()` to accept exclude list parameter
- Updated all callers (migrate, preflight, version check) to pass exclude configuration

### Usage Examples

```bash
# Exclude security-baseline directory from migration
tf-migrate migrate --config-dir ./tf/cloudflare-dash-production \
  --recursive \
  --exclude security-baseline

# Exclude multiple directories
tf-migrate migrate --config-dir ./terraform --recursive \
  --exclude modules \
  --exclude .terraform \
  --exclude examples

# Using wildcards
tf-migrate migrate --config-dir ./terraform --recursive \
  --exclude "test-*" \
  --exclude "tmp-*"
```