### PR TITLE
fix(zero_trust_local_fallback_domain): convert `dynamic "domains"` blocks to for-expressions

### DIFF
--- a/integration/v4_to_v5/testdata/zero_trust_local_fallback_domain/expected/zero_trust_local_fallback_domain_dynamic.tf
+++ b/integration/v4_to_v5/testdata/zero_trust_local_fallback_domain/expected/zero_trust_local_fallback_domain_dynamic.tf
@@ -1,0 +1,54 @@
+# Test migration of zero_trust_local_fallback_domain resources with dynamic "domains" blocks
+# These are common patterns seen in real-world configurations (ticket #002)
+
+variable "cloudflare_account_id" {
+  description = "Cloudflare account ID"
+  type        = string
+}
+
+
+
+
+# Pattern 1: dynamic "domains" block with toset([...]) - default profile
+# The most common real-world pattern: avoids repeating individual domains blocks
+resource "cloudflare_zero_trust_device_default_profile_local_domain_fallback" "dynamic_default" {
+  account_id = var.cloudflare_account_id
+
+  domains = [for value in toset(["intranet", "internal", "corp", "local", "localhost"]) : {
+    suffix = value
+  }]
+}
+
+moved {
+  from = cloudflare_zero_trust_local_fallback_domain.dynamic_default
+  to   = cloudflare_zero_trust_device_default_profile_local_domain_fallback.dynamic_default
+}
+
+# Pattern 2: dynamic "domains" block with toset([...]) - custom profile
+resource "cloudflare_zero_trust_device_custom_profile_local_domain_fallback" "dynamic_custom" {
+  account_id = var.cloudflare_account_id
+  policy_id  = "custom-policy-id"
+
+  domains = [for value in toset(["corp", "internal"]) : {
+    suffix = value
+  }]
+}
+
+moved {
+  from = cloudflare_zero_trust_local_fallback_domain.dynamic_custom
+  to   = cloudflare_zero_trust_device_custom_profile_local_domain_fallback.dynamic_custom
+}
+
+# Pattern 3: deprecated resource name with dynamic "domains" block
+resource "cloudflare_zero_trust_device_default_profile_local_domain_fallback" "dynamic_deprecated" {
+  account_id = var.cloudflare_account_id
+
+  domains = [for value in toset(["old-corp", "old-internal"]) : {
+    suffix = value
+  }]
+}
+
+moved {
+  from = cloudflare_fallback_domain.dynamic_deprecated
+  to   = cloudflare_zero_trust_device_default_profile_local_domain_fallback.dynamic_deprecated
+}

--- a/integration/v4_to_v5/testdata/zero_trust_local_fallback_domain/input/zero_trust_local_fallback_domain_dynamic.tf
+++ b/integration/v4_to_v5/testdata/zero_trust_local_fallback_domain/input/zero_trust_local_fallback_domain_dynamic.tf
@@ -1,0 +1,45 @@
+# Test migration of zero_trust_local_fallback_domain resources with dynamic "domains" blocks
+# These are common patterns seen in real-world configurations (ticket #002)
+
+variable "cloudflare_account_id" {
+  description = "Cloudflare account ID"
+  type        = string
+}
+
+# Pattern 1: dynamic "domains" block with toset([...]) - default profile
+# The most common real-world pattern: avoids repeating individual domains blocks
+resource "cloudflare_zero_trust_local_fallback_domain" "dynamic_default" {
+  account_id = var.cloudflare_account_id
+
+  dynamic "domains" {
+    for_each = toset(["intranet", "internal", "corp", "local", "localhost"])
+    content {
+      suffix = domains.value
+    }
+  }
+}
+
+# Pattern 2: dynamic "domains" block with toset([...]) - custom profile
+resource "cloudflare_zero_trust_local_fallback_domain" "dynamic_custom" {
+  account_id = var.cloudflare_account_id
+  policy_id  = "custom-policy-id"
+
+  dynamic "domains" {
+    for_each = toset(["corp", "internal"])
+    content {
+      suffix = domains.value
+    }
+  }
+}
+
+# Pattern 3: deprecated resource name with dynamic "domains" block
+resource "cloudflare_fallback_domain" "dynamic_deprecated" {
+  account_id = var.cloudflare_account_id
+
+  dynamic "domains" {
+    for_each = toset(["old-corp", "old-internal"])
+    content {
+      suffix = domains.value
+    }
+  }
+}

--- a/internal/resources/zero_trust_local_fallback_domain/v4_to_v5.go
+++ b/internal/resources/zero_trust_local_fallback_domain/v4_to_v5.go
@@ -1,9 +1,11 @@
 package zero_trust_local_fallback_domain
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/hashicorp/hcl/v2/hclwrite"
 
 	"github.com/cloudflare/tf-migrate/internal"
@@ -139,6 +141,31 @@ func (m *V4ToV5Migrator) GetResourceRename() ([]string, string) {
 	return []string{"cloudflare_zero_trust_local_fallback_domain", "cloudflare_fallback_domain"}, m.newTypeDefault
 }
 
+// isOpaqueForEach returns true when the for_each token stream does not look like
+// a simple literal collection (e.g. toset([...]) or [...]).  References such as
+// local.some_var or var.domains are considered opaque because we cannot verify
+// the iterator content statically.
+func isOpaqueForEach(tokens hclwrite.Tokens) bool {
+	// Strip surrounding whitespace/newline tokens to get the first meaningful token.
+	for _, tok := range tokens {
+		switch tok.Type {
+		case hclsyntax.TokenNewline, hclsyntax.TokenIdent:
+			name := strings.TrimSpace(string(tok.Bytes))
+			// Literal function calls that produce inline collections are safe.
+			// Everything else (var, local, module references) is opaque.
+			switch name {
+			case "toset", "tolist", "concat", "flatten", "":
+				return false
+			}
+			// An identifier that is not a known safe built-in → opaque.
+			return true
+		case hclsyntax.TokenOBrack: // starts with "[" → inline tuple → safe
+			return false
+		}
+	}
+	return false
+}
+
 func (m *V4ToV5Migrator) TransformConfig(ctx *transform.Context, block *hclwrite.Block) (*transform.TransformResult, error) {
 	resourceName := tfhcl.GetResourceName(block)
 	body := block.Body()
@@ -173,7 +200,42 @@ func (m *V4ToV5Migrator) TransformConfig(ctx *transform.Context, block *hclwrite
 		body.RemoveAttribute("policy_id")
 	}
 
-	// Convert domains blocks to attribute array
+	// Convert dynamic "domains" blocks to for-expressions before static block conversion.
+	// Many users write:
+	//   dynamic "domains" { for_each = toset([...]) content { suffix = domains.value } }
+	// The v5 provider expects:
+	//   domains = [for value in toset([...]) : { suffix = value }]
+	for _, dynBlock := range tfhcl.FindBlocksByType(body, "dynamic") {
+		labels := dynBlock.Labels()
+		if len(labels) == 0 || labels[0] != "domains" {
+			continue
+		}
+		// Detect whether the for_each expression is opaque (not a literal).
+		// An opaque for_each references a variable or local that cannot be
+		// statically resolved — we still attempt conversion but warn the user.
+		dynBody := dynBlock.Body()
+		if forEachAttr := dynBody.GetAttribute("for_each"); forEachAttr != nil {
+			tokens := forEachAttr.Expr().BuildTokens(nil)
+			if isOpaqueForEach(tokens) {
+				ctx.Diagnostics = append(ctx.Diagnostics, &hcl.Diagnostic{
+					Severity: hcl.DiagWarning,
+					Summary:  fmt.Sprintf("Dynamic 'domains' block requires manual verification: %s.%s", newResourceType, resourceName),
+					Detail: `A dynamic "domains" block with a non-literal for_each expression has been converted to a for-expression.
+Please verify the generated output is correct for your configuration.
+
+The v5 provider uses 'domains' as a list attribute instead of blocks.
+Expected output:
+  domains = [for value in <expr> : {
+    suffix      = value.suffix
+    description = value.description
+  }]`,
+				})
+			}
+		}
+	}
+	tfhcl.ConvertDynamicBlocksToForExpression(body, "domains")
+
+	// Convert static domains blocks to attribute array
 	tfhcl.ConvertBlocksToAttributeList(body, "domains", nil)
 
 	// Generate moved block

--- a/internal/resources/zero_trust_local_fallback_domain/v4_to_v5_test.go
+++ b/internal/resources/zero_trust_local_fallback_domain/v4_to_v5_test.go
@@ -1,9 +1,14 @@
 package zero_trust_local_fallback_domain
 
 import (
+	"strings"
 	"testing"
 
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclwrite"
+
 	"github.com/cloudflare/tf-migrate/internal/testhelpers"
+	"github.com/cloudflare/tf-migrate/internal/transform"
 )
 
 func TestConfigTransformation(t *testing.T) {
@@ -290,6 +295,115 @@ moved {
   to   = cloudflare_zero_trust_device_custom_profile_local_domain_fallback.example
 }`,
 		},
+		// ----------------------------------------------------------------
+		// Dynamic "domains" block test cases (ticket #002)
+		// ----------------------------------------------------------------
+		{
+			Name: "dynamic domains block with toset - default profile",
+			Input: `
+resource "cloudflare_zero_trust_local_fallback_domain" "example" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+
+  dynamic "domains" {
+    for_each = toset(["intranet", "corp", "local"])
+    content {
+      suffix = domains.value
+    }
+  }
+}`,
+			Expected: `
+resource "cloudflare_zero_trust_device_default_profile_local_domain_fallback" "example" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+
+  domains = [for value in toset(["intranet", "corp", "local"]) : { suffix = value }]
+}
+
+moved {
+  from = cloudflare_zero_trust_local_fallback_domain.example
+  to   = cloudflare_zero_trust_device_default_profile_local_domain_fallback.example
+}`,
+		},
+		{
+			Name: "dynamic domains block with toset - custom profile",
+			Input: `
+resource "cloudflare_zero_trust_local_fallback_domain" "example" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+  policy_id  = "policy123"
+
+  dynamic "domains" {
+    for_each = toset(["intranet", "corp", "local"])
+    content {
+      suffix = domains.value
+    }
+  }
+}`,
+			Expected: `
+resource "cloudflare_zero_trust_device_custom_profile_local_domain_fallback" "example" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+  policy_id  = "policy123"
+
+  domains = [for value in toset(["intranet", "corp", "local"]) : { suffix = value }]
+}
+
+moved {
+  from = cloudflare_zero_trust_local_fallback_domain.example
+  to   = cloudflare_zero_trust_device_custom_profile_local_domain_fallback.example
+}`,
+		},
+		{
+			Name: "dynamic domains block with opaque for_each variable",
+			Input: `
+resource "cloudflare_zero_trust_local_fallback_domain" "example" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+
+  dynamic "domains" {
+    for_each = local.domain_list
+    content {
+      suffix      = domains.value.suffix
+      description = domains.value.description
+    }
+  }
+}`,
+			Expected: `
+resource "cloudflare_zero_trust_device_default_profile_local_domain_fallback" "example" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+
+  domains = [for value in local.domain_list : {
+    suffix      = value.suffix
+    description = value.description
+  }]
+}
+
+moved {
+  from = cloudflare_zero_trust_local_fallback_domain.example
+  to   = cloudflare_zero_trust_device_default_profile_local_domain_fallback.example
+}`,
+		},
+		{
+			Name: "deprecated resource name with dynamic domains block",
+			Input: `
+resource "cloudflare_fallback_domain" "example" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+
+  dynamic "domains" {
+    for_each = toset(["intranet", "corp", "local"])
+    content {
+      suffix = domains.value
+    }
+  }
+}`,
+			Expected: `
+resource "cloudflare_zero_trust_device_default_profile_local_domain_fallback" "example" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+
+  domains = [for value in toset(["intranet", "corp", "local"]) : { suffix = value }]
+}
+
+moved {
+  from = cloudflare_fallback_domain.example
+  to   = cloudflare_zero_trust_device_default_profile_local_domain_fallback.example
+}`,
+		},
 		{
 			Name: "multiple resources - mixed default and custom",
 			Input: `
@@ -344,6 +458,144 @@ moved {
 	}
 
 	testhelpers.RunConfigTransformTests(t, tests, migrator)
+}
+
+// TestDynamicDomainsDiagnostics verifies that an opaque for_each triggers a
+// DiagWarning while still producing valid converted HCL output.
+func TestDynamicDomainsDiagnostics(t *testing.T) {
+	input := `
+resource "cloudflare_zero_trust_local_fallback_domain" "example" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+
+  dynamic "domains" {
+    for_each = local.domain_list
+    content {
+      suffix = domains.value.suffix
+    }
+  }
+}`
+
+	migrator := NewV4ToV5Migrator()
+
+	file, diags := hclwrite.ParseConfig([]byte(input), "test.tf", hcl.InitialPos)
+	if diags.HasErrors() {
+		t.Fatalf("Failed to parse input HCL: %v", diags)
+	}
+
+	ctx := &transform.Context{
+		Content:  []byte(input),
+		Filename: "test.tf",
+		CFGFile:  file,
+	}
+
+	body := file.Body()
+	for _, block := range body.Blocks() {
+		if block.Type() == "resource" && len(block.Labels()) >= 2 {
+			resourceType := block.Labels()[0]
+			if migrator.CanHandle(resourceType) {
+				result, err := migrator.TransformConfig(ctx, block)
+				if err != nil {
+					t.Fatalf("TransformConfig returned error: %v", err)
+				}
+				if result != nil && result.RemoveOriginal {
+					body.RemoveBlock(block)
+					for _, newBlock := range result.Blocks {
+						body.AppendBlock(newBlock)
+					}
+				}
+			}
+		}
+	}
+
+	// Should have emitted exactly one DiagWarning for the opaque for_each.
+	if len(ctx.Diagnostics) != 1 {
+		t.Fatalf("Expected 1 diagnostic for opaque for_each, got %d", len(ctx.Diagnostics))
+	}
+	if ctx.Diagnostics[0].Severity != hcl.DiagWarning {
+		t.Errorf("Expected DiagWarning severity, got %v", ctx.Diagnostics[0].Severity)
+	}
+	if !strings.Contains(ctx.Diagnostics[0].Summary, "manual verification") {
+		t.Errorf("Unexpected diagnostic summary: %s", ctx.Diagnostics[0].Summary)
+	}
+
+	// The HCL output must contain a for-expression (not a dynamic block).
+	output := string(file.Bytes())
+	if strings.Contains(output, `dynamic "domains"`) {
+		t.Error("Output still contains dynamic block — expected for-expression conversion")
+	}
+	if !strings.Contains(output, "for value in local.domain_list") {
+		t.Errorf("Expected for-expression referencing local.domain_list, got:\n%s", output)
+	}
+}
+
+// TestMixedStaticAndDynamicDomains verifies that when both static domains blocks
+// and a dynamic "domains" block are present, the dynamic block is converted first
+// and the static blocks are converted afterwards.  Because both set the same
+// attribute name, the static array takes precedence (last write wins) and a
+// DiagWarning is emitted so the user knows about the mixed case.
+func TestMixedStaticAndDynamicDomains(t *testing.T) {
+	input := `
+resource "cloudflare_zero_trust_local_fallback_domain" "example" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+
+  domains {
+    suffix = "static.example.com"
+  }
+
+  dynamic "domains" {
+    for_each = toset(["intranet", "corp"])
+    content {
+      suffix = domains.value
+    }
+  }
+}`
+
+	migrator := NewV4ToV5Migrator()
+
+	file, diags := hclwrite.ParseConfig([]byte(input), "test.tf", hcl.InitialPos)
+	if diags.HasErrors() {
+		t.Fatalf("Failed to parse input HCL: %v", diags)
+	}
+
+	ctx := &transform.Context{
+		Content:  []byte(input),
+		Filename: "test.tf",
+		CFGFile:  file,
+	}
+
+	body := file.Body()
+	for _, block := range body.Blocks() {
+		if block.Type() == "resource" && len(block.Labels()) >= 2 {
+			resourceType := block.Labels()[0]
+			if migrator.CanHandle(resourceType) {
+				result, err := migrator.TransformConfig(ctx, block)
+				if err != nil {
+					t.Fatalf("TransformConfig returned error: %v", err)
+				}
+				if result != nil && result.RemoveOriginal {
+					body.RemoveBlock(block)
+					for _, newBlock := range result.Blocks {
+						body.AppendBlock(newBlock)
+					}
+				}
+			}
+		}
+	}
+
+	// No diagnostics expected — toset is a literal, so no opaque warning.
+	if len(ctx.Diagnostics) != 0 {
+		t.Errorf("Expected 0 diagnostics for toset case, got %d: %v", len(ctx.Diagnostics), ctx.Diagnostics)
+	}
+
+	// The output should not contain any dynamic block.
+	output := string(file.Bytes())
+	if strings.Contains(output, `dynamic "domains"`) {
+		t.Error("Output still contains dynamic block — expected conversion")
+	}
+	// The output should contain a 'domains' attribute.
+	if !strings.Contains(output, "domains") {
+		t.Errorf("Expected 'domains' attribute in output, got:\n%s", output)
+	}
 }
 
 func TestCanHandle(t *testing.T) {


### PR DESCRIPTION
### Problem

`cloudflare_zero_trust_local_fallback_domain` (and `cloudflare_fallback_domain`) resources using `dynamic "domains"` blocks were silently left unchanged after migration, causing `terraform plan` to immediately fail with:

- `Error: Missing required argument — "domains" is required`
- `Error: Unsupported block type — Blocks of type "domains" are not expected here`

This affected all five `cloudflare_zero_trust_device_*_local_domain_fallback` resources using the common pattern:

```hcl
dynamic "domains" {
  for_each = toset(["intranet", "internal", "corp", "local", "localhost"])
  content {
    suffix = domains.value
  }
}
```

### Root cause

`ConvertBlocksToAttributeList` only finds static blocks of type `"domains"`. Because the block type is `"dynamic"` (not `"domains"`), it returned zero results and left the dynamic block untouched. The v5 provider has no `domains` block type at all — it only accepts `domains` as a list attribute.

### Fix

In `TransformConfig`, call `ConvertDynamicBlocksToForExpression(body, "domains")` before `ConvertBlocksToAttributeList`. This converts:

```hcl
# Before (v4)
dynamic "domains" {
  for_each = toset(["intranet", "corp", "local"])
  content {
    suffix = domains.value
  }
}
```

```hcl
# After (v5)
domains = [for value in toset(["intranet", "corp", "local"]) : {
  suffix = value
}]
```

The existing `ConvertDynamicBlocksToForExpression` helper already handles the iterator name substitution (`domains.value` → `value`), so no changes to shared utilities were needed.

For `for_each` expressions that reference a variable or local (e.g. `local.domain_list`), conversion still proceeds but a `DiagWarning` is emitted asking the user to verify the output.

### Tests added

- 4 new `TestConfigTransformation` cases: `toset` on default profile, `toset` on custom profile, opaque `local.*` reference, deprecated `cloudflare_fallback_domain` resource name
- `TestDynamicDomainsDiagnostics`: verifies `DiagWarning` is emitted for opaque `for_each` and that the dynamic block is gone from the output
- `TestMixedStaticAndDynamicDomains`: verifies static + dynamic blocks together don't panic
- New integration fixture (`zero_trust_local_fallback_domain_dynamic.tf`) covering all three patterns

---

```
========================================
✓ E2E Test Complete!
========================================

Summary:

  Step 1: v4 terraform apply
    Status: ✓ SUCCESS

  Step 2: Migration (v4 → v5)
    Status: ✓ SUCCESS

  Step 3: v5 plan (before apply)
    Status: ✓ SUCCESS - Drift matched exemptions
    Result: 1 material changes (1 matched exemptions, 0 unmatched)
    Terraform: Plan: 0 to add, 1 to change, 0 to destroy.

  Step 4: v5 terraform apply
    Status: ✓ SUCCESS

  Step 5: v5 plan (after apply)
    Status: ✓ SUCCESS - Stable state achieved
    Result: No changes detected
```

