### PR TITLE
fix(zero_trust_list): migrate items_with_description written as attribute

### DIFF
--- a/integration/v4_to_v5/testdata/zero_trust_list/expected/zero_trust_list_items_with_description_attr.tf
+++ b/integration/v4_to_v5/testdata/zero_trust_list/expected/zero_trust_list_items_with_description_attr.tf
@@ -18,7 +18,7 @@ locals {
 # Expected: attribute is renamed to items, expression preserved verbatim.
 resource "cloudflare_zero_trust_list" "iwd_opaque_local" {
   account_id  = var.cloudflare_account_id
-  name        = "Do Not Inspect Tunnels IWD Opaque"
+  name        = "cftftest Do Not Inspect Tunnels IWD Opaque"
   description = "List using items_with_description as a local reference"
   type        = "IP"
   items       = local.tunnel_routes
@@ -29,7 +29,7 @@ resource "cloudflare_zero_trust_list" "iwd_opaque_local" {
 # Expected: merged into a single items attribute; items_with_description entries first.
 resource "cloudflare_zero_trust_list" "iwd_inline_with_refs" {
   account_id  = var.cloudflare_account_id
-  name        = "Do Not Inspect IPs IWD Inline"
+  name        = "cftftest Do Not Inspect IPs IWD Inline"
   description = "List using items_with_description as an inline object list with references"
   type        = "IP"
   items = [
@@ -53,7 +53,7 @@ resource "cloudflare_zero_trust_list" "iwd_inline_with_refs" {
 # Expected: items_with_description replaced by items with object entries.
 resource "cloudflare_zero_trust_list" "iwd_inline_static" {
   account_id = var.cloudflare_account_id
-  name       = "Do Not Inspect IPs IWD Static"
+  name       = "cftftest Do Not Inspect IPs IWD Static"
   type       = "IP"
   items = [
     {

--- a/integration/v4_to_v5/testdata/zero_trust_list/expected/zero_trust_list_items_with_description_attr.tf
+++ b/integration/v4_to_v5/testdata/zero_trust_list/expected/zero_trust_list_items_with_description_attr.tf
@@ -1,0 +1,68 @@
+# Integration test fixtures for Bug #001:
+# items_with_description written as an attribute (not a block) must be migrated.
+
+locals {
+  tunnel_routes = [
+    {
+      value       = "10.0.0.0/8"
+      description = "Internal network"
+    },
+    {
+      value       = "172.16.0.0/12"
+      description = "RFC 1918 block"
+    },
+  ]
+}
+
+# Case A: items_with_description = local.<name>  (opaque expression)
+# Expected: attribute is renamed to items, expression preserved verbatim.
+resource "cloudflare_zero_trust_list" "iwd_opaque_local" {
+  account_id  = var.cloudflare_account_id
+  name        = "Do Not Inspect Tunnels IWD Opaque"
+  description = "List using items_with_description as a local reference"
+  type        = "IP"
+  items       = local.tunnel_routes
+}
+
+# Case B: items_with_description = [...] (inline object list with resource references)
+# AND a separate items = [...] attribute.
+# Expected: merged into a single items attribute; items_with_description entries first.
+resource "cloudflare_zero_trust_list" "iwd_inline_with_refs" {
+  account_id  = var.cloudflare_account_id
+  name        = "Do Not Inspect IPs IWD Inline"
+  description = "List using items_with_description as an inline object list with references"
+  type        = "IP"
+  items = [
+    {
+      value       = cloudflare_zero_trust_list.iwd_opaque_local.id
+      description = "Reference to another list"
+    },
+    {
+      value       = "8.14.199.1"
+      description = null
+    },
+    {
+      value       = "8.14.199.2"
+      description = null
+    }
+  ]
+}
+
+# Case C: items_with_description = [...] (inline object list, static strings only)
+# No separate items attr.
+# Expected: items_with_description replaced by items with object entries.
+resource "cloudflare_zero_trust_list" "iwd_inline_static" {
+  account_id = var.cloudflare_account_id
+  name       = "Do Not Inspect IPs IWD Static"
+  type       = "IP"
+  items = [
+    {
+      value       = "192.168.1.1"
+      description = "Gateway"
+    },
+    {
+      value       = "10.0.0.1"
+      description = "Internal host"
+    }
+  ]
+}

--- a/integration/v4_to_v5/testdata/zero_trust_list/input/zero_trust_list_items_with_description_attr.tf
+++ b/integration/v4_to_v5/testdata/zero_trust_list/input/zero_trust_list_items_with_description_attr.tf
@@ -1,0 +1,67 @@
+# Integration test fixtures for Bug #001:
+# items_with_description written as an attribute (not a block) must be migrated.
+
+locals {
+  tunnel_routes = [
+    {
+      value       = "10.0.0.0/8"
+      description = "Internal network"
+    },
+    {
+      value       = "172.16.0.0/12"
+      description = "RFC 1918 block"
+    },
+  ]
+}
+
+# Case A: items_with_description = local.<name>  (opaque expression)
+# Expected: attribute is renamed to items, expression preserved verbatim.
+resource "cloudflare_zero_trust_list" "iwd_opaque_local" {
+  account_id             = var.cloudflare_account_id
+  name                   = "Do Not Inspect Tunnels IWD Opaque"
+  description            = "List using items_with_description as a local reference"
+  type                   = "IP"
+  items_with_description = local.tunnel_routes
+}
+
+# Case B: items_with_description = [...] (inline object list with resource references)
+# AND a separate items = [...] attribute.
+# Expected: merged into a single items attribute; items_with_description entries first.
+resource "cloudflare_zero_trust_list" "iwd_inline_with_refs" {
+  account_id  = var.cloudflare_account_id
+  name        = "Do Not Inspect IPs IWD Inline"
+  description = "List using items_with_description as an inline object list with references"
+  type        = "IP"
+  items_with_description = [
+    {
+      value       = cloudflare_zero_trust_list.iwd_opaque_local.id
+      description = "Reference to another list"
+    },
+  ]
+  items = [{
+    description = null
+    value       = "8.14.199.1"
+    }, {
+    description = null
+    value       = "8.14.199.2"
+  }]
+}
+
+# Case C: items_with_description = [...] (inline object list, static strings only)
+# No separate items attr.
+# Expected: items_with_description replaced by items with object entries.
+resource "cloudflare_zero_trust_list" "iwd_inline_static" {
+  account_id = var.cloudflare_account_id
+  name       = "Do Not Inspect IPs IWD Static"
+  type       = "IP"
+  items_with_description = [
+    {
+      value       = "192.168.1.1"
+      description = "Gateway"
+    },
+    {
+      value       = "10.0.0.1"
+      description = "Internal host"
+    },
+  ]
+}

--- a/integration/v4_to_v5/testdata/zero_trust_list/input/zero_trust_list_items_with_description_attr.tf
+++ b/integration/v4_to_v5/testdata/zero_trust_list/input/zero_trust_list_items_with_description_attr.tf
@@ -18,7 +18,7 @@ locals {
 # Expected: attribute is renamed to items, expression preserved verbatim.
 resource "cloudflare_zero_trust_list" "iwd_opaque_local" {
   account_id             = var.cloudflare_account_id
-  name                   = "Do Not Inspect Tunnels IWD Opaque"
+  name                   = "cftftest Do Not Inspect Tunnels IWD Opaque"
   description            = "List using items_with_description as a local reference"
   type                   = "IP"
   items_with_description = local.tunnel_routes
@@ -29,7 +29,7 @@ resource "cloudflare_zero_trust_list" "iwd_opaque_local" {
 # Expected: merged into a single items attribute; items_with_description entries first.
 resource "cloudflare_zero_trust_list" "iwd_inline_with_refs" {
   account_id  = var.cloudflare_account_id
-  name        = "Do Not Inspect IPs IWD Inline"
+  name        = "cftftest Do Not Inspect IPs IWD Inline"
   description = "List using items_with_description as an inline object list with references"
   type        = "IP"
   items_with_description = [
@@ -52,7 +52,7 @@ resource "cloudflare_zero_trust_list" "iwd_inline_with_refs" {
 # Expected: items_with_description replaced by items with object entries.
 resource "cloudflare_zero_trust_list" "iwd_inline_static" {
   account_id = var.cloudflare_account_id
-  name       = "Do Not Inspect IPs IWD Static"
+  name       = "cftftest Do Not Inspect IPs IWD Static"
   type       = "IP"
   items_with_description = [
     {

--- a/internal/resources/zero_trust_list/v4_to_v5_test.go
+++ b/internal/resources/zero_trust_list/v4_to_v5_test.go
@@ -413,6 +413,169 @@ resource "cloudflare_zero_trust_list" "vault_cidrs" {
 	testhelpers.RunConfigTransformTests(t, tests, migrator)
 }
 
+// TestV4ToV5Transformation_ItemsWithDescriptionAsAttribute tests Bug #001:
+// items_with_description written as an HCL attribute (not a block) must be migrated.
+// These cover the three real-world patterns found in the production config.
+func TestV4ToV5Transformation_ItemsWithDescriptionAsAttribute(t *testing.T) {
+	migrator := NewV4ToV5Migrator()
+
+	tests := []testhelpers.ConfigTestCase{
+		{
+			// Real-world Case A: items_with_description = local.<name>
+			// The expression is opaque — cannot be evaluated statically.
+			// Expected: rename attribute to items verbatim, preserve the expression.
+			Name: "items_with_description as opaque local reference is renamed to items",
+			Input: `
+resource "cloudflare_zero_trust_list" "do_not_inspect_tunnels" {
+  account_id             = var.account_id
+  name                   = "Do Not Inspect Tunnels"
+  description            = "List of tunnels that should not undergo http inspection"
+  type                   = "IP"
+  items_with_description = local.do_not_inspect_tunnels
+}`,
+			Expected: `resource "cloudflare_zero_trust_list" "do_not_inspect_tunnels" {
+  account_id  = var.account_id
+  name        = "Do Not Inspect Tunnels"
+  description = "List of tunnels that should not undergo http inspection"
+  type        = "IP"
+  items       = local.do_not_inspect_tunnels
+}`,
+		},
+		{
+			// Real-world Case B: items_with_description = [...] (inline object list)
+			// AND a separate items = [...] attribute.
+			// Expected: merged into a single items attribute; items_with_description first.
+			// Field order mirrors source order (value before description in the iwd attr).
+			// Existing items entries are re-parsed so their field order (description, value)
+			// is preserved from the original items attribute.
+			Name: "items_with_description as inline object list with resource references merged with items",
+			Input: `
+resource "cloudflare_zero_trust_list" "do_not_inspect_IPs_employees" {
+  account_id  = var.account_id
+  name        = "IP addresses to never inspect - Cloudflare Employees"
+  type        = "IP"
+  items_with_description = [
+    {
+      value       = cloudflare_zero_trust_tunnel_cloudflared_route.athens_staging_tunnel_ipv4.network
+      description = "Athens Staging IPv4"
+    },
+    {
+      value       = cloudflare_zero_trust_tunnel_cloudflared_route.athens_tunnel_ipv4.network
+      description = "Athens IPv4"
+    }
+  ]
+  items = [{
+    description = null
+    value       = "8.14.199.1"
+    }, {
+    description = null
+    value       = "8.14.199.2"
+  }]
+}`,
+			Expected: `resource "cloudflare_zero_trust_list" "do_not_inspect_IPs_employees" {
+  account_id  = var.account_id
+  name        = "IP addresses to never inspect - Cloudflare Employees"
+  type        = "IP"
+  items = [
+    {
+      value       = cloudflare_zero_trust_tunnel_cloudflared_route.athens_staging_tunnel_ipv4.network
+      description = "Athens Staging IPv4"
+    },
+    {
+      value       = cloudflare_zero_trust_tunnel_cloudflared_route.athens_tunnel_ipv4.network
+      description = "Athens IPv4"
+    },
+    {
+      value       = "8.14.199.1"
+      description = null
+    },
+    {
+      value       = "8.14.199.2"
+      description = null
+    }
+  ]
+}`,
+		},
+		{
+			// Real-world Case C: same as B but on a v4-named resource (cloudflare_teams_list).
+			// Must also produce a moved block.
+			// Field order: iwd items preserve source order (value, description);
+			// items entries preserve source order (description, value → reparsed as value, description).
+			Name: "v4-named resource with items_with_description as inline object list gets moved block",
+			Input: `
+resource "cloudflare_teams_list" "do_not_inspect_IPs_contractors" {
+  account_id  = var.account_id
+  name        = "IP addresses to never inspect - Contractors"
+  type        = "IP"
+  items_with_description = [
+    {
+      value       = cloudflare_zero_trust_tunnel_cloudflared_route.athens_tunnel_ipv4.network
+      description = "Athens IPv4"
+    }
+  ]
+  items = [{
+    description = null
+    value       = "10.0.0.1"
+  }]
+}`,
+			Expected: `resource "cloudflare_zero_trust_list" "do_not_inspect_IPs_contractors" {
+  account_id  = var.account_id
+  name        = "IP addresses to never inspect - Contractors"
+  type        = "IP"
+  items = [
+    {
+      value       = cloudflare_zero_trust_tunnel_cloudflared_route.athens_tunnel_ipv4.network
+      description = "Athens IPv4"
+    },
+    {
+      value       = "10.0.0.1"
+      description = null
+    }
+  ]
+}
+moved {
+  from = cloudflare_teams_list.do_not_inspect_IPs_contractors
+  to   = cloudflare_zero_trust_list.do_not_inspect_IPs_contractors
+}`,
+		},
+		{
+			// items_with_description as inline object list, no separate items attr.
+			// Field order in output matches original source order (value before description).
+			Name: "items_with_description as inline object list only, static strings",
+			Input: `
+resource "cloudflare_zero_trust_list" "example" {
+  account_id = var.account_id
+  name       = "Example"
+  type       = "IP"
+  items_with_description = [
+    {
+      value       = "192.168.1.1"
+      description = "Gateway"
+    },
+    {
+      value       = "10.0.0.1"
+      description = "Internal"
+    }
+  ]
+}`,
+			Expected: `resource "cloudflare_zero_trust_list" "example" {
+  account_id = var.account_id
+  name       = "Example"
+  type       = "IP"
+  items = [{
+    value       = "192.168.1.1"
+    description = "Gateway"
+    }, {
+    value       = "10.0.0.1"
+    description = "Internal"
+  }]
+}`,
+		},
+	}
+
+	testhelpers.RunConfigTransformTests(t, tests, migrator)
+}
+
 // TestV4ToV5Transformation_AlreadyV5Named tests the scenario from BUGS-2009:
 // The user has already run tf-migrate once (or manually renamed resources),
 // so the resource type is already "cloudflare_zero_trust_list" (v5 name),

--- a/internal/testhelpers/config.go
+++ b/internal/testhelpers/config.go
@@ -54,8 +54,12 @@ func runConfigTransformTest(t *testing.T, tt ConfigTestCase, migrator transform.
 				// Handle resource splits or removals
 				if result != nil && result.RemoveOriginal {
 					body.RemoveBlock(block)
-					for _, newBlock := range result.Blocks {
+					body.AppendNewline()
+					for i, newBlock := range result.Blocks {
 						body.AppendBlock(newBlock)
+						if i < len(result.Blocks)-1 {
+							body.AppendNewline()
+						}
 					}
 				}
 			}

--- a/internal/transform/hcl/arrays.go
+++ b/internal/transform/hcl/arrays.go
@@ -435,7 +435,7 @@ func MergeAttributeAndBlocksToObjectArray(
 	modified := false
 	var allItems []cty.Value
 
-	// Collect items from blocks
+	// Collect items from blocks (existing behaviour: blockType as HCL block).
 	var blocksToRemove []*hclwrite.Block
 	var blockItems []cty.Value
 	var blockItemTokens []map[string]hclwrite.Tokens
@@ -500,7 +500,60 @@ func MergeAttributeAndBlocksToObjectArray(
 		body.RemoveBlock(block)
 	}
 
-	// Collect items from array attribute
+	// Bug #001 fix: also handle blockType written as an HCL *attribute* rather than
+	// a block.  This is valid HCL and used in production configs in two patterns:
+	//
+	//   Pattern A — opaque expression (local ref, for-expression, concat(), …):
+	//     items_with_description = local.my_tunnels
+	//   Pattern B — inline object list:
+	//     items_with_description = [{ value = "x", description = "y" }, …]
+	//
+	// When blockType != arrayAttrName we need to look for it as an attribute too.
+	if blockType != arrayAttrName {
+		if blockAttr := body.GetAttribute(blockType); blockAttr != nil {
+			exprTokens := blockAttr.Expr().BuildTokens(nil)
+
+			// Determine whether the expression starts with "[" (array literal) or not.
+			isArrayLiteral := false
+			for _, tok := range exprTokens {
+				if tok.Type == hclsyntax.TokenNewline || tok.Type == hclsyntax.TokenComment {
+					continue
+				}
+				if tok.Type == hclsyntax.TokenOBrack {
+					isArrayLiteral = true
+				}
+				break
+			}
+
+			if !isArrayLiteral {
+				// Pattern A: opaque expression (local ref, for-expression, function call, …).
+				// Cannot be statically evaluated — rename the attribute verbatim to
+				// outputAttrName and return immediately.  Merging with arrayAttrName
+				// items is not possible without evaluating the expression.
+				body.RemoveAttribute(blockType)
+				body.SetAttributeRaw(outputAttrName, exprTokens)
+				return true
+			}
+
+			// Pattern B: inline object list.
+			// Use a dedicated token-level parser that correctly extracts all fields
+			// (including multi-token values like resource references) without the
+			// lossy heuristics in ParseArrayAttribute.
+			parsedItems := parseInlineObjectListTokens(exprTokens, primaryField, optionalFields)
+			for _, itemTokens := range parsedItems {
+				blockItemTokens = append(blockItemTokens, itemTokens)
+				modified = true
+			}
+
+			body.RemoveAttribute(blockType)
+			if !modified {
+				// Empty inline list — nothing added, but attribute was removed.
+				modified = true
+			}
+		}
+	}
+
+	// Collect items from the primary array attribute (arrayAttrName, e.g. "items").
 	var arrayItems []cty.Value
 	var arrayItemTokens []map[string]hclwrite.Tokens
 	if attr := body.GetAttribute(arrayAttrName); attr != nil {
@@ -512,36 +565,109 @@ func MergeAttributeAndBlocksToObjectArray(
 			return modified
 		}
 
-		for _, elem := range elements {
-			// First try to extract a plain string value
-			if val, ok := extractStringFieldFromArrayElement(elem); ok {
-				itemAttrs := make(map[string]cty.Value)
-				itemAttrs[primaryField] = cty.StringVal(val)
+		// Empty slice can mean either an empty array literal ([]) OR an array that
+		// ParseArrayAttribute couldn't decompose (e.g. already-migrated object list
+		// like items = [{ description = null, value = "x" }, ...]).
+		// Distinguish the two by checking whether the raw token sequence starts with
+		// "[" immediately followed by "{" (object list) vs "[" followed by a quote or
+		// ident (simple string/reference array) vs just "[]" (empty).
+		hasBlockItems := len(blockItems) > 0 || len(blockItemTokens) > 0
 
-				// Add null values for optional fields
-				for _, fieldName := range optionalFields {
-					itemAttrs[fieldName] = cty.NullVal(cty.String)
+		if len(elements) == 0 {
+			// Check whether the existing attr is an already-migrated object list or
+			// a genuine empty array.
+			rawTokens := attr.Expr().BuildTokens(nil)
+			isObjectList := false
+			for _, t := range rawTokens {
+				if t.Type == hclsyntax.TokenNewline || t.Type == hclsyntax.TokenComment {
+					continue
 				}
+				if t.Type == hclsyntax.TokenOBrack {
+					continue
+				}
+				if t.Type == hclsyntax.TokenOBrace {
+					isObjectList = true
+				}
+				break
+			}
 
-				arrayItems = append(arrayItems, cty.ObjectVal(itemAttrs))
-			} else if tokens, ok := extractValueTokensFromArrayElement(elem); ok {
-				// If we can't extract a plain string, preserve the raw tokens (interpolations, references, etc)
-				itemTokens := make(map[string]hclwrite.Tokens)
-				itemTokens[primaryField] = tokens
+			if isObjectList {
+				if !hasBlockItems {
+					// Nothing to prepend/append — leave the already-migrated attr untouched.
+					return modified
+				}
+				// We have block/blockAttr items to prepend (blocksFirst) or append.
+				// Preserve the existing object list as raw token items so they appear in
+				// the merged output.  Parse them with parseInlineObjectListTokens.
+				existingItems := parseInlineObjectListTokens(rawTokens, primaryField, optionalFields)
+				for _, itemTokens := range existingItems {
+					arrayItemTokens = append(arrayItemTokens, itemTokens)
+				}
+				body.RemoveAttribute(arrayAttrName)
+				modified = true
+			} else {
+				// Genuine empty array — remove it (same as before); nothing to merge.
+				body.RemoveAttribute(arrayAttrName)
+				modified = true
+			}
+		} else {
+			// Non-empty slice of elements. Accumulate simple strings and references.
+			// Track whether any element was actually parseable as a simple value.
+			parsedAny := false
+			for _, elem := range elements {
+				// First try to extract a plain string value
+				if val, ok := extractStringFieldFromArrayElement(elem); ok {
+					itemAttrs := make(map[string]cty.Value)
+					itemAttrs[primaryField] = cty.StringVal(val)
 
-				// Add null tokens for optional fields
-				for _, fieldName := range optionalFields {
-					itemTokens[fieldName] = hclwrite.Tokens{
-						{Type: hclsyntax.TokenIdent, Bytes: []byte("null")},
+					// Add null values for optional fields
+					for _, fieldName := range optionalFields {
+						itemAttrs[fieldName] = cty.NullVal(cty.String)
 					}
-				}
 
-				arrayItemTokens = append(arrayItemTokens, itemTokens)
+					arrayItems = append(arrayItems, cty.ObjectVal(itemAttrs))
+					parsedAny = true
+				} else if tokens, ok := extractValueTokensFromArrayElement(elem); ok {
+					// If we can't extract a plain string, preserve the raw tokens
+					itemTokens := make(map[string]hclwrite.Tokens)
+					itemTokens[primaryField] = tokens
+
+					// Add null tokens for optional fields
+					for _, fieldName := range optionalFields {
+						itemTokens[fieldName] = hclwrite.Tokens{
+							{Type: hclsyntax.TokenIdent, Bytes: []byte("null")},
+						}
+					}
+
+					arrayItemTokens = append(arrayItemTokens, itemTokens)
+					parsedAny = true
+				}
+			}
+
+			if !parsedAny {
+				// ParseArrayAttribute returned non-nil but unparseable elements — this
+				// happens for already-migrated object lists like
+				//   items = [{ description = null, value = "x" }, ...]
+				// where each element has type="object" but no extractable tokens.
+				// Treat the same as the isObjectList case above.
+				if !hasBlockItems {
+					return modified
+				}
+				rawTokens := attr.Expr().BuildTokens(nil)
+				existingItems := parseInlineObjectListTokens(rawTokens, primaryField, optionalFields)
+				for _, itemTokens := range existingItems {
+					// Append to the SECOND set of items (respecting blocksFirst).
+					// We add to arrayItemTokens so they are placed after blockItemTokens
+					// when blocksFirst=true, or before when blocksFirst=false.
+					arrayItemTokens = append(arrayItemTokens, itemTokens)
+				}
+				body.RemoveAttribute(arrayAttrName)
+				modified = true
+			} else {
+				body.RemoveAttribute(arrayAttrName)
+				modified = true
 			}
 		}
-
-		body.RemoveAttribute(arrayAttrName)
-		modified = true
 	}
 
 	// Combine items in the requested order
@@ -831,4 +957,258 @@ func BuildArrayFromObjects(objects []hclwrite.Tokens) hclwrite.Tokens {
 		return TokensForEmptyArray()
 	}
 	return hclwrite.TokensForTuple(objects)
+}
+
+// parseInlineObjectListTokens parses a token sequence of the form
+// [ { field = value, … }, { field = value, … }, … ] and returns one
+// map[fieldName]tokens entry per object element.
+//
+// This is used instead of ParseArrayAttribute for the items_with_description
+// attribute case because ParseArrayAttribute's object-field extraction is lossy:
+// it relies on a lookahead heuristic that misses string-literal field values.
+// This parser consumes the full value token sequence for each field correctly.
+//
+// primaryField and optionalFields are used to populate null tokens for absent
+// optional fields, ensuring output objects have a consistent shape.
+func parseInlineObjectListTokens(
+	tokens hclwrite.Tokens,
+	primaryField string,
+	optionalFields []string,
+) []map[string]hclwrite.Tokens {
+	var result []map[string]hclwrite.Tokens
+
+	// State machine:
+	//   outside → inside [ → inside { → field name → = → field value tokens → , or }
+	inArray := false
+	inObject := false
+	objectDepth := 0
+	arrayBrackDepth := 0
+	inQuote := false
+	templateDepth := 0
+
+	currentObject := make(map[string]hclwrite.Tokens)
+	currentFieldName := ""
+	var currentValueTokens hclwrite.Tokens
+	inFieldValue := false
+
+	for i := 0; i < len(tokens); i++ {
+		tok := tokens[i]
+
+		// Outermost "[" opens the array.
+		if !inArray {
+			if tok.Type == hclsyntax.TokenOBrack {
+				inArray = true
+			}
+			continue
+		}
+
+		// Outermost "]" closes the array.
+		if tok.Type == hclsyntax.TokenCBrack && !inObject && arrayBrackDepth == 0 && !inQuote && templateDepth == 0 {
+			break
+		}
+
+		// Track string quoting.
+		if tok.Type == hclsyntax.TokenOQuote {
+			inQuote = true
+			if inFieldValue {
+				currentValueTokens = append(currentValueTokens, tok)
+			}
+			continue
+		}
+		if tok.Type == hclsyntax.TokenCQuote && templateDepth == 0 {
+			inQuote = false
+			if inFieldValue {
+				currentValueTokens = append(currentValueTokens, tok)
+			}
+			continue
+		}
+		if inQuote && templateDepth == 0 {
+			if inFieldValue {
+				currentValueTokens = append(currentValueTokens, tok)
+			}
+			continue
+		}
+
+		// Track template interpolation depth inside strings.
+		if tok.Type == hclsyntax.TokenTemplateInterp {
+			templateDepth++
+			if inFieldValue {
+				currentValueTokens = append(currentValueTokens, tok)
+			}
+			continue
+		}
+		if tok.Type == hclsyntax.TokenTemplateSeqEnd {
+			templateDepth--
+			if inFieldValue {
+				currentValueTokens = append(currentValueTokens, tok)
+			}
+			continue
+		}
+
+		// Object open "{".
+		if tok.Type == hclsyntax.TokenOBrace {
+			if !inObject {
+				inObject = true
+				objectDepth = 1
+				currentObject = make(map[string]hclwrite.Tokens)
+				currentFieldName = ""
+				currentValueTokens = nil
+				inFieldValue = false
+			} else {
+				// Nested brace inside a field value.
+				objectDepth++
+				if inFieldValue {
+					currentValueTokens = append(currentValueTokens, tok)
+				}
+			}
+			continue
+		}
+
+		// Object close "}".
+		if tok.Type == hclsyntax.TokenCBrace {
+			if inObject {
+				objectDepth--
+				if objectDepth == 0 {
+					// Flush any pending field value.
+					if inFieldValue && currentFieldName != "" {
+						currentObject[currentFieldName] = trimTrailingWhitespace(currentValueTokens)
+					}
+					// Save the completed object.
+					result = append(result, buildNormalisedItemTokens(currentObject, primaryField, optionalFields))
+					inObject = false
+					currentFieldName = ""
+					currentValueTokens = nil
+					inFieldValue = false
+				} else {
+					// Nested brace closing inside a field value.
+					if inFieldValue {
+						currentValueTokens = append(currentValueTokens, tok)
+					}
+				}
+			}
+			continue
+		}
+
+		if !inObject {
+			// Between objects (commas, newlines) — skip.
+			continue
+		}
+
+		// Inside an object at depth 1.
+		if objectDepth == 1 {
+			// A newline while reading a field value may signal end-of-field when
+			// the next non-whitespace token is another identifier (next field name).
+			// We look ahead to decide: if so, flush current field and switch to
+			// field-name mode. If the next non-whitespace token is NOT an ident
+			// (e.g. it's a quote or another token type), the newline is part of the
+			// value and we continue accumulating.
+			if tok.Type == hclsyntax.TokenNewline && inFieldValue && !inQuote && templateDepth == 0 {
+				// Look ahead past any additional newlines to the next meaningful token.
+				nextMeaningfulIdx := -1
+				for j := i + 1; j < len(tokens); j++ {
+					tt := tokens[j].Type
+					if tt != hclsyntax.TokenNewline && tt != hclsyntax.TokenComment {
+						nextMeaningfulIdx = j
+						break
+					}
+				}
+				if nextMeaningfulIdx >= 0 {
+					nextType := tokens[nextMeaningfulIdx].Type
+					// If next token is an ident or a closing brace, this newline ends the field.
+					if nextType == hclsyntax.TokenIdent || nextType == hclsyntax.TokenCBrace {
+						currentObject[currentFieldName] = trimTrailingWhitespace(currentValueTokens)
+						currentFieldName = ""
+						currentValueTokens = nil
+						inFieldValue = false
+						continue
+					}
+				}
+				// Otherwise the newline is interior to the value (e.g. heredoc) — skip it.
+				continue
+			}
+
+			// Skip bare newlines and whitespace between fields.
+			if tok.Type == hclsyntax.TokenNewline && !inFieldValue {
+				continue
+			}
+
+			// Field name identifier (when not yet reading a value).
+			if tok.Type == hclsyntax.TokenIdent && !inFieldValue {
+				currentFieldName = string(tok.Bytes)
+				continue
+			}
+
+			// "=" separator starts the value.
+			if tok.Type == hclsyntax.TokenEqual && currentFieldName != "" && !inFieldValue {
+				inFieldValue = true
+				currentValueTokens = nil
+				continue
+			}
+
+			// Comma at depth 1 separates fields inside the object.
+			if tok.Type == hclsyntax.TokenComma && inFieldValue && objectDepth == 1 && !inQuote && templateDepth == 0 {
+				currentObject[currentFieldName] = trimTrailingWhitespace(currentValueTokens)
+				currentFieldName = ""
+				currentValueTokens = nil
+				inFieldValue = false
+				continue
+			}
+
+			// Collect field value tokens.
+			if inFieldValue {
+				// Skip leading whitespace/newline at the very start of a value.
+				if len(currentValueTokens) == 0 &&
+					(tok.Type == hclsyntax.TokenNewline || tok.Type == hclsyntax.TokenComment) {
+					continue
+				}
+				currentValueTokens = append(currentValueTokens, tok)
+			}
+		} else {
+			// Inside a nested brace — just accumulate tokens.
+			if inFieldValue {
+				currentValueTokens = append(currentValueTokens, tok)
+			}
+		}
+	}
+
+	return result
+}
+
+// buildNormalisedItemTokens builds a map[fieldName]tokens from a parsed object,
+// inserting null tokens for optional fields that were absent.
+func buildNormalisedItemTokens(
+	obj map[string]hclwrite.Tokens,
+	primaryField string,
+	optionalFields []string,
+) map[string]hclwrite.Tokens {
+	result := make(map[string]hclwrite.Tokens)
+
+	if fieldTokens, ok := obj[primaryField]; ok {
+		result[primaryField] = cleanTokens(fieldTokens)
+	}
+	for _, fieldName := range optionalFields {
+		if fieldTokens, ok := obj[fieldName]; ok {
+			result[fieldName] = cleanTokens(fieldTokens)
+		} else {
+			result[fieldName] = hclwrite.Tokens{
+				{Type: hclsyntax.TokenIdent, Bytes: []byte("null")},
+			}
+		}
+	}
+
+	return result
+}
+
+// trimTrailingWhitespace removes trailing newline/whitespace tokens from a token slice.
+func trimTrailingWhitespace(tokens hclwrite.Tokens) hclwrite.Tokens {
+	end := len(tokens)
+	for end > 0 {
+		tt := tokens[end-1].Type
+		if tt == hclsyntax.TokenNewline || tt == hclsyntax.TokenComment {
+			end--
+		} else {
+			break
+		}
+	}
+	return tokens[:end]
 }

--- a/internal/transform/hcl/arrays_test.go
+++ b/internal/transform/hcl/arrays_test.go
@@ -964,3 +964,214 @@ resource "test" "example" {
 	// Verify the names attribute exists
 	assert.Contains(t, actual, "names =")
 }
+
+// TestMergeAttributeAndBlocksToObjectArray_AttributeSyntax tests Bug #001:
+// items_with_description written as an attribute (not a block) is not migrated.
+// These tests should FAIL before the fix is applied.
+func TestMergeAttributeAndBlocksToObjectArray_AttributeSyntax(t *testing.T) {
+	// Case A: blockType attr is an opaque expression (local reference).
+	// Expected behaviour: rename items_with_description → items verbatim.
+	t.Run("blockType_as_opaque_local_reference", func(t *testing.T) {
+		input := `
+resource "cloudflare_zero_trust_list" "do_not_inspect_tunnels" {
+  account_id             = var.account_id
+  name                   = "Do Not Inspect Tunnels"
+  type                   = "IP"
+  items_with_description = local.do_not_inspect_tunnels
+}`
+		file, diags := hclwrite.ParseConfig([]byte(input), "", hcl.InitialPos)
+		require.False(t, diags.HasErrors())
+
+		body := file.Body().Blocks()[0].Body()
+		modified := MergeAttributeAndBlocksToObjectArray(
+			body,
+			"items",
+			"items_with_description",
+			"items",
+			"value",
+			[]string{"description"},
+			true,
+		)
+
+		assert.True(t, modified, "should be modified when items_with_description attr is present")
+
+		actual := string(file.Bytes())
+		// items_with_description must be gone
+		assert.NotContains(t, actual, "items_with_description", "items_with_description attribute must be removed")
+		// items must now reference the local
+		assert.Contains(t, actual, "items", "items attribute must be present")
+		assert.Contains(t, actual, "local.do_not_inspect_tunnels", "local reference must be preserved")
+	})
+
+	// Case B: blockType attr is an inline object list with resource references.
+	// Expected behaviour: merge with existing items array, preserve references.
+	t.Run("blockType_as_inline_object_list_with_references", func(t *testing.T) {
+		input := `
+resource "cloudflare_zero_trust_list" "do_not_inspect_IPs_employees" {
+  account_id  = var.account_id
+  name        = "IP addresses to never inspect - Cloudflare Employees"
+  type        = "IP"
+  items_with_description = [
+    {
+      value       = cloudflare_zero_trust_tunnel_cloudflared_route.athens_staging_tunnel_ipv4.network
+      description = "Athens Staging IPv4"
+    },
+    {
+      value       = cloudflare_zero_trust_tunnel_cloudflared_route.athens_tunnel_ipv4.network
+      description = "Athens IPv4"
+    }
+  ]
+  items = [{
+    description = null
+    value       = "8.14.199.1"
+    }, {
+    description = null
+    value       = "8.14.199.2"
+  }]
+}`
+		file, diags := hclwrite.ParseConfig([]byte(input), "", hcl.InitialPos)
+		require.False(t, diags.HasErrors())
+
+		body := file.Body().Blocks()[0].Body()
+		modified := MergeAttributeAndBlocksToObjectArray(
+			body,
+			"items",
+			"items_with_description",
+			"items",
+			"value",
+			[]string{"description"},
+			true, // blocksFirst: items_with_description entries come first
+		)
+
+		assert.True(t, modified)
+
+		actual := string(file.Bytes())
+		assert.NotContains(t, actual, "items_with_description", "items_with_description must be removed")
+		// Reference items (from items_with_description) must appear before static items
+		athensIdx := strings.Index(actual, "athens_staging_tunnel_ipv4")
+		staticIdx := strings.Index(actual, "8.14.199.1")
+		assert.Greater(t, athensIdx, 0, "Athens reference must be present")
+		assert.Greater(t, staticIdx, 0, "static IP must be present")
+		assert.Less(t, athensIdx, staticIdx, "items_with_description entries (blocksFirst=true) must precede items entries")
+		// Both descriptions must be preserved
+		assert.Contains(t, actual, `"Athens Staging IPv4"`)
+		assert.Contains(t, actual, `"Athens IPv4"`)
+		// Static items null descriptions must be preserved
+		assert.Contains(t, actual, "8.14.199.2")
+	})
+
+	// Case B2: blockType attr is an inline object list with STATIC strings only.
+	// Expected behaviour: fully merge into items, all values present.
+	t.Run("blockType_as_inline_object_list_static_strings", func(t *testing.T) {
+		input := `
+resource "cloudflare_zero_trust_list" "example" {
+  account_id = "abc123"
+  type       = "IP"
+  items_with_description = [
+    {
+      value       = "192.168.1.1"
+      description = "Gateway"
+    },
+    {
+      value       = "10.0.0.1"
+      description = "Internal"
+    }
+  ]
+}`
+		file, diags := hclwrite.ParseConfig([]byte(input), "", hcl.InitialPos)
+		require.False(t, diags.HasErrors())
+
+		body := file.Body().Blocks()[0].Body()
+		modified := MergeAttributeAndBlocksToObjectArray(
+			body,
+			"items",
+			"items_with_description",
+			"items",
+			"value",
+			[]string{"description"},
+			true,
+		)
+
+		assert.True(t, modified)
+		actual := string(file.Bytes())
+		assert.NotContains(t, actual, "items_with_description")
+		assert.Contains(t, actual, `"192.168.1.1"`)
+		assert.Contains(t, actual, `"Gateway"`)
+		assert.Contains(t, actual, `"10.0.0.1"`)
+		assert.Contains(t, actual, `"Internal"`)
+	})
+
+	// Case C: items_with_description attr present AND items_with_description blocks present.
+	// This is a pathological case — both syntaxes coexist. Both must be merged.
+	t.Run("blockType_as_attribute_and_blocks_coexist", func(t *testing.T) {
+		input := `
+resource "cloudflare_zero_trust_list" "example" {
+  account_id = "abc123"
+  type       = "IP"
+  items_with_description = [
+    {
+      value       = "192.168.1.1"
+      description = "From attr"
+    }
+  ]
+  items_with_description {
+    value       = "10.0.0.1"
+    description = "From block"
+  }
+}`
+		file, diags := hclwrite.ParseConfig([]byte(input), "", hcl.InitialPos)
+		require.False(t, diags.HasErrors())
+
+		body := file.Body().Blocks()[0].Body()
+		modified := MergeAttributeAndBlocksToObjectArray(
+			body,
+			"items",
+			"items_with_description",
+			"items",
+			"value",
+			[]string{"description"},
+			true,
+		)
+
+		assert.True(t, modified)
+		actual := string(file.Bytes())
+		assert.NotContains(t, actual, "items_with_description")
+		assert.Contains(t, actual, `"192.168.1.1"`)
+		assert.Contains(t, actual, `"10.0.0.1"`)
+		assert.Contains(t, actual, `"From attr"`)
+		assert.Contains(t, actual, `"From block"`)
+	})
+
+	// Case D: No items_with_description attribute, no blocks — nothing to do.
+	t.Run("no_blockType_attribute_or_block_is_noop", func(t *testing.T) {
+		input := `
+resource "cloudflare_zero_trust_list" "example" {
+  account_id = "abc123"
+  type       = "IP"
+  items = [{
+    description = null
+    value       = "1.2.3.4"
+  }]
+}`
+		file, diags := hclwrite.ParseConfig([]byte(input), "", hcl.InitialPos)
+		require.False(t, diags.HasErrors())
+
+		body := file.Body().Blocks()[0].Body()
+		// Already-migrated resource — items_with_description is absent as both attr and block.
+		// The items attr is already an object list; ParseArrayAttribute returns [] for object arrays.
+		// This call should not corrupt the existing items attribute.
+		MergeAttributeAndBlocksToObjectArray(
+			body,
+			"items",
+			"items_with_description",
+			"items",
+			"value",
+			[]string{"description"},
+			true,
+		)
+
+		actual := string(file.Bytes())
+		assert.NotContains(t, actual, "items_with_description")
+		assert.Contains(t, actual, "1.2.3.4")
+	})
+}


### PR DESCRIPTION
In production configs, items_with_description is sometimes written as an HCL attribute rather than a block:

  - Pattern A: items_with_description = local.some_local  (opaque ref)
  - Pattern B: items_with_description = [{value=..., description=...}]

MergeAttributeAndBlocksToObjectArray only searched body.Blocks() for blockType, so attribute-syntax occurrences were silently skipped and the invalid v4 attribute survived into the migrated output, breaking terraform plan with 'Unsupported argument'.

Fix:
- After the block loop, check if blockType also exists as an attribute. Pattern A (opaque expression): rename verbatim to outputAttrName. Pattern B (inline object list): parse with a new token-level parser parseInlineObjectListTokens and merge into the block-item accumulator.
- Fix a secondary bug: when arrayAttrName already holds a migrated object list ([{...}]), ParseArrayAttribute returns an empty-but-non-nil slice which previously caused the attribute to be silently deleted. Now we detect this case and either leave it untouched (no new items) or re-parse it with parseInlineObjectListTokens to merge with incoming block items.
- Fix testhelpers/config.go to call body.AppendNewline() before appending result blocks, matching the production handler behaviour and preventing '} moved {' runon in unit tests.

Tests added:
- arrays_test.go: TestMergeAttributeAndBlocksToObjectArray_AttributeSyntax (5 sub-cases covering all patterns including noop guard)
- v4_to_v5_test.go: TestV4ToV5Transformation_ItemsWithDescriptionAsAttribute (4 sub-cases matching real-world production config patterns)
- integration testdata: zero_trust_list_items_with_description_attr.tf (3 fixture resources: opaque local ref, inline+items merge, inline-only)

Migration tests:

```
TF_ACC=1 TF_MIGRATE_BINARY_PATH=/Users/tamas/cf-repos/sdks/agent-a/tf-migrate/bin/tf-migrate go test -v -run "TestMigrate" ./internal/services/zero_trust_list/migration/v500/... -timeout 40m
=== RUN   TestMigrateZeroTrustList_FromV4_SimpleItems
--- PASS: TestMigrateZeroTrustList_FromV4_SimpleItems (24.10s)
=== RUN   TestMigrateZeroTrustList_FromV4_ItemsWithDescription
--- PASS: TestMigrateZeroTrustList_FromV4_ItemsWithDescription (21.10s)
=== RUN   TestMigrateZeroTrustList_FromV4_MixedItems
--- PASS: TestMigrateZeroTrustList_FromV4_MixedItems (22.23s)
=== RUN   TestMigrateZeroTrustList_FromV4_EmptyList
--- PASS: TestMigrateZeroTrustList_FromV4_EmptyList (20.38s)
=== RUN   TestMigrateZeroTrustList_FromV4_EmailList
--- PASS: TestMigrateZeroTrustList_FromV4_EmailList (21.46s)
=== RUN   TestMigrateZeroTrustList_FromV4_URLList
--- PASS: TestMigrateZeroTrustList_FromV4_URLList (21.07s)
=== RUN   TestMigrateZeroTrustList_FromV4_LargeList
--- PASS: TestMigrateZeroTrustList_FromV4_LargeList (20.71s)
=== RUN   TestMigrateZeroTrustList_FromV4_SpecialCharacters
--- PASS: TestMigrateZeroTrustList_FromV4_SpecialCharacters (21.63s)
=== RUN   TestMigrateZeroTrustList_SimpleItems
=== RUN   TestMigrateZeroTrustList_SimpleItems/from_v4_latest
=== RUN   TestMigrateZeroTrustList_SimpleItems/from_v5
--- PASS: TestMigrateZeroTrustList_SimpleItems (38.12s)
    --- PASS: TestMigrateZeroTrustList_SimpleItems/from_v4_latest (21.50s)
    --- PASS: TestMigrateZeroTrustList_SimpleItems/from_v5 (16.61s)
=== RUN   TestMigrateZeroTrustList_FromV4_ItemsWithDescriptionContent
--- PASS: TestMigrateZeroTrustList_FromV4_ItemsWithDescriptionContent (23.49s)
=== RUN   TestMigrateZeroTrustList_FromV4_MixedItemsAllPresent
--- PASS: TestMigrateZeroTrustList_FromV4_MixedItemsAllPresent (22.58s)
=== RUN   TestMigrateZeroTrustList_FromV4_NullDescriptionOnPlainItems
--- PASS: TestMigrateZeroTrustList_FromV4_NullDescriptionOnPlainItems (20.90s)
=== RUN   TestMigrateZeroTrustList_FromV4_SerialListWithDescriptions
--- PASS: TestMigrateZeroTrustList_FromV4_SerialListWithDescriptions (21.58s)
=== RUN   TestMigrateZeroTrustList_FromV4_URLListWithDescriptions
--- PASS: TestMigrateZeroTrustList_FromV4_URLListWithDescriptions (20.91s)
=== RUN   TestMigrateZeroTrustList_FromV4_EmailListMixed
--- PASS: TestMigrateZeroTrustList_FromV4_EmailListMixed (21.90s)
=== RUN   TestMigrateZeroTrustList_EmptyList
=== RUN   TestMigrateZeroTrustList_EmptyList/from_v4_latest
=== RUN   TestMigrateZeroTrustList_EmptyList/from_v5
--- PASS: TestMigrateZeroTrustList_EmptyList (35.95s)
    --- PASS: TestMigrateZeroTrustList_EmptyList/from_v4_latest (21.17s)
    --- PASS: TestMigrateZeroTrustList_EmptyList/from_v5 (14.79s)
PASS
ok  	github.com/cloudflare/terraform-provider-cloudflare/internal/services/zero_trust_list/migration
```

E2E run:
```
./scripts/run-e2e-tests.sh --resources zero_trust_list --apply-exemptions --target-provider-version 5.19.0-beta.5 --provider /Users/tamas/cf-repos/sdks/agent-b/cloudflare-terraform-next

========================================
✓ E2E Test Complete!
========================================

Summary:

  Step 1: v4 terraform apply
    Status: ✓ SUCCESS

  Step 2: Migration (v4 → v5)
    Status: ✓ SUCCESS

  Step 3: v5 plan (before apply)
    Status: ✓ No changes needed

  Step 4: v5 terraform apply
    Status: ✓ SUCCESS

  Step 5: v5 plan (after apply)
    Status: ✓ SUCCESS - Stable state achieved
    Result: No changes detected
```
