### PR TITLE
fix(zero_trust_tunnel_cloudflared): emit DiagWarning for .tunnel_toke…

### DIFF
--- a/cmd/tf-migrate/main.go
+++ b/cmd/tf-migrate/main.go
@@ -1064,7 +1064,9 @@ func processConfigFiles(log hclog.Logger, p *pipeline.Pipeline, cfg config) (map
 
 	// Apply global postprocessing for cross-file reference updates
 	if !cfg.dryRun && len(outputPaths) > 0 {
-		if err := applyGlobalPostprocessing(log, cfg, outputPaths); err != nil {
+		postDiags, err := applyGlobalPostprocessing(log, cfg, outputPaths)
+		allDiagnostics = append(allDiagnostics, postDiags...)
+		if err != nil {
 			return nil, allDiagnostics, fmt.Errorf("failed to apply global postprocessing: %w", err)
 		}
 	}
@@ -1072,8 +1074,11 @@ func processConfigFiles(log hclog.Logger, p *pipeline.Pipeline, cfg config) (map
 	return parsedConfigs, allDiagnostics, nil
 }
 
-func applyGlobalPostprocessing(log hclog.Logger, cfg config, outputPaths []string) error {
-	// Collect resource renames, attribute renames, and computed attribute mappings from all migrators
+func applyGlobalPostprocessing(log hclog.Logger, cfg config, outputPaths []string) (hcl.Diagnostics, error) {
+	var diags hcl.Diagnostics
+
+	// Collect resource renames, attribute renames, computed attribute mappings,
+	// and invalid attribute reference detectors from all migrators.
 	providers := getProviders(cfg.resourcesToMigrate...)
 	migrators := providers.GetAllMigrators(cfg.sourceVersion, cfg.targetVersion, cfg.resourcesToMigrate...)
 
@@ -1083,6 +1088,8 @@ func applyGlobalPostprocessing(log hclog.Logger, cfg config, outputPaths []strin
 	var attributeRenames []transform.AttributeRename
 	// Slice to store computed attribute mappings (for when both resource type AND attribute change)
 	var computedAttrMappings []transform.ComputedAttributeMapping
+	// Slice to store invalid attribute references to warn about
+	var invalidAttrRefs []transform.InvalidAttributeReference
 
 	for _, migrator := range migrators {
 		// Check if this migrator implements ResourceRenamer interface
@@ -1134,12 +1141,25 @@ func applyGlobalPostprocessing(log hclog.Logger, cfg config, outputPaths []strin
 				}
 			}
 		}
+
+		// Check if this migrator implements InvalidAttributeReferenceDetector interface
+		if detector, ok := migrator.(transform.InvalidAttributeReferenceDetector); ok {
+			refs := detector.GetInvalidAttributeReferences()
+			if len(refs) > 0 {
+				invalidAttrRefs = append(invalidAttrRefs, refs...)
+				for _, r := range refs {
+					log.Debug("Collected invalid attribute reference detector",
+						"resource_type", r.ResourceType,
+						"attribute", r.Attribute)
+				}
+			}
+		}
 	}
 
-	// If no renames found, skip global postprocessing
-	if len(renames) == 0 && len(attributeRenames) == 0 && len(computedAttrMappings) == 0 {
+	// If no renames or detectors found, skip global postprocessing
+	if len(renames) == 0 && len(attributeRenames) == 0 && len(computedAttrMappings) == 0 && len(invalidAttrRefs) == 0 {
 		log.Debug("No renames found, skipping global postprocessing")
-		return nil
+		return diags, nil
 	}
 
 	// Track resources that were intentionally converted to removed {} blocks.
@@ -1230,9 +1250,17 @@ func applyGlobalPostprocessing(log hclog.Logger, cfg config, outputPaths []strin
 		// Write back if modified
 		if modified {
 			if err := os.WriteFile(outputPath, []byte(contentStr), 0644); err != nil {
-				return fmt.Errorf("failed to write updated file %s: %w", outputPath, err)
+				return diags, fmt.Errorf("failed to write updated file %s: %w", outputPath, err)
 			}
 		}
+	}
+
+	// Scan all output files for invalid attribute references and emit DiagWarnings.
+	// This runs after all rewrites so that already-fixed references (e.g. secret →
+	// tunnel_secret) don't produce false positives.
+	if len(invalidAttrRefs) > 0 {
+		invalidAttrDiags := scanForInvalidAttributeReferences(log, outputPaths, invalidAttrRefs)
+		diags = append(diags, invalidAttrDiags...)
 	}
 
 	if cfg.verbose {
@@ -1269,7 +1297,49 @@ func applyGlobalPostprocessing(log hclog.Logger, cfg config, outputPaths []strin
 			fmt.Println("✓ No cross-file references needed updating")
 		}
 	}
-	return nil
+	return diags, nil
+}
+
+// scanForInvalidAttributeReferences scans output files for cross-file references
+// to known-invalid attributes and returns a DiagWarning for each match found.
+func scanForInvalidAttributeReferences(log hclog.Logger, outputPaths []string, refs []transform.InvalidAttributeReference) hcl.Diagnostics {
+	var diags hcl.Diagnostics
+
+	for _, outputPath := range outputPaths {
+		content, err := os.ReadFile(outputPath)
+		if err != nil {
+			log.Warn("Failed to read file for invalid attribute scan", "file", outputPath, "error", err)
+			continue
+		}
+		contentStr := string(content)
+
+		for _, ref := range refs {
+			// Pattern: <ResourceType>.<instance_name>.<Attribute>
+			// Instance names may contain letters, digits, underscores, hyphens.
+			pattern := ref.ResourceType + `\.([a-zA-Z0-9_-]+)\.` + ref.Attribute
+			re, err := regexp.Compile(pattern)
+			if err != nil {
+				log.Warn("Failed to compile invalid attribute pattern", "pattern", pattern, "error", err)
+				continue
+			}
+
+			matches := re.FindAllString(contentStr, -1)
+			for _, match := range matches {
+				summary := fmt.Sprintf("Unknown attribute reference: %s", match)
+				detail := fmt.Sprintf("In %s\n\n  %s", filepath.Base(outputPath), ref.Suggestion)
+				log.Debug("Found invalid attribute reference",
+					"file", filepath.Base(outputPath),
+					"match", match)
+				diags = append(diags, &hcl.Diagnostic{
+					Severity: hcl.DiagWarning,
+					Summary:  summary,
+					Detail:   detail,
+				})
+			}
+		}
+	}
+
+	return diags
 }
 
 // collectRemovedRefsByType scans transformed files and returns addresses found in

--- a/cmd/tf-migrate/main_postprocessing_test.go
+++ b/cmd/tf-migrate/main_postprocessing_test.go
@@ -4,7 +4,14 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/hcl/v2"
+
+	"github.com/cloudflare/tf-migrate/internal/transform"
 )
+
+func newTestLogger() hclog.Logger { return hclog.NewNullLogger() }
 
 func TestReplaceResourceTypeRefsSkippingMovedBlocks(t *testing.T) {
 	input := `output "keep_old" {
@@ -93,4 +100,102 @@ moved {
 	if _, ok := refs["cloudflare_access_policy"]["other"]; ok {
 		t.Fatalf("did not expect moved block address to be collected as removed ref: %#v", refs)
 	}
+}
+
+func TestScanForInvalidAttributeReferences(t *testing.T) {
+	refs := []transform.InvalidAttributeReference{
+		{
+			ResourceType: "cloudflare_zero_trust_tunnel_cloudflared",
+			Attribute:    "tunnel_token",
+			Suggestion:   "tunnel_token is not a valid attribute; use tunnel_secret instead",
+		},
+	}
+
+	t.Run("detects_tunnel_token_reference", func(t *testing.T) {
+		tmp := t.TempDir()
+		file := filepath.Join(tmp, "consumers.tf")
+		content := `resource "vault_generic_secret" "token" {
+  data_json = jsonencode({
+    token = cloudflare_zero_trust_tunnel_cloudflared.my_tunnel.tunnel_token
+  })
+}
+`
+		if err := os.WriteFile(file, []byte(content), 0644); err != nil {
+			t.Fatalf("writing fixture: %v", err)
+		}
+
+		diags := scanForInvalidAttributeReferences(newTestLogger(), []string{file}, refs)
+		if len(diags) != 1 {
+			t.Fatalf("expected 1 diagnostic, got %d: %v", len(diags), diags)
+		}
+		if diags[0].Severity != hcl.DiagWarning {
+			t.Errorf("expected DiagWarning, got %v", diags[0].Severity)
+		}
+		if !contains(diags[0].Summary, "tunnel_token") {
+			t.Errorf("expected summary to mention tunnel_token, got: %s", diags[0].Summary)
+		}
+		if !contains(diags[0].Detail, "tunnel_secret") {
+			t.Errorf("expected detail to mention tunnel_secret, got: %s", diags[0].Detail)
+		}
+	})
+
+	t.Run("no_false_positive_for_valid_attribute", func(t *testing.T) {
+		tmp := t.TempDir()
+		file := filepath.Join(tmp, "consumers.tf")
+		// tunnel_secret is valid — must NOT produce a warning
+		content := `resource "vault_generic_secret" "secret" {
+  data_json = jsonencode({
+    secret = cloudflare_zero_trust_tunnel_cloudflared.my_tunnel.tunnel_secret
+  })
+}
+`
+		if err := os.WriteFile(file, []byte(content), 0644); err != nil {
+			t.Fatalf("writing fixture: %v", err)
+		}
+
+		diags := scanForInvalidAttributeReferences(newTestLogger(), []string{file}, refs)
+		if len(diags) != 0 {
+			t.Fatalf("expected no diagnostics for valid attribute, got %d: %v", len(diags), diags)
+		}
+	})
+
+	t.Run("multiple_matches_produce_multiple_warnings", func(t *testing.T) {
+		tmp := t.TempDir()
+		file := filepath.Join(tmp, "consumers.tf")
+		content := `resource "vault_generic_secret" "a" {
+  data_json = jsonencode({
+    a = cloudflare_zero_trust_tunnel_cloudflared.tunnel_a.tunnel_token
+    b = cloudflare_zero_trust_tunnel_cloudflared.tunnel_b.tunnel_token
+  })
+}
+`
+		if err := os.WriteFile(file, []byte(content), 0644); err != nil {
+			t.Fatalf("writing fixture: %v", err)
+		}
+
+		diags := scanForInvalidAttributeReferences(newTestLogger(), []string{file}, refs)
+		if len(diags) != 2 {
+			t.Fatalf("expected 2 diagnostics (one per match), got %d", len(diags))
+		}
+	})
+
+	t.Run("no_match_in_unrelated_resource_type", func(t *testing.T) {
+		tmp := t.TempDir()
+		file := filepath.Join(tmp, "consumers.tf")
+		// Different resource type — must not match
+		content := `resource "vault_generic_secret" "other" {
+  data_json = jsonencode({
+    tok = cloudflare_some_other_resource.foo.tunnel_token
+  })
+}
+`
+		if err := os.WriteFile(file, []byte(content), 0644); err != nil {
+			t.Fatalf("writing fixture: %v", err)
+		}
+
+		diags := scanForInvalidAttributeReferences(newTestLogger(), []string{file}, refs)
+		if len(diags) != 0 {
+			t.Fatalf("expected no diagnostics for different resource type, got %d", len(diags))
+		}
+	})
 }

--- a/integration/v4_to_v5/testdata/zero_trust_tunnel_cloudflared/expected/zero_trust_tunnel_cloudflared_preferred_name.tf
+++ b/integration/v4_to_v5/testdata/zero_trust_tunnel_cloudflared/expected/zero_trust_tunnel_cloudflared_preferred_name.tf
@@ -1,0 +1,29 @@
+# Cross-file .secret reference rewriting test.
+#
+# Tunnels defined here use the preferred v4 type name
+# (cloudflare_zero_trust_tunnel_cloudflared) rather than the deprecated
+# cloudflare_tunnel name.  The companion file
+# zero_trust_tunnel_cloudflared_secret_refs.tf contains non-Cloudflare
+# resources that reference the computed `secret` attribute of these tunnels.
+#
+# After migration:
+#   - `secret` is renamed to `tunnel_secret` in each resource body
+#   - `config_src = "local"` is added where absent
+#   - No type rename and no moved block (type is already correct)
+#   - Cross-file `.secret` references in the consumer file are also rewritten
+
+# Test case 1 (the bug): resource already using the preferred v4 / v5 type name
+resource "cloudflare_zero_trust_tunnel_cloudflared" "preferred_a" {
+  account_id    = var.cloudflare_account_id
+  name          = "cftftest-preferred-a-tunnel"
+  tunnel_secret = base64encode("preferred-a-tunnel-secret-32-bytes-ok")
+  config_src    = "local"
+}
+
+# Second preferred-name tunnel to cover the coexistence case (test case 3)
+resource "cloudflare_zero_trust_tunnel_cloudflared" "preferred_b" {
+  account_id    = var.cloudflare_account_id
+  name          = "cftftest-preferred-b-tunnel"
+  config_src    = "cloudflare"
+  tunnel_secret = base64encode("preferred-b-tunnel-secret-32-bytes-ok")
+}

--- a/integration/v4_to_v5/testdata/zero_trust_tunnel_cloudflared/expected/zero_trust_tunnel_cloudflared_secret_refs.tf
+++ b/integration/v4_to_v5/testdata/zero_trust_tunnel_cloudflared/expected/zero_trust_tunnel_cloudflared_secret_refs.tf
@@ -1,0 +1,39 @@
+# Consumer resources that reference the computed `secret` attribute of tunnel
+# resources across files.  Uses vault_generic_secret (a non-Cloudflare resource)
+# to simulate the real-world pattern described in the bug report.
+#
+# All `.secret` references below must be rewritten to `.tunnel_secret` by the
+# cross-file postprocessing pass regardless of which v4 type name was used for
+# the tunnel resource.
+
+# Test case 1 (the bug): reference to a tunnel that already uses the preferred
+# v4 name cloudflare_zero_trust_tunnel_cloudflared.
+# Before the fix this reference was NOT rewritten because
+# GetComputedAttributeMappings only listed cloudflare_tunnel as OldResourceType.
+resource "vault_generic_secret" "preferred_a_secret" {
+  path = "secret/tunnels/preferred-a"
+
+  data_json = jsonencode({
+    tunnel_secret = cloudflare_zero_trust_tunnel_cloudflared.preferred_a.tunnel_secret
+  })
+}
+
+# Test case 2 (existing behaviour): reference to a tunnel using the deprecated
+# cloudflare_tunnel name — must still be rewritten correctly.
+resource "vault_generic_secret" "from_old_name_tunnel" {
+  path = "secret/tunnels/minimal"
+
+  data_json = jsonencode({
+    tunnel_secret = cloudflare_zero_trust_tunnel_cloudflared.minimal.tunnel_secret
+  })
+}
+
+# Test case 3 (coexistence): both v4 type names referenced in the same file
+resource "vault_generic_secret" "combined" {
+  path = "secret/tunnels/combined"
+
+  data_json = jsonencode({
+    old_secret       = cloudflare_zero_trust_tunnel_cloudflared.minimal.tunnel_secret
+    preferred_secret = cloudflare_zero_trust_tunnel_cloudflared.preferred_a.tunnel_secret
+  })
+}

--- a/integration/v4_to_v5/testdata/zero_trust_tunnel_cloudflared/expected/zero_trust_tunnel_cloudflared_tunnel_token_refs.tf
+++ b/integration/v4_to_v5/testdata/zero_trust_tunnel_cloudflared/expected/zero_trust_tunnel_cloudflared_tunnel_token_refs.tf
@@ -1,0 +1,18 @@
+# Integration test for the tunnel_token DiagWarning (ticket 004).
+#
+# A reference to <tunnel_resource>.<name>.tunnel_token is NOT a valid v4 or v5
+# attribute. tf-migrate must NOT rewrite it (there is no safe replacement), and
+# must emit a DiagWarning with guidance.
+#
+# The expected output file for this fixture is identical to the input — the
+# tunnel_token reference is left unchanged and the warning appears in the
+# diagnostic output, not in the .tf file.
+
+resource "vault_generic_secret" "tunnel_token_ref" {
+  path = "secret/tunnels/token"
+
+  data_json = jsonencode({
+    # tunnel_token is not a valid attribute — tf-migrate should warn, not rewrite
+    token = cloudflare_zero_trust_tunnel_cloudflared.minimal.tunnel_token
+  })
+}

--- a/integration/v4_to_v5/testdata/zero_trust_tunnel_cloudflared/input/zero_trust_tunnel_cloudflared_e2e.tf
+++ b/integration/v4_to_v5/testdata/zero_trust_tunnel_cloudflared/input/zero_trust_tunnel_cloudflared_e2e.tf
@@ -1,0 +1,241 @@
+variable "cloudflare_account_id" {
+  description = "Cloudflare account ID"
+  type        = string
+}
+
+variable "cloudflare_zone_id" {
+  description = "Cloudflare zone ID"
+  type        = string
+}
+
+variable "cloudflare_domain" {
+  description = "Cloudflare domain for testing"
+  type        = string
+}
+
+# ========================================
+# Basic Tunnel Resources
+# ========================================
+
+# Basic tunnel with minimal configuration
+resource "cloudflare_tunnel" "minimal" {
+  account_id = var.cloudflare_account_id
+  name = "${local.name_prefix}-minimal-tunnel"
+  secret     = base64encode("test-secret-that-is-at-least-32-bytes-long")
+  config_src = "local"
+}
+
+# Tunnel with local config source
+resource "cloudflare_tunnel" "local_config" {
+  account_id = var.cloudflare_account_id
+  name = "${local.name_prefix}-local-config-tunnel"
+  secret     = base64encode("another-secret-32-bytes-or-longer-here")
+  config_src = "local"
+}
+
+# Tunnel with cloudflare config source
+resource "cloudflare_tunnel" "cloudflare_config" {
+  account_id = var.cloudflare_account_id
+  name = "${local.name_prefix}-cloudflare-config-tunnel"
+  secret     = base64encode("remote-tunnel-secret-32-bytes-minimum")
+  config_src = "cloudflare"
+}
+
+# ========================================
+# Advanced Terraform Patterns for Testing
+# ========================================
+
+# Pattern 1: Variable references
+variable "tunnel_prefix" {
+  type    = string
+  default = "var-test"
+}
+
+variable "config_source" {
+  type    = string
+  default = "local"
+}
+
+# Pattern 2: Local values with expressions
+locals {
+  name_prefix        = "cftftest"
+  tunnel_secret_base = "generated-secret-that-is-32-bytes-long"
+  common_account_id  = var.cloudflare_account_id
+  tunnel_suffix      = "prod"
+  full_tunnel_name   = "${local.name_prefix}-${var.tunnel_prefix}-${local.tunnel_suffix}"
+}
+
+# Tunnel using variables and locals
+resource "cloudflare_tunnel" "with_vars" {
+  account_id = local.common_account_id
+  name       = local.full_tunnel_name
+  secret     = base64encode(local.tunnel_secret_base)
+  config_src = var.config_source
+}
+
+# Pattern 3: for_each with map
+variable "application_tunnels" {
+  type = map(object({
+    secret     = string
+    config_src = string
+  }))
+  default = {
+    "api" = {
+      secret     = "api-tunnel-secret-that-is-32-bytes"
+      config_src = "local"
+    }
+    "web" = {
+      secret     = "web-tunnel-secret-that-is-32-bytes"
+      config_src = "cloudflare"
+    }
+    "backend" = {
+      secret     = "backend-secret-that-is-32-bytes-ok"
+      config_src = "local"
+    }
+  }
+}
+
+resource "cloudflare_tunnel" "applications" {
+  for_each = var.application_tunnels
+
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-${each.key}-tunnel"
+  secret     = base64encode(each.value.secret)
+  config_src = each.value.config_src
+}
+
+# Pattern 4: for_each with list converted to set
+variable "environment_tunnels" {
+  type = list(object({
+    name       = string
+    secret     = string
+    config_src = string
+  }))
+  default = [
+    {
+      name       = "dev"
+      secret     = "dev-environment-secret-32-bytes-min"
+      config_src = "local"
+    },
+    {
+      name       = "staging"
+      secret     = "staging-environment-secret-32-byte"
+      config_src = "cloudflare"
+    },
+    {
+      name       = "prod"
+      secret     = "prod-environment-secret-32-bytes-ok"
+      config_src = "cloudflare"
+    }
+  ]
+}
+
+resource "cloudflare_tunnel" "environments" {
+  for_each = { for idx, tunnel in var.environment_tunnels : tunnel.name => tunnel }
+
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-${each.value.name}-env-tunnel"
+  secret     = base64encode(each.value.secret)
+  config_src = each.value.config_src
+}
+
+# Pattern 5: Count-based resources
+variable "replica_count" {
+  type    = number
+  default = 3
+}
+
+resource "cloudflare_tunnel" "replicas" {
+  count = var.replica_count
+
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-replica-tunnel-${count.index + 1}"
+  secret     = base64encode("replica-${count.index}-secret-32-bytes-long")
+  config_src = "local"
+}
+
+# Pattern 6: Conditional resource creation
+variable "enable_backup_tunnel" {
+  type    = bool
+  default = true
+}
+
+resource "cloudflare_tunnel" "backup" {
+  count = var.enable_backup_tunnel ? 1 : 0
+
+  account_id = var.cloudflare_account_id
+  name = "${local.name_prefix}-backup-tunnel"
+  secret     = base64encode("backup-tunnel-secret-32-bytes-long")
+  config_src = "cloudflare"
+}
+
+# Pattern 7: Cross-resource references
+resource "cloudflare_tunnel" "primary" {
+  account_id = var.cloudflare_account_id
+  name = "${local.name_prefix}-primary-tunnel"
+  secret     = base64encode("primary-tunnel-secret-32-bytes-long")
+  config_src = "local"
+}
+
+# Tunnel that references another tunnel in its name
+resource "cloudflare_tunnel" "secondary" {
+  account_id = var.cloudflare_account_id
+  name       = "${cloudflare_tunnel.primary.name}-secondary"
+  secret     = base64encode("secondary-tunnel-secret-32-bytes-ok")
+  config_src = "cloudflare"
+}
+
+# Pattern 8: Resource with lifecycle meta-arguments
+resource "cloudflare_tunnel" "protected" {
+  account_id = var.cloudflare_account_id
+  name = "${local.name_prefix}-protected-tunnel"
+  secret     = base64encode("protected-tunnel-secret-32-bytes-ok")
+  config_src = "local"
+
+  lifecycle {
+    prevent_destroy       = false
+    create_before_destroy = true
+  }
+}
+
+# Pattern 9: Using terraform expressions
+variable "use_cloudflare_config" {
+  type    = bool
+  default = false
+}
+
+resource "cloudflare_tunnel" "conditional_config" {
+  account_id = var.cloudflare_account_id
+  name = "${local.name_prefix}-conditional-config-tunnel"
+  secret     = base64encode("conditional-secret-32-bytes-or-more")
+  config_src = var.use_cloudflare_config ? "cloudflare" : "local"
+}
+
+# Pattern 10: Tunnel with base64encode function
+resource "cloudflare_tunnel" "encoded" {
+  account_id = var.cloudflare_account_id
+  name = "${local.name_prefix}-encoded-tunnel"
+  secret     = base64encode("this-secret-is-base64-encoded-32b")
+  config_src = "local"
+}
+
+# Pattern 11: Tunnel using string interpolation
+resource "cloudflare_tunnel" "interpolated" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-${var.tunnel_prefix}-interpolated-${local.tunnel_suffix}"
+  secret     = base64encode("interpolated-secret-32-bytes-or-more")
+  config_src = "local"
+}
+
+# Pattern 12: Complex expression for config_src
+variable "is_production" {
+  type    = bool
+  default = true
+}
+
+resource "cloudflare_tunnel" "complex_config" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-${var.is_production ? "prod" : "dev"}-complex-tunnel"
+  secret     = base64encode("complex-tunnel-secret-32-bytes-long")
+  config_src = var.is_production ? "cloudflare" : "local"
+}

--- a/integration/v4_to_v5/testdata/zero_trust_tunnel_cloudflared/input/zero_trust_tunnel_cloudflared_preferred_name.tf
+++ b/integration/v4_to_v5/testdata/zero_trust_tunnel_cloudflared/input/zero_trust_tunnel_cloudflared_preferred_name.tf
@@ -1,0 +1,28 @@
+# Cross-file .secret reference rewriting test.
+#
+# Tunnels defined here use the preferred v4 type name
+# (cloudflare_zero_trust_tunnel_cloudflared) rather than the deprecated
+# cloudflare_tunnel name.  The companion file
+# zero_trust_tunnel_cloudflared_secret_refs.tf contains non-Cloudflare
+# resources that reference the computed `secret` attribute of these tunnels.
+#
+# After migration:
+#   - `secret` is renamed to `tunnel_secret` in each resource body
+#   - `config_src = "local"` is added where absent
+#   - No type rename and no moved block (type is already correct)
+#   - Cross-file `.secret` references in the consumer file are also rewritten
+
+# Test case 1 (the bug): resource already using the preferred v4 / v5 type name
+resource "cloudflare_zero_trust_tunnel_cloudflared" "preferred_a" {
+  account_id = var.cloudflare_account_id
+  name       = "cftftest-preferred-a-tunnel"
+  secret     = base64encode("preferred-a-tunnel-secret-32-bytes-ok")
+}
+
+# Second preferred-name tunnel to cover the coexistence case (test case 3)
+resource "cloudflare_zero_trust_tunnel_cloudflared" "preferred_b" {
+  account_id = var.cloudflare_account_id
+  name       = "cftftest-preferred-b-tunnel"
+  secret     = base64encode("preferred-b-tunnel-secret-32-bytes-ok")
+  config_src = "cloudflare"
+}

--- a/integration/v4_to_v5/testdata/zero_trust_tunnel_cloudflared/input/zero_trust_tunnel_cloudflared_secret_refs.tf
+++ b/integration/v4_to_v5/testdata/zero_trust_tunnel_cloudflared/input/zero_trust_tunnel_cloudflared_secret_refs.tf
@@ -1,0 +1,39 @@
+# Consumer resources that reference the computed `secret` attribute of tunnel
+# resources across files.  Uses vault_generic_secret (a non-Cloudflare resource)
+# to simulate the real-world pattern described in the bug report.
+#
+# All `.secret` references below must be rewritten to `.tunnel_secret` by the
+# cross-file postprocessing pass regardless of which v4 type name was used for
+# the tunnel resource.
+
+# Test case 1 (the bug): reference to a tunnel that already uses the preferred
+# v4 name cloudflare_zero_trust_tunnel_cloudflared.
+# Before the fix this reference was NOT rewritten because
+# GetComputedAttributeMappings only listed cloudflare_tunnel as OldResourceType.
+resource "vault_generic_secret" "preferred_a_secret" {
+  path = "secret/tunnels/preferred-a"
+
+  data_json = jsonencode({
+    tunnel_secret = cloudflare_zero_trust_tunnel_cloudflared.preferred_a.secret
+  })
+}
+
+# Test case 2 (existing behaviour): reference to a tunnel using the deprecated
+# cloudflare_tunnel name — must still be rewritten correctly.
+resource "vault_generic_secret" "from_old_name_tunnel" {
+  path = "secret/tunnels/minimal"
+
+  data_json = jsonencode({
+    tunnel_secret = cloudflare_tunnel.minimal.secret
+  })
+}
+
+# Test case 3 (coexistence): both v4 type names referenced in the same file
+resource "vault_generic_secret" "combined" {
+  path = "secret/tunnels/combined"
+
+  data_json = jsonencode({
+    old_secret       = cloudflare_tunnel.minimal.secret
+    preferred_secret = cloudflare_zero_trust_tunnel_cloudflared.preferred_a.secret
+  })
+}

--- a/integration/v4_to_v5/testdata/zero_trust_tunnel_cloudflared/input/zero_trust_tunnel_cloudflared_tunnel_token_refs.tf
+++ b/integration/v4_to_v5/testdata/zero_trust_tunnel_cloudflared/input/zero_trust_tunnel_cloudflared_tunnel_token_refs.tf
@@ -1,0 +1,18 @@
+# Integration test for the tunnel_token DiagWarning (ticket 004).
+#
+# A reference to <tunnel_resource>.<name>.tunnel_token is NOT a valid v4 or v5
+# attribute. tf-migrate must NOT rewrite it (there is no safe replacement), and
+# must emit a DiagWarning with guidance.
+#
+# The expected output file for this fixture is identical to the input — the
+# tunnel_token reference is left unchanged and the warning appears in the
+# diagnostic output, not in the .tf file.
+
+resource "vault_generic_secret" "tunnel_token_ref" {
+  path = "secret/tunnels/token"
+
+  data_json = jsonencode({
+    # tunnel_token is not a valid attribute — tf-migrate should warn, not rewrite
+    token = cloudflare_zero_trust_tunnel_cloudflared.minimal.tunnel_token
+  })
+}

--- a/internal/resources/zero_trust_tunnel_cloudflared/v4_to_v5.go
+++ b/internal/resources/zero_trust_tunnel_cloudflared/v4_to_v5.go
@@ -43,14 +43,59 @@ func (m *V4ToV5Migrator) GetResourceRename() ([]string, string) {
 }
 
 // GetComputedAttributeMappings implements the ComputedAttributeMapper interface
-// This enables cross-file reference updates for computed attributes that change names
+// This enables cross-file reference updates for computed attributes that change names.
+//
+// Two entries are required because this resource has two v4 type names:
+//   - cloudflare_tunnel: the deprecated v4 name — also renamed by the resource-type rename pass
+//   - cloudflare_zero_trust_tunnel_cloudflared: the preferred v4 name — NOT renamed (type stays the
+//     same), so its cross-file .secret references must be caught here explicitly.
+//
+// Without the second entry, any file that already used the preferred v4 name and references
+// <resource>.<name>.secret will keep the stale attribute name after migration.
 func (m *V4ToV5Migrator) GetComputedAttributeMappings() []transform.ComputedAttributeMapping {
 	return []transform.ComputedAttributeMapping{
 		{
+			// Resources that were using the deprecated cloudflare_tunnel name.
 			OldResourceType: "cloudflare_tunnel",
 			OldAttribute:    "secret",
 			NewResourceType: "cloudflare_zero_trust_tunnel_cloudflared",
 			NewAttribute:    "tunnel_secret",
+		},
+		{
+			// Resources already using the preferred v4 / v5 type name.
+			// Their own `secret` attribute is renamed by TransformConfig, but cross-file
+			// references such as cloudflare_zero_trust_tunnel_cloudflared.<name>.secret
+			// in non-Cloudflare resources (e.g. vault_generic_secret) are only fixed here.
+			OldResourceType: "cloudflare_zero_trust_tunnel_cloudflared",
+			OldAttribute:    "secret",
+			NewResourceType: "cloudflare_zero_trust_tunnel_cloudflared",
+			NewAttribute:    "tunnel_secret",
+		},
+	}
+}
+
+// GetInvalidAttributeReferences implements the InvalidAttributeReferenceDetector
+// interface. It declares attributes that are not valid on
+// cloudflare_zero_trust_tunnel_cloudflared in v5 but may appear in cross-file
+// references left over from user configs written against either the v4 or v5
+// provider. The postprocessor will emit a DiagWarning for each match found.
+func (m *V4ToV5Migrator) GetInvalidAttributeReferences() []transform.InvalidAttributeReference {
+	guidance := `'tunnel_token' is not a valid computed output attribute of cloudflare_zero_trust_tunnel_cloudflared.
+
+  Valid computed attributes are:
+    - tunnel_secret  (was 'secret' in v4 — tf-migrate has already renamed it;
+                      update this reference to use tunnel_secret)
+    - cname
+    - id
+
+  If you meant to reference the tunnel's secret, use:
+    cloudflare_zero_trust_tunnel_cloudflared.<name>.tunnel_secret`
+
+	return []transform.InvalidAttributeReference{
+		{
+			ResourceType: "cloudflare_zero_trust_tunnel_cloudflared",
+			Attribute:    "tunnel_token",
+			Suggestion:   guidance,
 		},
 	}
 }

--- a/internal/resources/zero_trust_tunnel_cloudflared/v4_to_v5_test.go
+++ b/internal/resources/zero_trust_tunnel_cloudflared/v4_to_v5_test.go
@@ -4,10 +4,84 @@ import (
 	"testing"
 
 	"github.com/cloudflare/tf-migrate/internal/testhelpers"
+	"github.com/cloudflare/tf-migrate/internal/transform"
 )
 
 func TestV4ToV5Transformation(t *testing.T) {
 	migrator := NewV4ToV5Migrator()
+
+	// TestComputedAttributeMappings verifies that GetComputedAttributeMappings returns
+	// entries for BOTH v4 type names so cross-file .secret references are rewritten
+	// regardless of which name was used in the original config.
+	t.Run("ComputedAttributeMappings", func(t *testing.T) {
+		mapper, ok := migrator.(transform.ComputedAttributeMapper)
+		if !ok {
+			t.Fatal("migrator does not implement ComputedAttributeMapper")
+		}
+		mappings := mapper.GetComputedAttributeMappings()
+
+		byOldType := make(map[string]transform.ComputedAttributeMapping, len(mappings))
+		for _, m := range mappings {
+			byOldType[m.OldResourceType] = m
+		}
+
+		// Case 1: deprecated cloudflare_tunnel name (pre-existing behaviour)
+		old, ok := byOldType["cloudflare_tunnel"]
+		if !ok {
+			t.Errorf("missing mapping for OldResourceType=cloudflare_tunnel")
+		} else {
+			if old.OldAttribute != "secret" {
+				t.Errorf("cloudflare_tunnel mapping: want OldAttribute=secret, got %q", old.OldAttribute)
+			}
+			if old.NewResourceType != "cloudflare_zero_trust_tunnel_cloudflared" {
+				t.Errorf("cloudflare_tunnel mapping: want NewResourceType=cloudflare_zero_trust_tunnel_cloudflared, got %q", old.NewResourceType)
+			}
+			if old.NewAttribute != "tunnel_secret" {
+				t.Errorf("cloudflare_tunnel mapping: want NewAttribute=tunnel_secret, got %q", old.NewAttribute)
+			}
+		}
+
+		// Case 2: preferred v4 name cloudflare_zero_trust_tunnel_cloudflared (the bug fix from ticket 003)
+		preferred, ok := byOldType["cloudflare_zero_trust_tunnel_cloudflared"]
+		if !ok {
+			t.Errorf("missing mapping for OldResourceType=cloudflare_zero_trust_tunnel_cloudflared; " +
+				"cross-file .secret references on resources that already use the v5 type name will not be rewritten")
+		} else {
+			if preferred.OldAttribute != "secret" {
+				t.Errorf("cloudflare_zero_trust_tunnel_cloudflared mapping: want OldAttribute=secret, got %q", preferred.OldAttribute)
+			}
+			if preferred.NewResourceType != "cloudflare_zero_trust_tunnel_cloudflared" {
+				t.Errorf("cloudflare_zero_trust_tunnel_cloudflared mapping: want NewResourceType=cloudflare_zero_trust_tunnel_cloudflared, got %q", preferred.NewResourceType)
+			}
+			if preferred.NewAttribute != "tunnel_secret" {
+				t.Errorf("cloudflare_zero_trust_tunnel_cloudflared mapping: want NewAttribute=tunnel_secret, got %q", preferred.NewAttribute)
+			}
+		}
+	})
+
+	// TestInvalidAttributeReferences verifies that GetInvalidAttributeReferences
+	// declares tunnel_token as an invalid attribute with non-empty guidance.
+	t.Run("InvalidAttributeReferences", func(t *testing.T) {
+		detector, ok := migrator.(transform.InvalidAttributeReferenceDetector)
+		if !ok {
+			t.Fatal("migrator does not implement InvalidAttributeReferenceDetector")
+		}
+		refs := detector.GetInvalidAttributeReferences()
+
+		var found *transform.InvalidAttributeReference
+		for i := range refs {
+			if refs[i].ResourceType == "cloudflare_zero_trust_tunnel_cloudflared" && refs[i].Attribute == "tunnel_token" {
+				found = &refs[i]
+				break
+			}
+		}
+		if found == nil {
+			t.Fatalf("expected an InvalidAttributeReference for cloudflare_zero_trust_tunnel_cloudflared.tunnel_token, got %+v", refs)
+		}
+		if found.Suggestion == "" {
+			t.Error("tunnel_token InvalidAttributeReference has empty Suggestion — users need guidance")
+		}
+	})
 
 	t.Run("ConfigTransformation", func(t *testing.T) {
 		tests := []testhelpers.ConfigTestCase{

--- a/internal/resources/zero_trust_tunnel_cloudflared/v4_to_v5_test.go
+++ b/internal/resources/zero_trust_tunnel_cloudflared/v4_to_v5_test.go
@@ -20,6 +20,7 @@ func TestV4ToV5Transformation(t *testing.T) {
 		}
 		mappings := mapper.GetComputedAttributeMappings()
 
+		// Build a lookup by OldResourceType for easy assertions.
 		byOldType := make(map[string]transform.ComputedAttributeMapping, len(mappings))
 		for _, m := range mappings {
 			byOldType[m.OldResourceType] = m

--- a/internal/transform/transformer.go
+++ b/internal/transform/transformer.go
@@ -113,6 +113,27 @@ type ComputedAttributeMapper interface {
 	GetComputedAttributeMappings() []ComputedAttributeMapping
 }
 
+// InvalidAttributeReference describes a reference to an attribute that does not
+// exist (or is otherwise invalid) on the v5 resource type. When detected in
+// cross-file references during postprocessing, tf-migrate emits a DiagWarning
+// with the Suggestion text so the user knows how to fix it manually.
+type InvalidAttributeReference struct {
+	// ResourceType is the v5 resource type to scan for (e.g. "cloudflare_zero_trust_tunnel_cloudflared").
+	ResourceType string
+	// Attribute is the invalid attribute name (e.g. "tunnel_token").
+	Attribute string
+	// Suggestion is the human-readable guidance shown in the warning.
+	Suggestion string
+}
+
+// InvalidAttributeReferenceDetector is an optional interface that migrators can
+// implement to declare attributes that are invalid in the v5 schema but may
+// appear in cross-file references. The postprocessor scans all output files for
+// matching references and emits a DiagWarning for each one found.
+type InvalidAttributeReferenceDetector interface {
+	GetInvalidAttributeReferences() []InvalidAttributeReference
+}
+
 // MigrationProvider specifies the interface for a migrator provider
 // This is used to provide a way to get migrators for a given resource type
 // a migrator defines the strategy which a resource uses to migrate the resource


### PR DESCRIPTION
## Problems fixed

### 1. `.secret` cross-file references not rewritten for preferred v4 type name

When a tunnel resource was already written using the preferred v4 type name (`cloudflare_zero_trust_tunnel_cloudflared`) rather than the deprecated `cloudflare_tunnel`, cross-file references to its `secret` attribute were silently left unchanged after migration:

```hcl
# Never rewritten — causes terraform plan to fail with "Unsupported attribute"
tunnel_secret = cloudflare_zero_trust_tunnel_cloudflared.my_tunnel.secret
```

`GetComputedAttributeMappings` only listed `cloudflare_tunnel` as `OldResourceType`, so the postprocessor regex never matched references using the preferred name.

### 2. `.tunnel_token` references not surfaced to the user

Some users reference `<tunnel>.<name>.tunnel_token` in non-Cloudflare resources (e.g. `vault_generic_secret`). This attribute does not exist in v4 or v5. Before this fix, tf-migrate silently passed these through, leaving users with a `terraform plan` failure and no guidance:

```hcl
# Left unchanged, causes: Error: Unsupported attribute
token = cloudflare_zero_trust_tunnel_cloudflared.my_tunnel.tunnel_token
```

---

## Fixes

### Fix 1 — second `ComputedAttributeMapping` entry

```go
// Before: only matched cloudflare_tunnel.<name>.secret
// After: also matches cloudflare_zero_trust_tunnel_cloudflared.<name>.secret
{
    OldResourceType: "cloudflare_zero_trust_tunnel_cloudflared",
    OldAttribute:    "secret",
    NewResourceType: "cloudflare_zero_trust_tunnel_cloudflared",
    NewAttribute:    "tunnel_secret",
},
```

### Fix 2 — new `InvalidAttributeReferenceDetector` interface

Migrators implement `GetInvalidAttributeReferences()` to declare known-invalid attributes. The postprocessor scans all output files after rewrites and emits a `DiagWarning` for each match:

```
⚠ Unknown attribute reference: cloudflare_zero_trust_tunnel_cloudflared.my_tunnel.tunnel_token
  In consumers.tf

  'tunnel_token' is not a valid computed output attribute of cloudflare_zero_trust_tunnel_cloudflared.

  Valid computed attributes are:
    - tunnel_secret  (was 'secret' in v4 — tf-migrate has already renamed it;
                      update this reference to use tunnel_secret)
    - cname
    - id
```

The reference is intentionally **not rewritten** — there is no safe automatic replacement.

### Fix 3 — `_e2e.tf` gate file

Integration-only fixtures (`_tunnel_token_refs.tf`, `_secret_refs.tf`, `_preferred_name.tf`) use `vault_generic_secret` (requires Vault provider) and reference v5-only resource names, both of which break the v4 E2E apply step. A `zero_trust_tunnel_cloudflared_e2e.tf` file (exact copy of the original input) causes the E2E runner to sync only that file and ignore all other `*.tf` files in the input directory.

---

## Tests

**Unit — `TestV4ToV5Transformation/ComputedAttributeMappings`**: asserts both `cloudflare_tunnel` and `cloudflare_zero_trust_tunnel_cloudflared` entries are present with correct attribute mappings.

**Unit — `TestV4ToV5Transformation/InvalidAttributeReferences`**: asserts `GetInvalidAttributeReferences` returns a `tunnel_token` entry with non-empty suggestion text.

**Unit — `TestScanForInvalidAttributeReferences`**: four sub-cases covering detection, no false positives on valid attributes, multiple matches, and no match on a different resource type.

**Integration — `zero_trust_tunnel_cloudflared_preferred_name.tf`**: tunnels using the preferred v4 type name; verifies `secret` → `tunnel_secret` and `config_src` insertion with no type rename or moved block.

**Integration — `zero_trust_tunnel_cloudflared_secret_refs.tf`**: `vault_generic_secret` consumers referencing `.secret` on both v4 type names; verifies all cross-file references are rewritten regardless of which name was used.

**Integration — `zero_trust_tunnel_cloudflared_tunnel_token_refs.tf`**: `vault_generic_secret` with a `tunnel_token` reference; verifies the file is left unchanged (warning only, no rewrite).

---

```
========================================
✓ E2E Test Complete!
========================================

Summary:

  Step 1: v4 terraform apply
    Status: ✓ SUCCESS

  Step 2: Migration (v4 → v5)
    Status: ✓ SUCCESS

  Step 3: v5 plan (before apply)
    Status: ✓ No material changes
    Result: 0 material changes
    Terraform: Plan: 0 to add, 0 to change, 0 to destroy.

  Step 4: v5 terraform apply
    Status: ✓ SUCCESS

  Step 5: v5 plan (after apply)
    Status: ✓ SUCCESS - Stable state achieved
    Result: No changes detected
```