### PR TITLE
feat: consolidate duplicate warnings and move informational logs behind `--verbose` flag

### DIFF
--- a/cmd/tf-migrate/main.go
+++ b/cmd/tf-migrate/main.go
@@ -971,7 +971,9 @@ func processConfigFiles(log hclog.Logger, p *pipeline.Pipeline, cfg config) (map
 		return nil, nil, nil
 	}
 
-	fmt.Printf("Found %d configuration files to migrate\n", len(files))
+	if cfg.verbose {
+		fmt.Printf("Found %d configuration files to migrate\n", len(files))
+	}
 
 	// Store file paths for global postprocessing
 	outputPaths := make([]string, 0, len(files))
@@ -1482,6 +1484,73 @@ func getProviders(resources ...string) transform.MigrationProvider {
 	return transform.NewMigrationProvider(getFunc, getAllFunc)
 }
 
+// consolidatedDiagnostic groups multiple diagnostics with the same summary
+type consolidatedDiagnostic struct {
+	Summary  string
+	Severity hcl.DiagnosticSeverity
+	Details  []string // Multiple detail messages for resources with same issue
+	Sample   string   // Full detail from first occurrence (for reference)
+}
+
+// consolidateDiagnostics groups diagnostics by summary to avoid repetition
+func consolidateDiagnostics(diags hcl.Diagnostics) []consolidatedDiagnostic {
+	groups := make(map[string]*consolidatedDiagnostic)
+
+	for _, diag := range diags {
+		key := fmt.Sprintf("%s:%d", diag.Summary, diag.Severity)
+
+		if existing, ok := groups[key]; ok {
+			// Extract resource name from detail (first line typically contains it)
+			existing.Details = append(existing.Details, extractResourceName(diag.Detail))
+		} else {
+			groups[key] = &consolidatedDiagnostic{
+				Summary:  diag.Summary,
+				Severity: diag.Severity,
+				Details:  []string{extractResourceName(diag.Detail)},
+				Sample:   diag.Detail,
+			}
+		}
+	}
+
+	// Convert map to slice
+	result := make([]consolidatedDiagnostic, 0, len(groups))
+	for _, g := range groups {
+		result = append(result, *g)
+	}
+	return result
+}
+
+// extractResourceName extracts the resource identifier from diagnostic detail
+// Expected format: "Resource cloudflare_XXXX.name has ..." or similar
+func extractResourceName(detail string) string {
+	lines := strings.Split(detail, "\n")
+	if len(lines) == 0 {
+		return detail
+	}
+
+	firstLine := lines[0]
+	// Look for patterns like "Resource cloudflare_type.name has..." or "cloudflare_type.name has..."
+	if strings.HasPrefix(firstLine, "Resource ") {
+		// Extract the resource reference
+		parts := strings.SplitN(firstLine, " ", 3)
+		if len(parts) >= 2 {
+			return parts[1]
+		}
+	}
+
+	// Try to find resource reference in the first line
+	if idx := strings.Index(firstLine, "cloudflare_"); idx != -1 {
+		// Extract from cloudflare_ to the next space or end
+		rest := firstLine[idx:]
+		if spaceIdx := strings.Index(rest, " "); spaceIdx != -1 {
+			return rest[:spaceIdx]
+		}
+		return rest
+	}
+
+	return firstLine
+}
+
 // printDiagnostics prints diagnostics to the user based on verbosity settings
 // Default (medium verbosity): show warnings and errors
 // Quiet mode (--quiet): only show errors
@@ -1552,14 +1621,17 @@ func printDiagnostics(diags hcl.Diagnostics, cfg config) {
 	fmt.Printf("Migration diagnostics: %s\n", strings.Join(parts, ", "))
 	fmt.Println(strings.Repeat("─", 70))
 
-	for i, diag := range filtered {
+	// Consolidate diagnostics by summary
+	consolidated := consolidateDiagnostics(filtered)
+
+	for i, cd := range consolidated {
 		if i > 0 {
 			fmt.Println()
 		}
 
 		// Print severity icon
 		var icon string
-		switch diag.Severity {
+		switch cd.Severity {
 		case hcl.DiagError:
 			icon = "✗"
 		case hcl.DiagWarning:
@@ -1568,9 +1640,39 @@ func printDiagnostics(diags hcl.Diagnostics, cfg config) {
 			icon = "ℹ"
 		}
 
-		fmt.Printf("\n%s %s\n", icon, diag.Summary)
-		if diag.Detail != "" {
-			fmt.Printf("\n%s\n", diag.Detail)
+		// If there are multiple resources with the same issue, consolidate them
+		if len(cd.Details) > 1 {
+			fmt.Printf("\n%s %s (%d resources)\n", icon, cd.Summary, len(cd.Details))
+			fmt.Println()
+			// List affected resources
+			for _, detail := range cd.Details {
+				fmt.Printf("  - %s\n", detail)
+			}
+			// Show the full instructions once
+			if cd.Sample != "" {
+				// Extract the instructions part (after the first line/resource description)
+				lines := strings.Split(cd.Sample, "\n")
+				if len(lines) > 1 {
+					fmt.Println()
+					// Find where the actual instructions start (skip resource-specific lines)
+					for j := 1; j < len(lines); j++ {
+						line := lines[j]
+						// Skip empty lines at the start
+						if strings.TrimSpace(line) == "" && j < len(lines)-1 {
+							continue
+						}
+						// Print remaining lines
+						fmt.Println(strings.Join(lines[j:], "\n"))
+						break
+					}
+				}
+			}
+		} else {
+			// Single resource - show full detail
+			fmt.Printf("\n%s %s\n", icon, cd.Summary)
+			if cd.Sample != "" {
+				fmt.Printf("\n%s\n", cd.Sample)
+			}
 		}
 	}
 	fmt.Println(strings.Repeat("─", 70))

--- a/cmd/tf-migrate/main.go
+++ b/cmd/tf-migrate/main.go
@@ -1149,30 +1149,13 @@ func applyGlobalPostprocessing(log hclog.Logger, cfg config, outputPaths []strin
 		log.Warn("Failed to collect removed block references for postprocessing", "error", err)
 	}
 
+	// Track which renames were actually applied (content changed)
+	appliedRenames := make(map[string]string)
+	appliedAttrRenames := make(map[string]transform.AttributeRename)               // key: ResourceType.OldAttribute
+	appliedComputedMappings := make(map[string]transform.ComputedAttributeMapping) // key: OldResourceType.OldAttribute
+
 	if cfg.verbose {
-		totalUpdates := len(renames) + len(attributeRenames) + len(computedAttrMappings)
-		fmt.Printf("\nApplying cross-file reference updates (%d updates across %d files)...\n", totalUpdates, len(outputPaths))
-
-		if len(renames) > 0 {
-			fmt.Println("\nResource type renames:")
-			for oldType, newType := range renames {
-				fmt.Printf("  %s → %s\n", oldType, newType)
-			}
-		}
-
-		if len(attributeRenames) > 0 {
-			fmt.Println("\nAttribute renames:")
-			for _, rename := range attributeRenames {
-				fmt.Printf("  %s.*.%s → %s.*.%s\n", rename.ResourceType, rename.OldAttribute, rename.ResourceType, rename.NewAttribute)
-			}
-		}
-
-		if len(computedAttrMappings) > 0 {
-			fmt.Println("\nComputed attribute mappings:")
-			for _, mapping := range computedAttrMappings {
-				fmt.Printf("  %s.*.%s → %s.*.%s\n", mapping.OldResourceType, mapping.OldAttribute, mapping.NewResourceType, mapping.NewAttribute)
-			}
-		}
+		fmt.Printf("\nApplying cross-file reference updates across %d files...\n", len(outputPaths))
 	}
 
 	// Apply renames to all files
@@ -1199,6 +1182,8 @@ func applyGlobalPostprocessing(log hclog.Logger, cfg config, outputPaths []strin
 			if newContent != contentStr {
 				modified = true
 				contentStr = newContent
+				key := mapping.OldResourceType + "." + mapping.OldAttribute
+				appliedComputedMappings[key] = mapping
 				log.Debug("Updated computed attribute references",
 					"file", filepath.Base(outputPath),
 					"old_type", mapping.OldResourceType,
@@ -1214,6 +1199,7 @@ func applyGlobalPostprocessing(log hclog.Logger, cfg config, outputPaths []strin
 			if newContent != contentStr {
 				modified = true
 				contentStr = newContent
+				appliedRenames[oldType] = newType
 				log.Debug("Updated references", "file", filepath.Base(outputPath), "old", oldType, "new", newType)
 			}
 		}
@@ -1231,6 +1217,8 @@ func applyGlobalPostprocessing(log hclog.Logger, cfg config, outputPaths []strin
 			if newContent != contentStr {
 				modified = true
 				contentStr = newContent
+				key := rename.ResourceType + "." + rename.OldAttribute
+				appliedAttrRenames[key] = rename
 				log.Debug("Updated attribute references",
 					"file", filepath.Base(outputPath),
 					"resource_type", rename.ResourceType,
@@ -1248,7 +1236,38 @@ func applyGlobalPostprocessing(log hclog.Logger, cfg config, outputPaths []strin
 	}
 
 	if cfg.verbose {
-		fmt.Printf("✓ Updated cross-file references (%d rule(s) applied)\n", len(renames)+len(attributeRenames)+len(computedAttrMappings))
+		totalApplied := len(appliedRenames) + len(appliedAttrRenames) + len(appliedComputedMappings)
+		if totalApplied > 0 {
+			fmt.Printf("✓ Updated cross-file references (%d of %d rules applied)\n",
+				totalApplied, len(renames)+len(attributeRenames)+len(computedAttrMappings))
+
+			if len(appliedRenames) > 0 {
+				fmt.Println("\n  Resource type renames applied:")
+				for oldType, newType := range appliedRenames {
+					fmt.Printf("    %s → %s\n", oldType, newType)
+				}
+			}
+
+			if len(appliedAttrRenames) > 0 {
+				fmt.Println("\n  Attribute renames applied:")
+				for _, rename := range appliedAttrRenames {
+					fmt.Printf("    %s.*.%s → %s.*.%s\n",
+						rename.ResourceType, rename.OldAttribute,
+						rename.ResourceType, rename.NewAttribute)
+				}
+			}
+
+			if len(appliedComputedMappings) > 0 {
+				fmt.Println("\n  Computed attribute mappings applied:")
+				for _, mapping := range appliedComputedMappings {
+					fmt.Printf("    %s.*.%s → %s.*.%s\n",
+						mapping.OldResourceType, mapping.OldAttribute,
+						mapping.NewResourceType, mapping.NewAttribute)
+				}
+			}
+		} else {
+			fmt.Println("✓ No cross-file references needed updating")
+		}
 	}
 	return nil
 }

--- a/cmd/tf-migrate/preflight.go
+++ b/cmd/tf-migrate/preflight.go
@@ -331,10 +331,8 @@ func printPreflightReport(report *preflightReport, cfg config) {
 		}
 	}
 
-	// Only show detailed scan output in verbose mode or if there are issues (manual/unsupported)
-	hasIssues := len(manual) > 0 || len(unsupported) > 0
-
-	if cfg.verbose || hasIssues {
+	// Only show detailed scan output in verbose mode
+	if cfg.verbose {
 		fmt.Println()
 		fmt.Println("Pre-migration scan:")
 		fmt.Printf("  %d Cloudflare resource(s) found\n", len(report.Resources))
@@ -348,45 +346,42 @@ func printPreflightReport(report *preflightReport, cfg config) {
 			fmt.Println()
 		}
 
-		if len(autoMigrated) > 0 && cfg.verbose {
+		if len(autoMigrated) > 0 {
 			fmt.Printf("  Resources with config-only changes (%d):\n", len(autoMigrated))
 			for _, r := range autoMigrated {
 				fmt.Printf("    %s.%s\n", r.ResourceType, r.ResourceName)
 			}
 			fmt.Println()
-		} else if len(autoMigrated) > 0 && hasIssues {
-			fmt.Printf("  %d resource(s) with config-only changes (no rename)\n", len(autoMigrated))
+		}
+
+		if len(manual) > 0 {
+			fmt.Printf("  Resources requiring manual intervention (%d):\n", len(manual))
+			for _, r := range manual {
+				fmt.Printf("    %s.%s: %s\n", r.ResourceType, r.ResourceName, r.Detail)
+			}
+			fmt.Println()
+		}
+
+		if len(unsupported) > 0 {
+			fmt.Printf("  Unsupported resources -- no transformer registered (%d):\n", len(unsupported))
+			for _, r := range unsupported {
+				fmt.Printf("    %s.%s\n", r.ResourceType, r.ResourceName)
+			}
+			fmt.Println("  These resources must be migrated manually. Check the v5 migration guide:")
+			fmt.Println("  https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/guides/version-5-upgrade")
+			fmt.Println()
+		}
+
+		if len(report.MovedBlocks) > 0 {
+			fmt.Printf("  Existing moved blocks found (%d):\n", len(report.MovedBlocks))
+			for _, mb := range report.MovedBlocks {
+				fmt.Printf("    %s: %s.%s → %s.%s\n", mb.File, mb.FromType, mb.FromName, mb.ToType, mb.ToName)
+			}
 			fmt.Println()
 		}
 	} else {
-		// Minimal output in non-verbose mode with no issues
+		// Minimal output in non-verbose mode
 		fmt.Printf("  Migrated %d resources (%d renamed, %d config-only)\n",
 			len(report.Resources), len(renamed), len(autoMigrated))
-	}
-
-	if len(manual) > 0 {
-		fmt.Printf("  ⚠ Resources requiring manual intervention (%d):\n", len(manual))
-		for _, r := range manual {
-			fmt.Printf("    %s.%s: %s\n", r.ResourceType, r.ResourceName, r.Detail)
-		}
-		fmt.Println()
-	}
-
-	if len(unsupported) > 0 {
-		fmt.Printf("  ⚠ Unsupported resources -- no transformer registered (%d):\n", len(unsupported))
-		for _, r := range unsupported {
-			fmt.Printf("    %s.%s\n", r.ResourceType, r.ResourceName)
-		}
-		fmt.Println("  These resources must be migrated manually. Check the v5 migration guide:")
-		fmt.Println("  https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/guides/version-5-upgrade")
-		fmt.Println()
-	}
-
-	if len(report.MovedBlocks) > 0 {
-		fmt.Printf("  Existing moved blocks found (%d):\n", len(report.MovedBlocks))
-		for _, mb := range report.MovedBlocks {
-			fmt.Printf("    %s: %s.%s → %s.%s\n", mb.File, mb.FromType, mb.FromName, mb.ToType, mb.ToName)
-		}
-		fmt.Println()
 	}
 }


### PR DESCRIPTION
### Description

This PR improves the user experience of tf-migrate by reducing noise and showing only actionable information by default. Duplicate warnings are now consolidated, and informational logs are moved behind the `--verbose` flag.

### Problem

The previous output was noisy and repetitive:

1. **Informational logs shown by default** - Resource listings, rename tables, and file counts added clutter without actionable information
2. **Duplicate warnings** - The same "Application-scoped access policy cannot be automatically migrated" warning was repeated 10 times for 10 different resources
3. **Confusing output flow** - Preflight scan showed manual intervention warnings, then diagnostics repeated the same warnings in full detail

### Solution

#### 1. Minimal Output by Default
- Only show: `Migrated X resources (Y renamed, Z config-only)`
- Move all resource listings, rename tables, and file counts behind `--verbose`
- Show warnings and "Next steps" (actionable information) by default

#### 2. Consolidated Duplicate Warnings
- Group diagnostics by summary
- Show: `⚠ Warning Summary (N resources)` followed by resource list
- Show full detail/instructions once, not N times

#### 3. Simplified Output Flow
- Removed duplicate "Resources requiring manual intervention" section from preflight
- Warnings now only appear once in the diagnostics section

### Changes

| File | Change |
|------|--------|
| `cmd/tf-migrate/preflight.go` | Moved all scan details behind `--verbose` flag |
| `cmd/tf-migrate/main.go` | Added diagnostic consolidation; moved file count to verbose |

### New Types/Functions

```go
// Groups multiple diagnostics with the same summary
type consolidatedDiagnostic struct {
    Summary  string
    Severity hcl.DiagnosticSeverity
    Details  []string  // Resource names
    Sample   string    // Full detail from first occurrence
}

func consolidateDiagnostics(diags hcl.Diagnostics) []consolidatedDiagnostic
func extractResourceName(detail string) string
```

### Before vs After

**Before (default, non-verbose):**
```
Pre-migration scan:
  37 Cloudflare resource(s) found

  Resources with type rename + moved block (12):
    cloudflare_access_identity_provider.idp_saml → ...
    ... (11 more)

  15 resource(s) with config-only changes (no rename)

  ⚠ Resources requiring manual intervention (10):
    cloudflare_access_policy.authn_api_prod_humans: application_id detected...
    ... (9 more, one line each)

Migration diagnostics: 10 warning(s)
──────────────────────────────────────────────────────

⚠ Application-scoped access policy cannot be automatically migrated
Resource cloudflare_access_policy.authn_api_prod_humans...

⚠ Application-scoped access policy cannot be automatically migrated
Resource cloudflare_access_policy.authn_api_staging_humans...
... (repeated 8 more times with same instructions)
```

**After (default, non-verbose):**
```
  Migrated 37 resources (12 renamed, 15 config-only)

Migration diagnostics: 10 warning(s)
──────────────────────────────────────────────────────

⚠ Application-scoped access policy cannot be automatically migrated (10 resources)

  - cloudflare_access_policy.authn_api_prod_humans
  - cloudflare_access_policy.authn_api_staging_humans
  - cloudflare_access_policy.policyd_edge_prod_service_humans
  ... (all 10 listed once)

Application-scoped policies use a different API endpoint...

Manual steps required:
1. Review the generated 'removed' block
2. Add this policy inline...
... (instructions shown once)
```

**With `--verbose`:**
```
Pre-migration scan:
  37 Cloudflare resource(s) found

  Resources with type rename + moved block (12):
    ... (full list)

  Resources with config-only changes (15):
    ... (full list)

  Resources requiring manual intervention (10):
    ... (full list with details)

Found 15 configuration files to migrate
[1/15] Processing access.tf... ✓
[2/15] Processing identity.tf... ✓
...
```

### Testing

- [x] Build succeeds: `go build ./cmd/tf-migrate`
- [x] Default mode shows only summary and actionable warnings
- [x] `--verbose` mode shows full details
- [x] Duplicate warnings are consolidated correctly
- [x] Single warnings still show full detail

### Backwards Compatibility

- **Breaking:** Users relying on default output for resource listings will need to use `--verbose`
- **Migration:** Add `--verbose` flag to scripts that parse resource listings

### Example Usage

```bash
# Default - minimal output, only actionable information
tf-migrate migrate --config-dir ./terraform

# Verbose - full details for debugging
tf-migrate migrate --config-dir ./terraform --verbose

# Quiet - only errors
tf-migrate migrate --config-dir ./terraform --quiet
```

---

