### PR TITLE
fix(zero_trust_tunnel_cloudflared): rewrite .secret cross-file refs for preferred v4 type name

### DIFF
--- a/integration/v4_to_v5/testdata/zero_trust_tunnel_cloudflared/expected/zero_trust_tunnel_cloudflared_preferred_name.tf
+++ b/integration/v4_to_v5/testdata/zero_trust_tunnel_cloudflared/expected/zero_trust_tunnel_cloudflared_preferred_name.tf
@@ -1,0 +1,29 @@
+# Cross-file .secret reference rewriting test.
+#
+# Tunnels defined here use the preferred v4 type name
+# (cloudflare_zero_trust_tunnel_cloudflared) rather than the deprecated
+# cloudflare_tunnel name.  The companion file
+# zero_trust_tunnel_cloudflared_secret_refs.tf contains non-Cloudflare
+# resources that reference the computed `secret` attribute of these tunnels.
+#
+# After migration:
+#   - `secret` is renamed to `tunnel_secret` in each resource body
+#   - `config_src = "local"` is added where absent
+#   - No type rename and no moved block (type is already correct)
+#   - Cross-file `.secret` references in the consumer file are also rewritten
+
+# Test case 1 (the bug): resource already using the preferred v4 / v5 type name
+resource "cloudflare_zero_trust_tunnel_cloudflared" "preferred_a" {
+  account_id    = var.cloudflare_account_id
+  name          = "cftftest-preferred-a-tunnel"
+  tunnel_secret = base64encode("preferred-a-tunnel-secret-32-bytes-ok")
+  config_src    = "local"
+}
+
+# Second preferred-name tunnel to cover the coexistence case (test case 3)
+resource "cloudflare_zero_trust_tunnel_cloudflared" "preferred_b" {
+  account_id    = var.cloudflare_account_id
+  name          = "cftftest-preferred-b-tunnel"
+  config_src    = "cloudflare"
+  tunnel_secret = base64encode("preferred-b-tunnel-secret-32-bytes-ok")
+}

--- a/integration/v4_to_v5/testdata/zero_trust_tunnel_cloudflared/expected/zero_trust_tunnel_cloudflared_secret_refs.tf
+++ b/integration/v4_to_v5/testdata/zero_trust_tunnel_cloudflared/expected/zero_trust_tunnel_cloudflared_secret_refs.tf
@@ -1,0 +1,39 @@
+# Consumer resources that reference the computed `secret` attribute of tunnel
+# resources across files.  Uses vault_generic_secret (a non-Cloudflare resource)
+# to simulate the real-world pattern described in the bug report.
+#
+# All `.secret` references below must be rewritten to `.tunnel_secret` by the
+# cross-file postprocessing pass regardless of which v4 type name was used for
+# the tunnel resource.
+
+# Test case 1 (the bug): reference to a tunnel that already uses the preferred
+# v4 name cloudflare_zero_trust_tunnel_cloudflared.
+# Before the fix this reference was NOT rewritten because
+# GetComputedAttributeMappings only listed cloudflare_tunnel as OldResourceType.
+resource "vault_generic_secret" "preferred_a_secret" {
+  path = "secret/tunnels/preferred-a"
+
+  data_json = jsonencode({
+    tunnel_secret = cloudflare_zero_trust_tunnel_cloudflared.preferred_a.tunnel_secret
+  })
+}
+
+# Test case 2 (existing behaviour): reference to a tunnel using the deprecated
+# cloudflare_tunnel name — must still be rewritten correctly.
+resource "vault_generic_secret" "from_old_name_tunnel" {
+  path = "secret/tunnels/minimal"
+
+  data_json = jsonencode({
+    tunnel_secret = cloudflare_zero_trust_tunnel_cloudflared.minimal.tunnel_secret
+  })
+}
+
+# Test case 3 (coexistence): both v4 type names referenced in the same file
+resource "vault_generic_secret" "combined" {
+  path = "secret/tunnels/combined"
+
+  data_json = jsonencode({
+    old_secret       = cloudflare_zero_trust_tunnel_cloudflared.minimal.tunnel_secret
+    preferred_secret = cloudflare_zero_trust_tunnel_cloudflared.preferred_a.tunnel_secret
+  })
+}

--- a/integration/v4_to_v5/testdata/zero_trust_tunnel_cloudflared/input/zero_trust_tunnel_cloudflared_e2e.tf
+++ b/integration/v4_to_v5/testdata/zero_trust_tunnel_cloudflared/input/zero_trust_tunnel_cloudflared_e2e.tf
@@ -1,0 +1,241 @@
+variable "cloudflare_account_id" {
+  description = "Cloudflare account ID"
+  type        = string
+}
+
+variable "cloudflare_zone_id" {
+  description = "Cloudflare zone ID"
+  type        = string
+}
+
+variable "cloudflare_domain" {
+  description = "Cloudflare domain for testing"
+  type        = string
+}
+
+# ========================================
+# Basic Tunnel Resources
+# ========================================
+
+# Basic tunnel with minimal configuration
+resource "cloudflare_tunnel" "minimal" {
+  account_id = var.cloudflare_account_id
+  name = "${local.name_prefix}-minimal-tunnel"
+  secret     = base64encode("test-secret-that-is-at-least-32-bytes-long")
+  config_src = "local"
+}
+
+# Tunnel with local config source
+resource "cloudflare_tunnel" "local_config" {
+  account_id = var.cloudflare_account_id
+  name = "${local.name_prefix}-local-config-tunnel"
+  secret     = base64encode("another-secret-32-bytes-or-longer-here")
+  config_src = "local"
+}
+
+# Tunnel with cloudflare config source
+resource "cloudflare_tunnel" "cloudflare_config" {
+  account_id = var.cloudflare_account_id
+  name = "${local.name_prefix}-cloudflare-config-tunnel"
+  secret     = base64encode("remote-tunnel-secret-32-bytes-minimum")
+  config_src = "cloudflare"
+}
+
+# ========================================
+# Advanced Terraform Patterns for Testing
+# ========================================
+
+# Pattern 1: Variable references
+variable "tunnel_prefix" {
+  type    = string
+  default = "var-test"
+}
+
+variable "config_source" {
+  type    = string
+  default = "local"
+}
+
+# Pattern 2: Local values with expressions
+locals {
+  name_prefix        = "cftftest"
+  tunnel_secret_base = "generated-secret-that-is-32-bytes-long"
+  common_account_id  = var.cloudflare_account_id
+  tunnel_suffix      = "prod"
+  full_tunnel_name   = "${local.name_prefix}-${var.tunnel_prefix}-${local.tunnel_suffix}"
+}
+
+# Tunnel using variables and locals
+resource "cloudflare_tunnel" "with_vars" {
+  account_id = local.common_account_id
+  name       = local.full_tunnel_name
+  secret     = base64encode(local.tunnel_secret_base)
+  config_src = var.config_source
+}
+
+# Pattern 3: for_each with map
+variable "application_tunnels" {
+  type = map(object({
+    secret     = string
+    config_src = string
+  }))
+  default = {
+    "api" = {
+      secret     = "api-tunnel-secret-that-is-32-bytes"
+      config_src = "local"
+    }
+    "web" = {
+      secret     = "web-tunnel-secret-that-is-32-bytes"
+      config_src = "cloudflare"
+    }
+    "backend" = {
+      secret     = "backend-secret-that-is-32-bytes-ok"
+      config_src = "local"
+    }
+  }
+}
+
+resource "cloudflare_tunnel" "applications" {
+  for_each = var.application_tunnels
+
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-${each.key}-tunnel"
+  secret     = base64encode(each.value.secret)
+  config_src = each.value.config_src
+}
+
+# Pattern 4: for_each with list converted to set
+variable "environment_tunnels" {
+  type = list(object({
+    name       = string
+    secret     = string
+    config_src = string
+  }))
+  default = [
+    {
+      name       = "dev"
+      secret     = "dev-environment-secret-32-bytes-min"
+      config_src = "local"
+    },
+    {
+      name       = "staging"
+      secret     = "staging-environment-secret-32-byte"
+      config_src = "cloudflare"
+    },
+    {
+      name       = "prod"
+      secret     = "prod-environment-secret-32-bytes-ok"
+      config_src = "cloudflare"
+    }
+  ]
+}
+
+resource "cloudflare_tunnel" "environments" {
+  for_each = { for idx, tunnel in var.environment_tunnels : tunnel.name => tunnel }
+
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-${each.value.name}-env-tunnel"
+  secret     = base64encode(each.value.secret)
+  config_src = each.value.config_src
+}
+
+# Pattern 5: Count-based resources
+variable "replica_count" {
+  type    = number
+  default = 3
+}
+
+resource "cloudflare_tunnel" "replicas" {
+  count = var.replica_count
+
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-replica-tunnel-${count.index + 1}"
+  secret     = base64encode("replica-${count.index}-secret-32-bytes-long")
+  config_src = "local"
+}
+
+# Pattern 6: Conditional resource creation
+variable "enable_backup_tunnel" {
+  type    = bool
+  default = true
+}
+
+resource "cloudflare_tunnel" "backup" {
+  count = var.enable_backup_tunnel ? 1 : 0
+
+  account_id = var.cloudflare_account_id
+  name = "${local.name_prefix}-backup-tunnel"
+  secret     = base64encode("backup-tunnel-secret-32-bytes-long")
+  config_src = "cloudflare"
+}
+
+# Pattern 7: Cross-resource references
+resource "cloudflare_tunnel" "primary" {
+  account_id = var.cloudflare_account_id
+  name = "${local.name_prefix}-primary-tunnel"
+  secret     = base64encode("primary-tunnel-secret-32-bytes-long")
+  config_src = "local"
+}
+
+# Tunnel that references another tunnel in its name
+resource "cloudflare_tunnel" "secondary" {
+  account_id = var.cloudflare_account_id
+  name       = "${cloudflare_tunnel.primary.name}-secondary"
+  secret     = base64encode("secondary-tunnel-secret-32-bytes-ok")
+  config_src = "cloudflare"
+}
+
+# Pattern 8: Resource with lifecycle meta-arguments
+resource "cloudflare_tunnel" "protected" {
+  account_id = var.cloudflare_account_id
+  name = "${local.name_prefix}-protected-tunnel"
+  secret     = base64encode("protected-tunnel-secret-32-bytes-ok")
+  config_src = "local"
+
+  lifecycle {
+    prevent_destroy       = false
+    create_before_destroy = true
+  }
+}
+
+# Pattern 9: Using terraform expressions
+variable "use_cloudflare_config" {
+  type    = bool
+  default = false
+}
+
+resource "cloudflare_tunnel" "conditional_config" {
+  account_id = var.cloudflare_account_id
+  name = "${local.name_prefix}-conditional-config-tunnel"
+  secret     = base64encode("conditional-secret-32-bytes-or-more")
+  config_src = var.use_cloudflare_config ? "cloudflare" : "local"
+}
+
+# Pattern 10: Tunnel with base64encode function
+resource "cloudflare_tunnel" "encoded" {
+  account_id = var.cloudflare_account_id
+  name = "${local.name_prefix}-encoded-tunnel"
+  secret     = base64encode("this-secret-is-base64-encoded-32b")
+  config_src = "local"
+}
+
+# Pattern 11: Tunnel using string interpolation
+resource "cloudflare_tunnel" "interpolated" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-${var.tunnel_prefix}-interpolated-${local.tunnel_suffix}"
+  secret     = base64encode("interpolated-secret-32-bytes-or-more")
+  config_src = "local"
+}
+
+# Pattern 12: Complex expression for config_src
+variable "is_production" {
+  type    = bool
+  default = true
+}
+
+resource "cloudflare_tunnel" "complex_config" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-${var.is_production ? "prod" : "dev"}-complex-tunnel"
+  secret     = base64encode("complex-tunnel-secret-32-bytes-long")
+  config_src = var.is_production ? "cloudflare" : "local"
+}

--- a/integration/v4_to_v5/testdata/zero_trust_tunnel_cloudflared/input/zero_trust_tunnel_cloudflared_preferred_name.tf
+++ b/integration/v4_to_v5/testdata/zero_trust_tunnel_cloudflared/input/zero_trust_tunnel_cloudflared_preferred_name.tf
@@ -1,0 +1,28 @@
+# Cross-file .secret reference rewriting test.
+#
+# Tunnels defined here use the preferred v4 type name
+# (cloudflare_zero_trust_tunnel_cloudflared) rather than the deprecated
+# cloudflare_tunnel name.  The companion file
+# zero_trust_tunnel_cloudflared_secret_refs.tf contains non-Cloudflare
+# resources that reference the computed `secret` attribute of these tunnels.
+#
+# After migration:
+#   - `secret` is renamed to `tunnel_secret` in each resource body
+#   - `config_src = "local"` is added where absent
+#   - No type rename and no moved block (type is already correct)
+#   - Cross-file `.secret` references in the consumer file are also rewritten
+
+# Test case 1 (the bug): resource already using the preferred v4 / v5 type name
+resource "cloudflare_zero_trust_tunnel_cloudflared" "preferred_a" {
+  account_id = var.cloudflare_account_id
+  name       = "cftftest-preferred-a-tunnel"
+  secret     = base64encode("preferred-a-tunnel-secret-32-bytes-ok")
+}
+
+# Second preferred-name tunnel to cover the coexistence case (test case 3)
+resource "cloudflare_zero_trust_tunnel_cloudflared" "preferred_b" {
+  account_id = var.cloudflare_account_id
+  name       = "cftftest-preferred-b-tunnel"
+  secret     = base64encode("preferred-b-tunnel-secret-32-bytes-ok")
+  config_src = "cloudflare"
+}

--- a/integration/v4_to_v5/testdata/zero_trust_tunnel_cloudflared/input/zero_trust_tunnel_cloudflared_secret_refs.tf
+++ b/integration/v4_to_v5/testdata/zero_trust_tunnel_cloudflared/input/zero_trust_tunnel_cloudflared_secret_refs.tf
@@ -1,0 +1,39 @@
+# Consumer resources that reference the computed `secret` attribute of tunnel
+# resources across files.  Uses vault_generic_secret (a non-Cloudflare resource)
+# to simulate the real-world pattern described in the bug report.
+#
+# All `.secret` references below must be rewritten to `.tunnel_secret` by the
+# cross-file postprocessing pass regardless of which v4 type name was used for
+# the tunnel resource.
+
+# Test case 1 (the bug): reference to a tunnel that already uses the preferred
+# v4 name cloudflare_zero_trust_tunnel_cloudflared.
+# Before the fix this reference was NOT rewritten because
+# GetComputedAttributeMappings only listed cloudflare_tunnel as OldResourceType.
+resource "vault_generic_secret" "preferred_a_secret" {
+  path = "secret/tunnels/preferred-a"
+
+  data_json = jsonencode({
+    tunnel_secret = cloudflare_zero_trust_tunnel_cloudflared.preferred_a.secret
+  })
+}
+
+# Test case 2 (existing behaviour): reference to a tunnel using the deprecated
+# cloudflare_tunnel name — must still be rewritten correctly.
+resource "vault_generic_secret" "from_old_name_tunnel" {
+  path = "secret/tunnels/minimal"
+
+  data_json = jsonencode({
+    tunnel_secret = cloudflare_tunnel.minimal.secret
+  })
+}
+
+# Test case 3 (coexistence): both v4 type names referenced in the same file
+resource "vault_generic_secret" "combined" {
+  path = "secret/tunnels/combined"
+
+  data_json = jsonencode({
+    old_secret       = cloudflare_tunnel.minimal.secret
+    preferred_secret = cloudflare_zero_trust_tunnel_cloudflared.preferred_a.secret
+  })
+}

--- a/internal/resources/zero_trust_tunnel_cloudflared/v4_to_v5.go
+++ b/internal/resources/zero_trust_tunnel_cloudflared/v4_to_v5.go
@@ -43,11 +43,30 @@ func (m *V4ToV5Migrator) GetResourceRename() ([]string, string) {
 }
 
 // GetComputedAttributeMappings implements the ComputedAttributeMapper interface
-// This enables cross-file reference updates for computed attributes that change names
+// This enables cross-file reference updates for computed attributes that change names.
+//
+// Two entries are required because this resource has two v4 type names:
+//   - cloudflare_tunnel: the deprecated v4 name — also renamed by the resource-type rename pass
+//   - cloudflare_zero_trust_tunnel_cloudflared: the preferred v4 name — NOT renamed (type stays the
+//     same), so its cross-file .secret references must be caught here explicitly.
+//
+// Without the second entry, any file that already used the preferred v4 name and references
+// <resource>.<name>.secret will keep the stale attribute name after migration.
 func (m *V4ToV5Migrator) GetComputedAttributeMappings() []transform.ComputedAttributeMapping {
 	return []transform.ComputedAttributeMapping{
 		{
+			// Resources that were using the deprecated cloudflare_tunnel name.
 			OldResourceType: "cloudflare_tunnel",
+			OldAttribute:    "secret",
+			NewResourceType: "cloudflare_zero_trust_tunnel_cloudflared",
+			NewAttribute:    "tunnel_secret",
+		},
+		{
+			// Resources already using the preferred v4 / v5 type name.
+			// Their own `secret` attribute is renamed by TransformConfig, but cross-file
+			// references such as cloudflare_zero_trust_tunnel_cloudflared.<name>.secret
+			// in non-Cloudflare resources (e.g. vault_generic_secret) are only fixed here.
+			OldResourceType: "cloudflare_zero_trust_tunnel_cloudflared",
 			OldAttribute:    "secret",
 			NewResourceType: "cloudflare_zero_trust_tunnel_cloudflared",
 			NewAttribute:    "tunnel_secret",

--- a/internal/resources/zero_trust_tunnel_cloudflared/v4_to_v5_test.go
+++ b/internal/resources/zero_trust_tunnel_cloudflared/v4_to_v5_test.go
@@ -4,10 +4,61 @@ import (
 	"testing"
 
 	"github.com/cloudflare/tf-migrate/internal/testhelpers"
+	"github.com/cloudflare/tf-migrate/internal/transform"
 )
 
 func TestV4ToV5Transformation(t *testing.T) {
 	migrator := NewV4ToV5Migrator()
+
+	// TestComputedAttributeMappings verifies that GetComputedAttributeMappings returns
+	// entries for BOTH v4 type names so cross-file .secret references are rewritten
+	// regardless of which name was used in the original config.
+	t.Run("ComputedAttributeMappings", func(t *testing.T) {
+		mapper, ok := migrator.(transform.ComputedAttributeMapper)
+		if !ok {
+			t.Fatal("migrator does not implement ComputedAttributeMapper")
+		}
+		mappings := mapper.GetComputedAttributeMappings()
+
+		// Build a lookup by OldResourceType for easy assertions.
+		byOldType := make(map[string]transform.ComputedAttributeMapping, len(mappings))
+		for _, m := range mappings {
+			byOldType[m.OldResourceType] = m
+		}
+
+		// Case 1: deprecated cloudflare_tunnel name (pre-existing behaviour)
+		old, ok := byOldType["cloudflare_tunnel"]
+		if !ok {
+			t.Errorf("missing mapping for OldResourceType=cloudflare_tunnel")
+		} else {
+			if old.OldAttribute != "secret" {
+				t.Errorf("cloudflare_tunnel mapping: want OldAttribute=secret, got %q", old.OldAttribute)
+			}
+			if old.NewResourceType != "cloudflare_zero_trust_tunnel_cloudflared" {
+				t.Errorf("cloudflare_tunnel mapping: want NewResourceType=cloudflare_zero_trust_tunnel_cloudflared, got %q", old.NewResourceType)
+			}
+			if old.NewAttribute != "tunnel_secret" {
+				t.Errorf("cloudflare_tunnel mapping: want NewAttribute=tunnel_secret, got %q", old.NewAttribute)
+			}
+		}
+
+		// Case 2: preferred v4 name cloudflare_zero_trust_tunnel_cloudflared (the bug — this was missing)
+		preferred, ok := byOldType["cloudflare_zero_trust_tunnel_cloudflared"]
+		if !ok {
+			t.Errorf("missing mapping for OldResourceType=cloudflare_zero_trust_tunnel_cloudflared; " +
+				"cross-file .secret references on resources that already use the v5 type name will not be rewritten")
+		} else {
+			if preferred.OldAttribute != "secret" {
+				t.Errorf("cloudflare_zero_trust_tunnel_cloudflared mapping: want OldAttribute=secret, got %q", preferred.OldAttribute)
+			}
+			if preferred.NewResourceType != "cloudflare_zero_trust_tunnel_cloudflared" {
+				t.Errorf("cloudflare_zero_trust_tunnel_cloudflared mapping: want NewResourceType=cloudflare_zero_trust_tunnel_cloudflared, got %q", preferred.NewResourceType)
+			}
+			if preferred.NewAttribute != "tunnel_secret" {
+				t.Errorf("cloudflare_zero_trust_tunnel_cloudflared mapping: want NewAttribute=tunnel_secret, got %q", preferred.NewAttribute)
+			}
+		}
+	})
 
 	t.Run("ConfigTransformation", func(t *testing.T) {
 		tests := []testhelpers.ConfigTestCase{


### PR DESCRIPTION
## Problem

When a `cloudflare_zero_trust_tunnel_cloudflared` resource used the **preferred v4 type name** (rather than the deprecated `cloudflare_tunnel`), cross-file references to its computed `secret` attribute were silently left unrewritten after migration.

For example, a `vault_generic_secret` resource in another file containing:

```hcl
tunnel_secret = cloudflare_zero_trust_tunnel_cloudflared.my_tunnel.secret
```

would survive into v5 config unchanged, causing `terraform plan` to fail with `Error: Unsupported attribute` because `secret` no longer exists in v5 — it was renamed to `tunnel_secret`.

The resource body transformation (`secret` → `tunnel_secret` inside the tunnel resource block itself) was applied correctly. The bug was exclusively in the cross-file postprocessing pass.

## Root Cause

`GetComputedAttributeMappings` only listed `cloudflare_tunnel` as `OldResourceType`:

```go
// Before
return []transform.ComputedAttributeMapping{
    {
        OldResourceType: "cloudflare_tunnel",   // ← only the deprecated name
        OldAttribute:    "secret",
        NewResourceType: "cloudflare_zero_trust_tunnel_cloudflared",
        NewAttribute:    "tunnel_secret",
    },
}
```

The postprocessor builds a regex from `OldResourceType`, so it only matched `cloudflare_tunnel.<name>.secret`. Any reference using `cloudflare_zero_trust_tunnel_cloudflared.<name>.secret` was never touched.

## Fix

Add a second mapping entry for the preferred v4 type name:

```go
// After
return []transform.ComputedAttributeMapping{
    {
        OldResourceType: "cloudflare_tunnel",
        OldAttribute:    "secret",
        NewResourceType: "cloudflare_zero_trust_tunnel_cloudflared",
        NewAttribute:    "tunnel_secret",
    },
    {
        OldResourceType: "cloudflare_zero_trust_tunnel_cloudflared",
        OldAttribute:    "secret",
        NewResourceType: "cloudflare_zero_trust_tunnel_cloudflared",
        NewAttribute:    "tunnel_secret",
    },
}
```

## Tests

**Unit test** (`TestV4ToV5Transformation/ComputedAttributeMappings`): asserts that both `cloudflare_tunnel` and `cloudflare_zero_trust_tunnel_cloudflared` are present as `OldResourceType` entries with the correct attribute mapping. This test **failed before the fix** and passes after.

**Integration test fixtures** (added to the existing `zero_trust_tunnel_cloudflared` testdata):
- `zero_trust_tunnel_cloudflared_preferred_name.tf` — two tunnel resources already using the preferred v4 name with a `secret` attribute
- `zero_trust_tunnel_cloudflared_secret_refs.tf` — `vault_generic_secret` resources referencing `.secret` on both v4 type names, covering all three cases from the ticket:
  1. `cloudflare_zero_trust_tunnel_cloudflared.<name>.secret` → `.tunnel_secret` (the bug)
  2. `cloudflare_tunnel.<name>.secret` → `cloudflare_zero_trust_tunnel_cloudflared.<name>.tunnel_secret` (existing behaviour preserved)
  3. Both patterns coexisting in the same file

**E2E**: `zero_trust_tunnel_cloudflared_e2e.tf` added (exact copy of the original input) to prevent the vault-provider fixtures from being synced into the E2E environment, which only has the Cloudflare provider available. E2E run passes end-to-end.

---



```
./scripts/run-e2e-tests.sh --resources zero_trust_tunnel_cloudflared --apply-exemptions --target-provider-version 5.19.0-beta.5 --provider /Users/tamas/cf-repos/sdks/agent-a/cloudflare-terraform-next
Building binaries...
Syncing exemption YAMLs from e2e/ into internal/verifydrift/exemptions/...
cp e2e/global-drift-exemptions.yaml internal/verifydrift/exemptions/
cp -r e2e/drift-exemptions/. internal/verifydrift/exemptions/drift-exemptions/
Sync complete
go build -v -o bin/tf-migrate ./cmd/tf-migrate
go build -v -o bin/e2e-runner ./cmd/e2e-runner

Targeting specific resources: zero_trust_tunnel_cloudflared
Target arguments: -target=module.zero_trust_tunnel_cloudflared


========================================
E2E Migration Test
========================================

Step 0: Initializing test resources
Running tests with:
  User:       apix-ci@cloudflareapitest.com
  Account ID: a09697b020084f87a205896b35575a37
  Zone ID:    cd581854c1f59f8c686ee796d0eddce2
  Domain:     e2e.terraform.cfapi.net
  Provider:   Local (/Users/tamas/cf-repos/sdks/agent-a/cloudflare-terraform-next)

Running init script...

========================================
Syncing Test Resources
========================================

Filtering to specific resources: zero_trust_tunnel_cloudflared
Syncing resource files from testdata...
  ✓ zero_trust_tunnel_cloudflared/zero_trust_tunnel_cloudflared.tf (from zero_trust_tunnel_cloudflared_e2e.tf)
  ✓ zero_trust_tunnel_cloudflared/versions.tf

  Total: 2 files synced

Configuring terraform variables...


✓ Saved configuration
    Account ID: a09697b020084f87a205896b35575a37
    Zone ID: cd581854c1f59f8c686ee796d0eddce2
    Domain: e2e.terraform.cfapi.net
    File: v4/terraform.tfvars

Scanning for import annotations...

Updating main.tf with module references...
  ↻ Updated main.tf with 1 module references


========================================
✓ Sync Complete!
========================================

Summary:
  - Terraform v4 configs: /Users/tamas/cf-repos/sdks/agent-a/tf-migrate/e2e/tf/v4
  - Modules: 1
  - Files synced: 2

Configuring remote backend...
✓ Backend configured

  ✓ Provider installation preserved
  ✓ Backend already configured

Next steps:
  cd tf/v4 && terraform apply

Note: Configuration is automatically loaded from terraform.tfvars
      State is managed remotely in R2

✓ Test resources initialized


========================================
Setting up local provider
========================================

Using provider from: /Users/tamas/cf-repos/sdks/agent-a/cloudflare-terraform-next
Building provider...
  Building in: /Users/tamas/cf-repos/sdks/agent-a/cloudflare-terraform-next
  Output: /Users/tamas/cf-repos/sdks/agent-a/cloudflare-terraform-next/terraform-provider-cloudflare
✓ Provider built successfully: /Users/tamas/cf-repos/sdks/agent-a/cloudflare-terraform-next/terraform-provider-cloudflare
✓ Created dev overrides config: /Users/tamas/cf-repos/sdks/agent-a/tf-migrate/.terraformrc-tf-migrate
✓ Local provider will be used for v5 testing

Note: v4 tests will use the registry provider (v4.x)
      v5 tests will use the local provider with dev overrides

Step 1: Testing v4 configurations
Running terraform init in v4/...
Found local state file, backing up and using remote state...
✓ Terraform init successful (remote state loaded from R2)
Running terraform plan in v4/...
✓ Terraform plan shows no changes

Running terraform apply in v4/...
✓ Terraform apply successful
  Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
Syncing state from remote...
✓ Local state file synced from R2
Capturing v4 state...
✓ Saved v4 state to tmp/v4-state.json


Step 2: Running migration
Running ./scripts/migrate...
Building tf-migrate binary...
✓ Binary built successfully

========================================
Running v4 to v5 Migration
========================================

Preparing output directory...
  ✓ Preserved v5 provider installation (.terraform/)
  ✓ Preserved v5 dependency lock file (.terraform.lock.hcl)
Copying only targeted resources: zero_trust_tunnel_cloudflared
    ✓ Copied root file: provider.tf
    ✓ Copied root file: terraform.tfvars
    ✓ Copied root file: terraform.tfstate

    ✓ Copied module: zero_trust_tunnel_cloudflared
Creating filtered main.tf...
✓ Copied targeted resources to migrated-v4_to_v5/
✓ Updated provider.tf to use ~> 5.0 and removed backend config

Migrating configuration files...
  Migrated 15 resources (15 renamed, 0 config-only)

Provider version updated to 5.19.0-beta.5.

Next steps:

  1. Regenerate the lock file locally in each directory:
       cd /Users/tamas/cf-repos/sdks/agent-a/tf-migrate/e2e/migrated-v4_to_v5 && terraform init -upgrade -backend=false
       cd /Users/tamas/cf-repos/sdks/agent-a/tf-migrate/e2e/migrated-v4_to_v5/zero_trust_tunnel_cloudflared && terraform init -upgrade -backend=false

  2. Commit and push all changed files:
       git add .
       git commit -m "chore: migrate Cloudflare provider to v5.19.0-beta.5"
       git push
✓ Migration complete (config transformed; state will be upgraded by the provider)


========================================
✓ Migration Complete!
========================================

Results:
  Input (v4):  /Users/tamas/cf-repos/sdks/agent-a/tf-migrate/e2e/tf/v4
  Output (v5): /Users/tamas/cf-repos/sdks/agent-a/tf-migrate/e2e/migrated-v4_to_v5

Next steps:
  cd /Users/tamas/cf-repos/sdks/agent-a/tf-migrate/e2e/migrated-v4_to_v5
  terraform init
  terraform plan

✓ Migration successful
Removing obsolete state entry (no v5 schema): module.zero_trust_access_policy.cloudflare_access_policy.any_service_token_policy
Removing obsolete state entry (no v5 schema): module.zero_trust_access_policy.cloudflare_access_policy.app_scoped_policy
Removing obsolete state entry (no v5 schema): module.zero_trust_access_policy.cloudflare_access_policy.common_names_overflow
Removing obsolete state entry (no v5 schema): module.zero_trust_access_policy.cloudflare_access_policy.complex
Removing obsolete state entry (no v5 schema): module.zero_trust_access_policy.cloudflare_access_policy.email_domain_policy
Removing obsolete state entry (no v5 schema): module.zero_trust_access_policy.cloudflare_access_policy.example
Removing obsolete state entry (no v5 schema): module.zero_trust_access_policy.cloudflare_access_policy.maximal
Removing obsolete state entry (no v5 schema): module.zero_trust_access_policy.cloudflare_access_policy.minimal
Removing obsolete state entry (no v5 schema): module.zero_trust_access_policy.cloudflare_access_policy.multi_email_domain_policy
Removing obsolete state entry (no v5 schema): module.zero_trust_access_policy.cloudflare_access_policy.no_service_token_policy
Removing obsolete state entry (no v5 schema): module.zero_trust_access_policy.cloudflare_access_policy.with_connection_rules
Removing obsolete state entry (no v5 schema): module.zone_setting.cloudflare_zone_settings_override.conditional_enabled
Removing obsolete state entry (no v5 schema): module.zone_setting.cloudflare_zone_settings_override.minimal
Removing obsolete state entry (no v5 schema): module.zone_setting.cloudflare_zone_settings_override.with_deprecated
Removing obsolete state entry (no v5 schema): module.zone_setting.cloudflare_zone_settings_override.with_functions
Removing obsolete state entry (no v5 schema): module.zone_setting.cloudflare_zone_settings_override.with_ignore_changes
Removing obsolete state entry (no v5 schema): module.zone_setting.cloudflare_zone_settings_override.with_integers
Removing obsolete state entry (no v5 schema): module.zone_setting.cloudflare_zone_settings_override.with_interpolation
Removing obsolete state entry (no v5 schema): module.zone_setting.cloudflare_zone_settings_override.with_lifecycle
Removing obsolete state entry (no v5 schema): module.zone_setting.cloudflare_zone_settings_override.with_name_mapping
Removing obsolete state entry (no v5 schema): module.zone_setting.cloudflare_zone_settings_override.with_security_header

Step 3: Testing v5 configurations
Running terraform init in migrated-v4_to_v5/...
Cleaning v5 .terraform directory for fresh init...
Removing .terraform.lock.hcl to allow dev_overrides...
✓ Terraform init successful
Running terraform plan in v5/...
✓ Terraform plan shows only computed value refreshes (ignored with --apply-exemptions)
Running terraform apply in v5/...
✓ Terraform apply successful
Capturing v5 state...
Warning: Skipping v5 state snapshot — schema version mismatch for an unvisited resource

Step 4: Verifying stable state (v5 plan after apply)
Running terraform plan again to check for ongoing drift...
✓ No ongoing drift detected - migration achieved stable state!



========================================
✓ E2E Test Complete!
========================================

Summary:

  Step 1: v4 terraform apply
    Status: ✓ SUCCESS

  Step 2: Migration (v4 → v5)
    Status: ✓ SUCCESS

  Step 3: v5 plan (before apply)
    Status: ✓ No material changes
    Result: 0 material changes
    Terraform: Plan: 0 to add, 0 to change, 0 to destroy.

  Step 4: v5 terraform apply
    Status: ✓ SUCCESS

  Step 5: v5 plan (after apply)
    Status: ✓ SUCCESS - Stable state achieved
    Result: No changes detected
```