### PR TITLE
fix(ruleset): convert action_parameters.rules map values from strings to lists

### DIFF
--- a/e2e/drift-exemptions/load_balancer_pool.yaml
+++ b/e2e/drift-exemptions/load_balancer_pool.yaml
@@ -8,14 +8,20 @@ version: 1
 
 exemptions:
   - name: "origins_reorder_drift"
-    description: "After migration, the v5 provider may show origins in a different order and report the 'enabled' field toggling between true/false and null. This is caused by a gap in the provider's state upgrader — the underlying load balancer pool and its origins are not changed in Cloudflare. Run terraform apply to re-sync state; the drift will not reappear on subsequent plans."
+    description: "After migration, the v5 provider may show origins in a different order and report computed fields changing. This is caused by a gap in the provider's state upgrader — the underlying load balancer pool and its origins are not changed in Cloudflare. Run terraform apply to re-sync state; the drift will not reappear on subsequent plans."
     patterns:
-      - 'enabled\s*=\s*(true|false)\s*->\s*null'
-      - 'enabled\s*=\s*(true|false)'
+      # NOTE: 'enabled = true/false -> null' patterns removed — now covered by
+      # global computed_value_refreshes exemption ('= false -> null', '= true -> null')
       - 'disabled_at'
-      - 'address.*192\.0\.2\.201'
-      - 'name.*static-origin'
-      - 'weight\s*=\s*1'
+    enabled: true
+
+  - name: "notification_filter_empty_removal"
+    description: "The 'notification_filter' attribute is new in the v5 provider (it did not exist in v4). After migration, the v5 provider may read an empty notification_filter from the API and include it in state, but since it is not present in the Terraform config, the plan shows it being removed (notification_filter = { pool = {} } -> null). This is safe — there are no actual notification filter settings configured. The drift resolves after running terraform apply."
+    resource_types:
+      - "cloudflare_load_balancer_pool"
+    patterns:
+      - 'notification_filter\s*='
+      - 'pool\s*=\s*\{\}\s*->\s*null'
     enabled: true
 
 settings:

--- a/e2e/drift-exemptions/zero_trust_access_policy.yaml
+++ b/e2e/drift-exemptions/zero_trust_access_policy.yaml
@@ -3,18 +3,6 @@
 version: 1
 
 exemptions:
-  # NOTE: session_duration_normalization exemption removed as the bug is fixed.
-  # tf-migrate now correctly preserves session_duration during migration.
-  # The exemption is kept here (disabled) for historical reference.
-  - name: "session_duration_normalization"
-    description: "DEPRECATED: tf-migrate now preserves session_duration. This exemption is no longer needed."
-    resource_types:
-      - "cloudflare_zero_trust_access_policy"
-    patterns:
-      - '~ session_duration\s*='
-      - 'session_duration.*->.*"24h"'
-    enabled: false
-
   # Application-scoped policies are converted to inline policies in v5.
   # The inline policy shows as being removed from the application because
   # the application resource needs to be updated to include the policy inline.

--- a/e2e/drift-exemptions/zero_trust_dlp_predefined_profile.yaml
+++ b/e2e/drift-exemptions/zero_trust_dlp_predefined_profile.yaml
@@ -15,18 +15,9 @@ exemptions:
       - 'enabled_entries.*->.*null'
     enabled: true
 
-  # name and open_access are Computed-only in v5 — the provider reads them from
-  # the API and stores them in state, but they cannot be set in config. After
-  # migration these fields show as (known after apply) on the first plan.
-  # One-time drift that resolves after the first terraform apply.
-  - name: "computed_only_fields"
-    description: "name and open_access are Computed-only in v5 and become (known after apply) on the first plan after migration. Resolves after apply."
-    resource_types:
-      - "cloudflare_zero_trust_dlp_predefined_profile"
-    patterns:
-      - '~ name\s*=.*->.*\(known after apply\)'
-      - '~ open_access\s*=.*->.*\(known after apply\)'
-    enabled: true
+  # NOTE: computed_only_fields exemption removed — the global computed_value_refreshes
+  # exemption already matches all lines containing (known after apply), which covers
+  # the name and open_access fields that are Computed-only in v5.
 
 settings:
   apply_exemptions: true

--- a/e2e/drift-exemptions/zero_trust_local_fallback_domain.yaml
+++ b/e2e/drift-exemptions/zero_trust_local_fallback_domain.yaml
@@ -1,3 +1,8 @@
+# Drift Exemptions for zero_trust_local_fallback_domain resource
+#
+# This module also manages cloudflare_zero_trust_device_custom_profile resources,
+# which can show precedence recalculation drift after migration.
+
 version: 1
 
 exemptions:
@@ -11,4 +16,4 @@ exemptions:
 
 settings:
   apply_exemptions: true
-  verbose_exemptions: true
+  verbose_exemptions: false

--- a/e2e/drift-exemptions/zone_dnssec.yaml
+++ b/e2e/drift-exemptions/zone_dnssec.yaml
@@ -27,25 +27,19 @@ exemptions:
       - '~ status\s*=\s*"pending-disabled"\s*->\s*"disabled"'
     enabled: true
 
-  # occurs when status field doesn't exist in the config (v4 > v5)
-  - name: "status_pending_to_null"
-    description: "When DNSSEC is being activated, the Cloudflare API returns a status of 'pending' before the DS records have fully propagated. If your config does not explicitly set the status field, Terraform will show 'status = \"pending\" -> null'. This is expected during the activation window and does not indicate a problem. Once DNSSEC activation completes, this drift will disappear on its own."
-    patterns:
-      - 'status.*=.*"pending".*->.*null'
-      - '-\s+status\s*=\s*"pending"\s*->\s*null'
-    enabled: true
+  # NOTE: status_pending_to_null exemption removed — it was fully subsumed by status_to_null below.
 
-  # Status field drift when migration doesn't preserve state value
+  # Status field drift when migration doesn't preserve state value.
+  # Covers status going to null (removal) for all possible status values.
   - name: "status_to_null"
-    description: "Status field going to null when state is not available during migration"
+    description: "The v4 provider stored DNSSEC status as a Computed attribute. During migration, the status may not be preserved in state, causing the plan to show the status being removed. Your DNSSEC configuration is not changed. This drift resolves after the next terraform apply."
     patterns:
       - 'status\s*=\s*"pending"\s*->\s*null'
       - 'status\s*=\s*"active"\s*->\s*null'
       - 'status\s*=\s*"disabled"\s*->\s*null'
-      - '-\s*status\s*=\s*"pending"'
-      - '-\s*status\s*=\s*"active"'
-      # Match the terraform plan format with varying whitespace
-      - '-\s+status\s+=\s+"pending"\s+->\s+null'
+      - '-\s*status\s*=\s*"pending"\s*->\s*null'
+      - '-\s*status\s*=\s*"active"\s*->\s*null'
+      - '-\s*status\s*=\s*"disabled"\s*->\s*null'
     enabled: true
 
 settings:

--- a/e2e/drift-exemptions/zone_setting.yaml
+++ b/e2e/drift-exemptions/zone_setting.yaml
@@ -15,6 +15,14 @@ exemptions:
     allow_resource_creation: true
     enabled: true
 
+  - name: "zone_setting_value_type_coercion"
+    description: "In v4, the cloudflare_zone_settings_override resource used individually-typed attributes for each setting (e.g. max_upload was TypeInt). In v5, cloudflare_zone_setting uses a single DynamicAttribute for 'value' that normalizes all values. The migrator writes the value as an integer (e.g. value = 300) matching the v4 type, but the v5 provider normalizes it to a string (value = \"300\"). The underlying setting is unchanged. The drift resolves after running terraform apply."
+    resource_types:
+      - "cloudflare_zone_setting"
+    patterns:
+      - 'value\s+=\s+\d+\s+->\s+"\d+"'
+    enabled: true
+
 settings:
   apply_exemptions: true
   verbose_exemptions: false

--- a/e2e/global-drift-exemptions.yaml
+++ b/e2e/global-drift-exemptions.yaml
@@ -12,6 +12,8 @@ exemptions:
     patterns:
       - '\(known after apply\)'
       - '= \{\} -> null'
+      - '= false -> null'
+      - '= true -> null'
     enabled: true
 
   # HTML entity encoding differences between v4 and v5 providers

--- a/integration/v4_to_v5/testdata/ruleset/expected/ruleset.tf
+++ b/integration/v4_to_v5/testdata/ruleset/expected/ruleset.tf
@@ -194,9 +194,98 @@ resource "cloudflare_ruleset" "log_custom_fields" {
   ]
 }
 
-# Note: WAF managed ruleset test removed - Cloudflare only allows one custom ruleset
-# per zone for http_request_firewall_managed phase. Testing WAF ruleset overrides
-# requires manual setup or importing existing rulesets.
+# Test Case: WAF managed ruleset with skip rules (action_parameters.rules map)
+# Tests conversion of comma-separated rule IDs to lists
+resource "cloudflare_ruleset" "waf_with_skip_rules" {
+  zone_id     = var.cloudflare_zone_id
+  name        = "${local.name_prefix}-waf-skip"
+  kind        = "zone"
+  phase       = "http_request_firewall_managed"
+  description = "WAF managed ruleset with skip rules"
+
+
+
+
+
+  rules = [
+    {
+      action      = "skip"
+      description = "Exempt firewall rule expressions from log4j WAF block"
+      enabled     = true
+      expression  = "(http.request.uri.path contains \"/filters\")"
+      action_parameters = {
+        rules = {
+          efb7b8c949ac4650a09736fc376e9aee = ["0c054d4e4dd5455c9ff8f01efe5abb10", "3536f964ccc345308b6445e8dc29b753", "e7e4b386797e417c998d872956c390a1"]
+        }
+      }
+      logging = {
+        enabled = true
+      }
+    },
+    {
+      action      = "skip"
+      description = "Single rule skip"
+      enabled     = true
+      expression  = "(http.request.uri.path contains \"/graphql\")"
+      action_parameters = {
+        rules = {
+          efb7b8c949ac4650a09736fc376e9aee = ["5f6744fa026a4638bda5b3d7d5e015dd"]
+        }
+      }
+      logging = {
+        enabled = true
+      }
+    },
+    {
+      action      = "skip"
+      description = "Multi-ruleset skip with mixed values"
+      enabled     = true
+      expression  = "(ip.src in {64.39.96.0/20})"
+      action_parameters = {
+        rules = {
+          "4814384a9e5d4991b9815dcfc25d2f1f" = ["6179ae15870a4bb7b2d480d4843b323c"]
+          "efb7b8c949ac4650a09736fc376e9aee" = ["0242110ae62e44028a13bf4834780914", "6b1cc72dff9746469d4695a474430f12"]
+        }
+      }
+      logging = {
+        enabled = true
+      }
+    },
+    {
+      action      = "skip"
+      description = "Skip current ruleset"
+      enabled     = true
+      expression  = "(http.request.uri.path contains \"/exempt\")"
+      action_parameters = {
+        ruleset = "current"
+      }
+      logging = {
+        enabled = true
+      }
+    },
+    {
+      action      = "execute"
+      enabled     = true
+      description = "Execute managed ruleset"
+      expression  = "true"
+      action_parameters = {
+        id = "efb7b8c949ac4650a09736fc376e9aee"
+        overrides = {
+          rules = [
+            {
+              enabled = false
+              id      = "5de7edfa648c4d6891dc3e7f84534ffa"
+            },
+            {
+              enabled = false
+              id      = "e3a567afc347477d9702d9047e97d760"
+            }
+          ]
+        }
+      }
+    }
+  ]
+}
 
 # Test Case 12: Cache settings with cache_reserve and query_string
 resource "cloudflare_ruleset" "cache_with_reserve" {

--- a/integration/v4_to_v5/testdata/ruleset/input/ruleset.tf
+++ b/integration/v4_to_v5/testdata/ruleset/input/ruleset.tf
@@ -185,9 +185,94 @@ resource "cloudflare_ruleset" "log_custom_fields" {
   }
 }
 
-# Note: WAF managed ruleset test removed - Cloudflare only allows one custom ruleset
-# per zone for http_request_firewall_managed phase. Testing WAF ruleset overrides
-# requires manual setup or importing existing rulesets.
+# Test Case: WAF managed ruleset with skip rules (action_parameters.rules map)
+# Tests conversion of comma-separated rule IDs to lists
+resource "cloudflare_ruleset" "waf_with_skip_rules" {
+  zone_id     = var.cloudflare_zone_id
+  name        = "${local.name_prefix}-waf-skip"
+  kind        = "zone"
+  phase       = "http_request_firewall_managed"
+  description = "WAF managed ruleset with skip rules"
+
+  rules {
+    action = "skip"
+    action_parameters {
+      rules = {
+        efb7b8c949ac4650a09736fc376e9aee = "0c054d4e4dd5455c9ff8f01efe5abb10,3536f964ccc345308b6445e8dc29b753,e7e4b386797e417c998d872956c390a1"
+      }
+    }
+    description = "Exempt firewall rule expressions from log4j WAF block"
+    enabled     = true
+    expression  = "(http.request.uri.path contains \"/filters\")"
+    logging {
+      enabled = true
+    }
+  }
+
+  rules {
+    action = "skip"
+    action_parameters {
+      rules = {
+        efb7b8c949ac4650a09736fc376e9aee = "5f6744fa026a4638bda5b3d7d5e015dd"
+      }
+    }
+    description = "Single rule skip"
+    enabled     = true
+    expression  = "(http.request.uri.path contains \"/graphql\")"
+    logging {
+      enabled = true
+    }
+  }
+
+  rules {
+    action = "skip"
+    action_parameters {
+      rules = {
+        "4814384a9e5d4991b9815dcfc25d2f1f" = "6179ae15870a4bb7b2d480d4843b323c"
+        "efb7b8c949ac4650a09736fc376e9aee" = "0242110ae62e44028a13bf4834780914,6b1cc72dff9746469d4695a474430f12"
+      }
+    }
+    description = "Multi-ruleset skip with mixed values"
+    enabled     = true
+    expression  = "(ip.src in {64.39.96.0/20})"
+    logging {
+      enabled = true
+    }
+  }
+
+  rules {
+    action = "skip"
+    action_parameters {
+      ruleset = "current"
+    }
+    description = "Skip current ruleset"
+    enabled     = true
+    expression  = "(http.request.uri.path contains \"/exempt\")"
+    logging {
+      enabled = true
+    }
+  }
+
+  rules {
+    action      = "execute"
+    enabled     = true
+    description = "Execute managed ruleset"
+    expression  = "true"
+    action_parameters {
+      id = "efb7b8c949ac4650a09736fc376e9aee"
+      overrides {
+        rules {
+          enabled = false
+          id      = "5de7edfa648c4d6891dc3e7f84534ffa"
+        }
+        rules {
+          enabled = false
+          id      = "e3a567afc347477d9702d9047e97d760"
+        }
+      }
+    }
+  }
+}
 
 # Test Case 12: Cache settings with cache_reserve and query_string
 resource "cloudflare_ruleset" "cache_with_reserve" {

--- a/internal/resources/ruleset/v4_to_v5.go
+++ b/internal/resources/ruleset/v4_to_v5.go
@@ -93,6 +93,11 @@ func (m *V4ToV5Migrator) TransformConfig(ctx *transform.Context, block *hclwrite
 			convertStringArrayToNameObjectArray(actionParamsBody, "cookie_fields")
 			convertStringArrayToNameObjectArray(actionParamsBody, "request_fields")
 			convertStringArrayToNameObjectArray(actionParamsBody, "response_fields")
+
+			// Transform action_parameters.rules map values from comma-separated strings to lists
+			// v4: rules = { ruleset_id = "rule1,rule2,rule3" }
+			// v5: rules = { ruleset_id = ["rule1", "rule2", "rule3"] }
+			convertRulesMapValuesToLists(actionParamsBody)
 		}
 	}
 
@@ -395,6 +400,108 @@ func convertStringArrayToNameObjectArray(body *hclwrite.Body, fieldName string) 
 
 	// Set the new attribute value
 	body.SetAttributeRaw(fieldName, tokens)
+}
+
+// convertRulesMapValuesToLists converts action_parameters.rules map values from strings
+// to lists of strings.
+// v4: rules = { efb7b8c9... = "rule1,rule2,rule3" } or rules = { efb7b8c9... = "rule1" }
+// v5: rules = { efb7b8c9... = ["rule1", "rule2", "rule3"] } or rules = { efb7b8c9... = ["rule1"] }
+// In v4, action_parameters.rules was a map(string) where values could be single or comma-separated rule IDs.
+// In v5, it changed to map(list(string)) where every value must be a list.
+func convertRulesMapValuesToLists(body *hclwrite.Body) {
+	rulesAttr := body.GetAttribute("rules")
+	if rulesAttr == nil {
+		return
+	}
+
+	// Get the expression tokens and check if it looks like a map literal
+	exprTokens := rulesAttr.Expr().BuildTokens(nil)
+	exprStr := strings.TrimSpace(string(exprTokens.Bytes()))
+
+	// Only process if it starts with { (a map literal)
+	if !strings.HasPrefix(exprStr, "{") {
+		return
+	}
+
+	// Check if this map has any string values (as opposed to already being lists or other types).
+	// We need to distinguish map keys (quoted strings before =) from map values (quoted strings after =).
+	// Track whether we've seen an = sign to know if a quoted string is a key or value.
+	hasStringValues := false
+	afterEqual := false
+	for _, token := range exprTokens {
+		if token.Type == hclsyntax.TokenEqual {
+			afterEqual = true
+			continue
+		}
+		if afterEqual && token.Type == hclsyntax.TokenOQuote {
+			hasStringValues = true
+			break
+		}
+		if token.Type == hclsyntax.TokenNewline || token.Type == hclsyntax.TokenOBrace || token.Type == hclsyntax.TokenCBrace {
+			afterEqual = false
+		}
+	}
+
+	if !hasStringValues {
+		return
+	}
+
+	// Build new tokens converting all map string values to lists.
+	// We track whether we're after an = sign to only convert values (not keys).
+	var newTokens hclwrite.Tokens
+	afterEq := false
+	for i := 0; i < len(exprTokens); i++ {
+		token := exprTokens[i]
+
+		if token.Type == hclsyntax.TokenEqual {
+			afterEq = true
+			newTokens = append(newTokens, token)
+			continue
+		}
+
+		// Reset afterEq on newline or braces (next line is a new key-value pair)
+		if token.Type == hclsyntax.TokenNewline || token.Type == hclsyntax.TokenCBrace {
+			afterEq = false
+			newTokens = append(newTokens, token)
+			continue
+		}
+
+		// Look for pattern: TokenOQuote TokenQuotedLit TokenCQuote after an = sign
+		// These are map values that need to be converted to lists
+		if afterEq && token.Type == hclsyntax.TokenOQuote &&
+			i+2 < len(exprTokens) &&
+			exprTokens[i+1].Type == hclsyntax.TokenQuotedLit &&
+			exprTokens[i+2].Type == hclsyntax.TokenCQuote {
+
+			quotedVal := string(exprTokens[i+1].Bytes)
+
+			// Split by comma (handles both single values and comma-separated)
+			parts := strings.Split(quotedVal, ",")
+			newTokens = append(newTokens, &hclwrite.Token{Type: hclsyntax.TokenOBrack, Bytes: []byte("[")})
+
+			for j, part := range parts {
+				part = strings.TrimSpace(part)
+				if j > 0 {
+					newTokens = append(newTokens, &hclwrite.Token{Type: hclsyntax.TokenComma, Bytes: []byte(",")})
+					newTokens = append(newTokens, &hclwrite.Token{Type: hclsyntax.TokenIdent, Bytes: []byte(" ")})
+				}
+				newTokens = append(newTokens, &hclwrite.Token{Type: hclsyntax.TokenOQuote, Bytes: []byte("\"")})
+				newTokens = append(newTokens, &hclwrite.Token{Type: hclsyntax.TokenQuotedLit, Bytes: []byte(part)})
+				newTokens = append(newTokens, &hclwrite.Token{Type: hclsyntax.TokenCQuote, Bytes: []byte("\"")})
+			}
+
+			newTokens = append(newTokens, &hclwrite.Token{Type: hclsyntax.TokenCBrack, Bytes: []byte("]")})
+
+			// Skip the original 3 tokens (OQuote, QuotedLit, CQuote)
+			i += 2
+			afterEq = false
+			continue
+		}
+
+		newTokens = append(newTokens, token)
+	}
+
+	body.SetAttributeRaw("rules", newTokens)
 }
 
 // convertDynamicRulesToForExpression converts dynamic "rules" blocks to rules = [for ...] syntax

--- a/internal/resources/ruleset/v4_to_v5_test.go
+++ b/internal/resources/ruleset/v4_to_v5_test.go
@@ -467,6 +467,149 @@ func TestV4ToV5Transformation(t *testing.T) {
 }`,
 			},
 			{
+				Name: "WAF managed ruleset skip with action_parameters.rules comma-separated strings to lists",
+				Input: `resource "cloudflare_ruleset" "example" {
+  zone_id = "test123"
+  name    = "zone"
+  kind    = "zone"
+  phase   = "http_request_firewall_managed"
+
+  rules {
+    action = "skip"
+    action_parameters {
+      rules = {
+        efb7b8c949ac4650a09736fc376e9aee = "0c054d4e4dd5455c9ff8f01efe5abb10,3536f964ccc345308b6445e8dc29b753,e7e4b386797e417c998d872956c390a1"
+      }
+    }
+    description = "Exempt firewall rule expressions from log4j WAF block"
+    enabled     = true
+    expression  = "(http.request.uri.path contains \"/filters\")"
+    logging {
+      enabled = true
+    }
+  }
+}`,
+				Expected: `resource "cloudflare_ruleset" "example" {
+  zone_id = "test123"
+  name    = "zone"
+  kind    = "zone"
+  phase   = "http_request_firewall_managed"
+
+  rules = [
+    {
+      action      = "skip"
+      description = "Exempt firewall rule expressions from log4j WAF block"
+      enabled     = true
+      expression  = "(http.request.uri.path contains \"/filters\")"
+      action_parameters = {
+        rules = {
+          efb7b8c949ac4650a09736fc376e9aee = ["0c054d4e4dd5455c9ff8f01efe5abb10", "3536f964ccc345308b6445e8dc29b753", "e7e4b386797e417c998d872956c390a1"]
+        }
+      }
+      logging = {
+        enabled = true
+      }
+    }
+  ]
+}`,
+			},
+			{
+				Name: "WAF managed ruleset skip with single rule ID (no comma) also becomes list",
+				Input: `resource "cloudflare_ruleset" "example" {
+  zone_id = "test123"
+  name    = "zone"
+  kind    = "zone"
+  phase   = "http_request_firewall_managed"
+
+  rules {
+    action = "skip"
+    action_parameters {
+      rules = {
+        efb7b8c949ac4650a09736fc376e9aee = "5f6744fa026a4638bda5b3d7d5e015dd"
+      }
+    }
+    description = "Single rule skip"
+    enabled     = true
+    expression  = "true"
+    logging {
+      enabled = true
+    }
+  }
+}`,
+				Expected: `resource "cloudflare_ruleset" "example" {
+  zone_id = "test123"
+  name    = "zone"
+  kind    = "zone"
+  phase   = "http_request_firewall_managed"
+
+  rules = [
+    {
+      action      = "skip"
+      description = "Single rule skip"
+      enabled     = true
+      expression  = "true"
+      action_parameters = {
+        rules = {
+          efb7b8c949ac4650a09736fc376e9aee = ["5f6744fa026a4638bda5b3d7d5e015dd"]
+        }
+      }
+      logging = {
+        enabled = true
+      }
+    }
+  ]
+}`,
+			},
+			{
+				Name: "WAF managed ruleset skip with multiple map entries and mixed comma values",
+				Input: `resource "cloudflare_ruleset" "example" {
+  zone_id = "test123"
+  name    = "zone"
+  kind    = "zone"
+  phase   = "http_request_firewall_managed"
+
+  rules {
+    action = "skip"
+    action_parameters {
+      rules = {
+        "4814384a9e5d4991b9815dcfc25d2f1f" = "6179ae15870a4bb7b2d480d4843b323c"
+        "efb7b8c949ac4650a09736fc376e9aee" = "0242110ae62e44028a13bf4834780914,6b1cc72dff9746469d4695a474430f12,55b100786189495c93744db0e1efdffb"
+      }
+    }
+    description = "Multiple map entries"
+    enabled     = true
+    expression  = "true"
+    logging {
+      enabled = true
+    }
+  }
+}`,
+				Expected: `resource "cloudflare_ruleset" "example" {
+  zone_id = "test123"
+  name    = "zone"
+  kind    = "zone"
+  phase   = "http_request_firewall_managed"
+
+  rules = [
+    {
+      action      = "skip"
+      description = "Multiple map entries"
+      enabled     = true
+      expression  = "true"
+      action_parameters = {
+        rules = {
+          "4814384a9e5d4991b9815dcfc25d2f1f" = ["6179ae15870a4bb7b2d480d4843b323c"]
+          "efb7b8c949ac4650a09736fc376e9aee" = ["0242110ae62e44028a13bf4834780914", "6b1cc72dff9746469d4695a474430f12", "55b100786189495c93744db0e1efdffb"]
+        }
+      }
+      logging = {
+        enabled = true
+      }
+    }
+  ]
+}`,
+			},
+			{
 				Name: "Cache key query_string with only exclude",
 				Input: `resource "cloudflare_ruleset" "example" {
   zone_id = "test123"

--- a/internal/verifydrift/exemptions/drift-exemptions/load_balancer_pool.yaml
+++ b/internal/verifydrift/exemptions/drift-exemptions/load_balancer_pool.yaml
@@ -8,14 +8,20 @@ version: 1
 
 exemptions:
   - name: "origins_reorder_drift"
-    description: "After migration, the v5 provider may show origins in a different order and report the 'enabled' field toggling between true/false and null. This is caused by a gap in the provider's state upgrader — the underlying load balancer pool and its origins are not changed in Cloudflare. Run terraform apply to re-sync state; the drift will not reappear on subsequent plans."
+    description: "After migration, the v5 provider may show origins in a different order and report computed fields changing. This is caused by a gap in the provider's state upgrader — the underlying load balancer pool and its origins are not changed in Cloudflare. Run terraform apply to re-sync state; the drift will not reappear on subsequent plans."
     patterns:
-      - 'enabled\s*=\s*(true|false)\s*->\s*null'
-      - 'enabled\s*=\s*(true|false)'
+      # NOTE: 'enabled = true/false -> null' patterns removed — now covered by
+      # global computed_value_refreshes exemption ('= false -> null', '= true -> null')
       - 'disabled_at'
-      - 'address.*192\.0\.2\.201'
-      - 'name.*static-origin'
-      - 'weight\s*=\s*1'
+    enabled: true
+
+  - name: "notification_filter_empty_removal"
+    description: "The 'notification_filter' attribute is new in the v5 provider (it did not exist in v4). After migration, the v5 provider may read an empty notification_filter from the API and include it in state, but since it is not present in the Terraform config, the plan shows it being removed (notification_filter = { pool = {} } -> null). This is safe — there are no actual notification filter settings configured. The drift resolves after running terraform apply."
+    resource_types:
+      - "cloudflare_load_balancer_pool"
+    patterns:
+      - 'notification_filter\s*='
+      - 'pool\s*=\s*\{\}\s*->\s*null'
     enabled: true
 
 settings:

--- a/internal/verifydrift/exemptions/drift-exemptions/zero_trust_access_policy.yaml
+++ b/internal/verifydrift/exemptions/drift-exemptions/zero_trust_access_policy.yaml
@@ -3,18 +3,6 @@
 version: 1
 
 exemptions:
-  # NOTE: session_duration_normalization exemption removed as the bug is fixed.
-  # tf-migrate now correctly preserves session_duration during migration.
-  # The exemption is kept here (disabled) for historical reference.
-  - name: "session_duration_normalization"
-    description: "DEPRECATED: tf-migrate now preserves session_duration. This exemption is no longer needed."
-    resource_types:
-      - "cloudflare_zero_trust_access_policy"
-    patterns:
-      - '~ session_duration\s*='
-      - 'session_duration.*->.*"24h"'
-    enabled: false
-
   # Application-scoped policies are converted to inline policies in v5.
   # The inline policy shows as being removed from the application because
   # the application resource needs to be updated to include the policy inline.

--- a/internal/verifydrift/exemptions/drift-exemptions/zero_trust_dlp_predefined_profile.yaml
+++ b/internal/verifydrift/exemptions/drift-exemptions/zero_trust_dlp_predefined_profile.yaml
@@ -15,18 +15,9 @@ exemptions:
       - 'enabled_entries.*->.*null'
     enabled: true
 
-  # name and open_access are Computed-only in v5 — the provider reads them from
-  # the API and stores them in state, but they cannot be set in config. After
-  # migration these fields show as (known after apply) on the first plan.
-  # One-time drift that resolves after the first terraform apply.
-  - name: "computed_only_fields"
-    description: "name and open_access are Computed-only in v5 and become (known after apply) on the first plan after migration. Resolves after apply."
-    resource_types:
-      - "cloudflare_zero_trust_dlp_predefined_profile"
-    patterns:
-      - '~ name\s*=.*->.*\(known after apply\)'
-      - '~ open_access\s*=.*->.*\(known after apply\)'
-    enabled: true
+  # NOTE: computed_only_fields exemption removed — the global computed_value_refreshes
+  # exemption already matches all lines containing (known after apply), which covers
+  # the name and open_access fields that are Computed-only in v5.
 
 settings:
   apply_exemptions: true

--- a/internal/verifydrift/exemptions/drift-exemptions/zero_trust_local_fallback_domain.yaml
+++ b/internal/verifydrift/exemptions/drift-exemptions/zero_trust_local_fallback_domain.yaml
@@ -1,3 +1,8 @@
+# Drift Exemptions for zero_trust_local_fallback_domain resource
+#
+# This module also manages cloudflare_zero_trust_device_custom_profile resources,
+# which can show precedence recalculation drift after migration.
+
 version: 1
 
 exemptions:
@@ -11,4 +16,4 @@ exemptions:
 
 settings:
   apply_exemptions: true
-  verbose_exemptions: true
+  verbose_exemptions: false

--- a/internal/verifydrift/exemptions/drift-exemptions/zone_dnssec.yaml
+++ b/internal/verifydrift/exemptions/drift-exemptions/zone_dnssec.yaml
@@ -27,25 +27,19 @@ exemptions:
       - '~ status\s*=\s*"pending-disabled"\s*->\s*"disabled"'
     enabled: true
 
-  # occurs when status field doesn't exist in the config (v4 > v5)
-  - name: "status_pending_to_null"
-    description: "When DNSSEC is being activated, the Cloudflare API returns a status of 'pending' before the DS records have fully propagated. If your config does not explicitly set the status field, Terraform will show 'status = \"pending\" -> null'. This is expected during the activation window and does not indicate a problem. Once DNSSEC activation completes, this drift will disappear on its own."
-    patterns:
-      - 'status.*=.*"pending".*->.*null'
-      - '-\s+status\s*=\s*"pending"\s*->\s*null'
-    enabled: true
+  # NOTE: status_pending_to_null exemption removed — it was fully subsumed by status_to_null below.
 
-  # Status field drift when migration doesn't preserve state value
+  # Status field drift when migration doesn't preserve state value.
+  # Covers status going to null (removal) for all possible status values.
   - name: "status_to_null"
-    description: "Status field going to null when state is not available during migration"
+    description: "The v4 provider stored DNSSEC status as a Computed attribute. During migration, the status may not be preserved in state, causing the plan to show the status being removed. Your DNSSEC configuration is not changed. This drift resolves after the next terraform apply."
     patterns:
       - 'status\s*=\s*"pending"\s*->\s*null'
       - 'status\s*=\s*"active"\s*->\s*null'
       - 'status\s*=\s*"disabled"\s*->\s*null'
-      - '-\s*status\s*=\s*"pending"'
-      - '-\s*status\s*=\s*"active"'
-      # Match the terraform plan format with varying whitespace
-      - '-\s+status\s+=\s+"pending"\s+->\s+null'
+      - '-\s*status\s*=\s*"pending"\s*->\s*null'
+      - '-\s*status\s*=\s*"active"\s*->\s*null'
+      - '-\s*status\s*=\s*"disabled"\s*->\s*null'
     enabled: true
 
 settings:

--- a/internal/verifydrift/exemptions/drift-exemptions/zone_setting.yaml
+++ b/internal/verifydrift/exemptions/drift-exemptions/zone_setting.yaml
@@ -15,6 +15,14 @@ exemptions:
     allow_resource_creation: true
     enabled: true
 
+  - name: "zone_setting_value_type_coercion"
+    description: "In v4, the cloudflare_zone_settings_override resource used individually-typed attributes for each setting (e.g. max_upload was TypeInt). In v5, cloudflare_zone_setting uses a single DynamicAttribute for 'value' that normalizes all values. The migrator writes the value as an integer (e.g. value = 300) matching the v4 type, but the v5 provider normalizes it to a string (value = \"300\"). The underlying setting is unchanged. The drift resolves after running terraform apply."
+    resource_types:
+      - "cloudflare_zone_setting"
+    patterns:
+      - 'value\s+=\s+\d+\s+->\s+"\d+"'
+    enabled: true
+
 settings:
   apply_exemptions: true
   verbose_exemptions: false

--- a/internal/verifydrift/exemptions/global-drift-exemptions.yaml
+++ b/internal/verifydrift/exemptions/global-drift-exemptions.yaml
@@ -12,6 +12,8 @@ exemptions:
     patterns:
       - '\(known after apply\)'
       - '= \{\} -> null'
+      - '= false -> null'
+      - '= true -> null'
     enabled: true
 
   # HTML entity encoding differences between v4 and v5 providers


### PR DESCRIPTION
In v4, action_parameters.rules in skip/execute rules was map(string) where
values were single or comma-separated rule IDs. In v5, this changed to
map(list(string)) where every value must be an explicit list.

The migrator was not handling this conversion, causing terraform plan to fail
with 'list of string required' after migration.