### PR TITLE
feat(drift): Add drift exemptions for `cloudflare_pages_project`

### DIFF
--- a/e2e/drift-exemptions/pages_project.yaml
+++ b/e2e/drift-exemptions/pages_project.yaml
@@ -1,0 +1,45 @@
+# Drift Exemptions for pages_project resource
+#
+# Resource-specific exemptions for cloudflare_pages_project
+#
+# Two known drift patterns arise when upgrading from the v4 to v5 Cloudflare
+# provider for Pages projects:
+#
+# 1. build_image_major_version: the v5 provider defaults to version 3 (up from
+#    the v4 default of 2). If the config does not pin this value, the provider
+#    reports an in-place update. The underlying build image used for future
+#    deployments changes, but no Pages content or settings are destroyed.
+#
+# 2. env_vars inside deployment_configs: the v5 provider schema treats
+#    deployment_configs.{preview,production}.env_vars as a computed attribute.
+#    Values that were tracked in v4 state are no longer surfaced by the v5
+#    provider's read, so Terraform plans to remove them. The environment
+#    variables themselves are NOT deleted from Cloudflare — they remain in
+#    place and are simply no longer managed via this attribute path.
+
+version: 1
+
+exemptions:
+  - name: "pages_project_build_image_version"
+    description: "The v5 Cloudflare provider changed the default build image from major version 2 to 3. If the Terraform config does not explicitly pin build_image_major_version, the v5 provider will plan an in-place update from 2 to 3. This does not affect live Pages deployments or content — it only changes the build environment used for future deployments. The drift resolves after running terraform apply."
+    resource_types:
+      - "cloudflare_pages_project"
+    patterns:
+      - 'build_image_major_version\s+=\s+\d+\s+->\s+\d+'
+    enabled: true
+
+  - name: "pages_project_env_vars_computed"
+    description: "In v5, the deployment_configs.{preview,production}.env_vars attribute is treated as computed by the provider. Values stored in v4 state are not returned by the v5 provider's Read, so Terraform plans to remove them. The environment variables are NOT deleted from Cloudflare — they continue to exist and function. This is a state representation change only, not a destructive action."
+    resource_types:
+      - "cloudflare_pages_project"
+    patterns:
+      - 'env_vars\s+=\s+\{.*->.*null'
+      - 'env_vars\s+=\s+\{'
+      - '"[A-Z_]+"\s+=\s+\{'
+      - 'type\s+=\s+"(plain_text|secret_text)"\s+->\s+null'
+      - 'value\s+=\s+\(sensitive value\)\s+->\s+null'
+    enabled: true
+
+settings:
+  apply_exemptions: true
+  verbose_exemptions: false

--- a/internal/verifydrift/exemptions/drift-exemptions/pages_project.yaml
+++ b/internal/verifydrift/exemptions/drift-exemptions/pages_project.yaml
@@ -1,0 +1,45 @@
+# Drift Exemptions for pages_project resource
+#
+# Resource-specific exemptions for cloudflare_pages_project
+#
+# Two known drift patterns arise when upgrading from the v4 to v5 Cloudflare
+# provider for Pages projects:
+#
+# 1. build_image_major_version: the v5 provider defaults to version 3 (up from
+#    the v4 default of 2). If the config does not pin this value, the provider
+#    reports an in-place update. The underlying build image used for future
+#    deployments changes, but no Pages content or settings are destroyed.
+#
+# 2. env_vars inside deployment_configs: the v5 provider schema treats
+#    deployment_configs.{preview,production}.env_vars as a computed attribute.
+#    Values that were tracked in v4 state are no longer surfaced by the v5
+#    provider's read, so Terraform plans to remove them. The environment
+#    variables themselves are NOT deleted from Cloudflare — they remain in
+#    place and are simply no longer managed via this attribute path.
+
+version: 1
+
+exemptions:
+  - name: "pages_project_build_image_version"
+    description: "The v5 Cloudflare provider changed the default build image from major version 2 to 3. If the Terraform config does not explicitly pin build_image_major_version, the v5 provider will plan an in-place update from 2 to 3. This does not affect live Pages deployments or content — it only changes the build environment used for future deployments. The drift resolves after running terraform apply."
+    resource_types:
+      - "cloudflare_pages_project"
+    patterns:
+      - 'build_image_major_version\s+=\s+\d+\s+->\s+\d+'
+    enabled: true
+
+  - name: "pages_project_env_vars_computed"
+    description: "In v5, the deployment_configs.{preview,production}.env_vars attribute is treated as computed by the provider. Values stored in v4 state are not returned by the v5 provider's Read, so Terraform plans to remove them. The environment variables are NOT deleted from Cloudflare — they continue to exist and function. This is a state representation change only, not a destructive action."
+    resource_types:
+      - "cloudflare_pages_project"
+    patterns:
+      - 'env_vars\s+=\s+\{.*->.*null'
+      - 'env_vars\s+=\s+\{'
+      - '"[A-Z_]+"\s+=\s+\{'
+      - 'type\s+=\s+"(plain_text|secret_text)"\s+->\s+null'
+      - 'value\s+=\s+\(sensitive value\)\s+->\s+null'
+    enabled: true
+
+settings:
+  apply_exemptions: true
+  verbose_exemptions: false


### PR DESCRIPTION
When users with `cloudflare_pages_project` resources run `tf-migrate verify-drift` after upgrading to the v5 provider, two false-positive drift patterns are reported. This PR registers them as known-safe exemptions so `verify-drift` correctly reports `MIGRATION LOOKS GOOD`.

### Background

Validated against a real production plan (`dash-production.out`) showing 40 flagged changes across two Pages projects — all of which are provider behaviour changes, not config regressions.

### Exempted patterns

**`pages_project_build_image_version`**

```
~ build_image_major_version = 2 -> 3
```

The v5 provider changed its default build image from major version 2 to 3. Configs that don't explicitly pin `build_image_major_version` will see this in-place update. No Pages content or settings are affected; only future build environments change. Resolves after `terraform apply`.

**`pages_project_env_vars_computed`**

```
- env_vars = { "DASH_HOST" = { type = "plain_text" -> null, value = (sensitive) -> null }, ... }
```

In v5, `deployment_configs.{preview,production}.env_vars` is a computed attribute. The v5 provider's Read does not surface values already set in Cloudflare, so Terraform plans to remove them from state. This is **not destructive** — the environment variables remain in Cloudflare and continue to function. It is a state representation change only.

### Files changed

- `e2e/drift-exemptions/pages_project.yaml` — source of truth
- `internal/verifydrift/exemptions/drift-exemptions/pages_project.yaml` — synced embedded copy (via `make sync-exemptions`)

---

