### PR TITLE
fix: multiple dynamic blocks of the same type

### DIFF
--- a/integration/v4_to_v5/testdata/zero_trust_local_fallback_domain/expected/zero_trust_local_fallback_domain_multi_dynamic.tf
+++ b/integration/v4_to_v5/testdata/zero_trust_local_fallback_domain/expected/zero_trust_local_fallback_domain_multi_dynamic.tf
@@ -1,0 +1,87 @@
+# Test migration of zero_trust_local_fallback_domain with MULTIPLE dynamic "domains" blocks.
+# Regression test for https://github.com/cloudflare/tf-migrate/issues/288
+#
+# Previously, only the last dynamic block survived (silent data loss).
+# After the fix, all dynamic blocks are merged via concat().
+
+variable "cloudflare_account_id" {
+  description = "Cloudflare account ID"
+  type        = string
+}
+
+
+
+
+# Pattern 1: Multiple dynamic "domains" blocks — custom profile (issue #288 exact scenario)
+resource "cloudflare_zero_trust_device_custom_profile_local_domain_fallback" "cftftest_multi_dynamic_custom" {
+  account_id = var.cloudflare_account_id
+  policy_id  = "multi-dynamic-policy-id"
+
+
+
+  domains = concat(
+    [for value in toset(["primary.corp", "primary.internal"]) : {
+      suffix = value
+    }],
+    [for value in toset(["static.corp"]) : {
+      suffix      = value
+      dns_server  = ["1.1.1.1"]
+      description = "Static domains resolved via regional DNS"
+    }],
+    [for value in toset(["dev.corp"]) : {
+      suffix      = value
+      dns_server  = ["1.1.1.1"]
+      description = "Dev domains resolved via regional DNS"
+    }],
+  )
+}
+
+moved {
+  from = cloudflare_fallback_domain.cftftest_multi_dynamic_custom
+  to   = cloudflare_zero_trust_device_custom_profile_local_domain_fallback.cftftest_multi_dynamic_custom
+}
+
+# Pattern 2: Multiple dynamic "domains" blocks — default profile
+resource "cloudflare_zero_trust_device_default_profile_local_domain_fallback" "cftftest_multi_dynamic_default" {
+  account_id = var.cloudflare_account_id
+
+
+  domains = concat(
+    [for value in toset(["intranet", "internal"]) : {
+      suffix = value
+    }],
+    [for value in toset(["vpn.corp"]) : {
+      suffix      = value
+      description = "VPN domains"
+    }],
+  )
+}
+
+moved {
+  from = cloudflare_zero_trust_local_fallback_domain.cftftest_multi_dynamic_default
+  to   = cloudflare_zero_trust_device_default_profile_local_domain_fallback.cftftest_multi_dynamic_default
+}
+
+# Pattern 3: Mixed static and dynamic "domains" blocks — default profile
+resource "cloudflare_zero_trust_device_default_profile_local_domain_fallback" "cftftest_mixed_static_dynamic" {
+  account_id = var.cloudflare_account_id
+
+
+
+  domains = concat(
+    [for value in toset(["dynamic.corp", "dynamic.internal"]) : {
+      suffix = value
+    }],
+    [{
+      suffix = "static-only.corp"
+      }, {
+      suffix      = "another-static.corp"
+      description = "Another static domain"
+    }],
+  )
+}
+
+moved {
+  from = cloudflare_zero_trust_local_fallback_domain.cftftest_mixed_static_dynamic
+  to   = cloudflare_zero_trust_device_default_profile_local_domain_fallback.cftftest_mixed_static_dynamic
+}

--- a/integration/v4_to_v5/testdata/zero_trust_local_fallback_domain/input/zero_trust_local_fallback_domain_multi_dynamic.tf
+++ b/integration/v4_to_v5/testdata/zero_trust_local_fallback_domain/input/zero_trust_local_fallback_domain_multi_dynamic.tf
@@ -1,0 +1,82 @@
+# Test migration of zero_trust_local_fallback_domain with MULTIPLE dynamic "domains" blocks.
+# Regression test for https://github.com/cloudflare/tf-migrate/issues/288
+#
+# Previously, only the last dynamic block survived (silent data loss).
+# After the fix, all dynamic blocks are merged via concat().
+
+variable "cloudflare_account_id" {
+  description = "Cloudflare account ID"
+  type        = string
+}
+
+# Pattern 1: Multiple dynamic "domains" blocks — custom profile (issue #288 exact scenario)
+resource "cloudflare_fallback_domain" "cftftest_multi_dynamic_custom" {
+  account_id = var.cloudflare_account_id
+  policy_id  = "multi-dynamic-policy-id"
+
+  dynamic "domains" {
+    for_each = toset(["primary.corp", "primary.internal"])
+    content {
+      suffix = domains.value
+    }
+  }
+
+  dynamic "domains" {
+    for_each = toset(["static.corp"])
+    content {
+      suffix      = domains.value
+      dns_server  = ["1.1.1.1"]
+      description = "Static domains resolved via regional DNS"
+    }
+  }
+
+  dynamic "domains" {
+    for_each = toset(["dev.corp"])
+    content {
+      suffix      = domains.value
+      dns_server  = ["1.1.1.1"]
+      description = "Dev domains resolved via regional DNS"
+    }
+  }
+}
+
+# Pattern 2: Multiple dynamic "domains" blocks — default profile
+resource "cloudflare_zero_trust_local_fallback_domain" "cftftest_multi_dynamic_default" {
+  account_id = var.cloudflare_account_id
+
+  dynamic "domains" {
+    for_each = toset(["intranet", "internal"])
+    content {
+      suffix = domains.value
+    }
+  }
+
+  dynamic "domains" {
+    for_each = toset(["vpn.corp"])
+    content {
+      suffix      = domains.value
+      description = "VPN domains"
+    }
+  }
+}
+
+# Pattern 3: Mixed static and dynamic "domains" blocks — default profile
+resource "cloudflare_zero_trust_local_fallback_domain" "cftftest_mixed_static_dynamic" {
+  account_id = var.cloudflare_account_id
+
+  domains {
+    suffix = "static-only.corp"
+  }
+
+  dynamic "domains" {
+    for_each = toset(["dynamic.corp", "dynamic.internal"])
+    content {
+      suffix = domains.value
+    }
+  }
+
+  domains {
+    suffix      = "another-static.corp"
+    description = "Another static domain"
+  }
+}

--- a/internal/resources/zero_trust_local_fallback_domain/v4_to_v5.go
+++ b/internal/resources/zero_trust_local_fallback_domain/v4_to_v5.go
@@ -205,11 +205,16 @@ func (m *V4ToV5Migrator) TransformConfig(ctx *transform.Context, block *hclwrite
 	//   dynamic "domains" { for_each = toset([...]) content { suffix = domains.value } }
 	// The v5 provider expects:
 	//   domains = [for value in toset([...]) : { suffix = value }]
+	//
+	// When multiple dynamic "domains" blocks exist, they are automatically merged
+	// via concat() by ConvertDynamicBlocksToForExpression.
+	dynamicDomainsCount := 0
 	for _, dynBlock := range tfhcl.FindBlocksByType(body, "dynamic") {
 		labels := dynBlock.Labels()
 		if len(labels) == 0 || labels[0] != "domains" {
 			continue
 		}
+		dynamicDomainsCount++
 		// Detect whether the for_each expression is opaque (not a literal).
 		// An opaque for_each references a variable or local that cannot be
 		// statically resolved — we still attempt conversion but warn the user.
@@ -233,10 +238,37 @@ Expected output:
 			}
 		}
 	}
+
+	if dynamicDomainsCount > 1 {
+		ctx.Diagnostics = append(ctx.Diagnostics, &hcl.Diagnostic{
+			Severity: hcl.DiagWarning,
+			Summary:  fmt.Sprintf("Multiple dynamic 'domains' blocks merged via concat(): %s.%s", newResourceType, resourceName),
+			Detail: fmt.Sprintf(`%d dynamic "domains" blocks were found and merged into a single attribute using concat().
+Please verify the generated output preserves all intended domain entries and ordering.`, dynamicDomainsCount),
+		})
+	}
+
 	tfhcl.ConvertDynamicBlocksToForExpression(body, "domains")
 
-	// Convert static domains blocks to attribute array
-	tfhcl.ConvertBlocksToAttributeList(body, "domains", nil)
+	// Convert static domains blocks to attribute array.
+	// If dynamic blocks already produced a "domains" attribute, we need to merge
+	// the static blocks into it via concat() rather than overwriting.
+	staticDomainsBlocks := tfhcl.FindBlocksByType(body, "domains")
+	hasDynamicDomains := dynamicDomainsCount > 0 && body.GetAttribute("domains") != nil
+
+	if hasDynamicDomains && len(staticDomainsBlocks) > 0 {
+		// Mixed case: merge dynamic for-expression(s) and static blocks via concat().
+		existingTokens := body.GetAttribute("domains").Expr().BuildTokens(nil)
+		tfhcl.MergeStaticBlocksIntoAttribute(body, "domains", existingTokens)
+
+		ctx.Diagnostics = append(ctx.Diagnostics, &hcl.Diagnostic{
+			Severity: hcl.DiagWarning,
+			Summary:  fmt.Sprintf("Mixed static and dynamic 'domains' blocks merged via concat(): %s.%s", newResourceType, resourceName),
+			Detail:   "Both static domains blocks and dynamic domains blocks were found. They have been merged into a single attribute using concat(). Please verify the generated output.",
+		})
+	} else {
+		tfhcl.ConvertBlocksToAttributeList(body, "domains", nil)
+	}
 
 	// Generate moved block
 	from := oldType + "." + resourceName
@@ -248,4 +280,3 @@ Expected output:
 		RemoveOriginal: true,
 	}, nil
 }
-

--- a/internal/resources/zero_trust_local_fallback_domain/v4_to_v5_test.go
+++ b/internal/resources/zero_trust_local_fallback_domain/v4_to_v5_test.go
@@ -529,10 +529,7 @@ resource "cloudflare_zero_trust_local_fallback_domain" "example" {
 }
 
 // TestMixedStaticAndDynamicDomains verifies that when both static domains blocks
-// and a dynamic "domains" block are present, the dynamic block is converted first
-// and the static blocks are converted afterwards.  Because both set the same
-// attribute name, the static array takes precedence (last write wins) and a
-// DiagWarning is emitted so the user knows about the mixed case.
+// and a dynamic "domains" block are present, both are preserved via concat().
 func TestMixedStaticAndDynamicDomains(t *testing.T) {
 	input := `
 resource "cloudflare_zero_trust_local_fallback_domain" "example" {
@@ -582,19 +579,239 @@ resource "cloudflare_zero_trust_local_fallback_domain" "example" {
 		}
 	}
 
-	// No diagnostics expected — toset is a literal, so no opaque warning.
-	if len(ctx.Diagnostics) != 0 {
-		t.Errorf("Expected 0 diagnostics for toset case, got %d: %v", len(ctx.Diagnostics), ctx.Diagnostics)
-	}
+	output := string(file.Bytes())
 
 	// The output should not contain any dynamic block.
-	output := string(file.Bytes())
 	if strings.Contains(output, `dynamic "domains"`) {
 		t.Error("Output still contains dynamic block — expected conversion")
 	}
-	// The output should contain a 'domains' attribute.
-	if !strings.Contains(output, "domains") {
-		t.Errorf("Expected 'domains' attribute in output, got:\n%s", output)
+
+	// Both static and dynamic content should be preserved via concat.
+	if !strings.Contains(output, "concat(") {
+		t.Errorf("Expected concat() to merge static and dynamic domains, got:\n%s", output)
+	}
+	if !strings.Contains(output, "static.example.com") {
+		t.Errorf("Expected static.example.com to be preserved in output, got:\n%s", output)
+	}
+	if !strings.Contains(output, "toset") {
+		t.Errorf("Expected toset for-expression to be preserved in output, got:\n%s", output)
+	}
+
+	// Should have a mixed-merge diagnostic warning.
+	foundMixedWarning := false
+	for _, d := range ctx.Diagnostics {
+		if strings.Contains(d.Summary, "Mixed static and dynamic") {
+			foundMixedWarning = true
+			break
+		}
+	}
+	if !foundMixedWarning {
+		t.Errorf("Expected a diagnostic warning about mixed static and dynamic domains, got: %v", ctx.Diagnostics)
+	}
+}
+
+// TestMultipleDynamicDomainsBlocks verifies that when multiple dynamic "domains"
+// blocks exist in a single resource, all of them are preserved via concat().
+// This is the regression test for https://github.com/cloudflare/tf-migrate/issues/288.
+func TestMultipleDynamicDomainsBlocks(t *testing.T) {
+	input := `
+resource "cloudflare_fallback_domain" "remote_region_profile_fallback_domains" {
+  account_id = var.account_id
+  policy_id  = cloudflare_zero_trust_device_custom_profile.remote_region_profile.id
+
+  dynamic "domains" {
+    for_each = local.primary_domain_fallback_entries
+    content {
+      suffix = domains.value
+    }
+  }
+
+  dynamic "domains" {
+    for_each = local.static_domain_fallback_entries
+    content {
+      suffix      = domains.value
+      dns_server  = ["1.1.1.1"]
+      description = "Static domains resolved via regional DNS"
+    }
+  }
+
+  dynamic "domains" {
+    for_each = local.dev_domain_fallback_entries
+    content {
+      suffix      = domains.value
+      dns_server  = ["1.1.1.1"]
+      description = "Dev domains resolved via regional DNS"
+    }
+  }
+}
+`
+
+	migrator := NewV4ToV5Migrator()
+
+	file, diags := hclwrite.ParseConfig([]byte(input), "test.tf", hcl.InitialPos)
+	if diags.HasErrors() {
+		t.Fatalf("Failed to parse input HCL: %v", diags)
+	}
+
+	ctx := &transform.Context{
+		Content:  []byte(input),
+		Filename: "test.tf",
+		CFGFile:  file,
+	}
+
+	body := file.Body()
+	for _, block := range body.Blocks() {
+		if block.Type() == "resource" && len(block.Labels()) >= 2 {
+			resourceType := block.Labels()[0]
+			if migrator.CanHandle(resourceType) {
+				result, err := migrator.TransformConfig(ctx, block)
+				if err != nil {
+					t.Fatalf("TransformConfig returned error: %v", err)
+				}
+				if result != nil && result.RemoveOriginal {
+					body.RemoveBlock(block)
+					for _, newBlock := range result.Blocks {
+						body.AppendBlock(newBlock)
+					}
+				}
+			}
+		}
+	}
+
+	output := string(file.Bytes())
+
+	// All dynamic blocks must be removed
+	if strings.Contains(output, `dynamic "domains"`) {
+		t.Error("Output still contains dynamic block — expected for-expression conversion")
+	}
+
+	// Must use concat() to merge all three dynamic blocks
+	if !strings.Contains(output, "concat(") {
+		t.Errorf("Expected concat() to merge multiple dynamic blocks, got:\n%s", output)
+	}
+
+	// All three for_each collections must be present — none silently dropped
+	for _, expr := range []string{
+		"local.primary_domain_fallback_entries",
+		"local.static_domain_fallback_entries",
+		"local.dev_domain_fallback_entries",
+	} {
+		if !strings.Contains(output, expr) {
+			t.Errorf("Expected %q in output (was silently dropped!), got:\n%s", expr, output)
+		}
+	}
+
+	// Verify resource was renamed to v5 custom type (has policy_id)
+	if !strings.Contains(output, "cloudflare_zero_trust_device_custom_profile_local_domain_fallback") {
+		t.Errorf("Expected v5 custom profile resource type in output, got:\n%s", output)
+	}
+
+	// Should have a diagnostic warning about multiple dynamic blocks
+	foundMultiBlockWarning := false
+	for _, d := range ctx.Diagnostics {
+		if strings.Contains(d.Summary, "Multiple dynamic") {
+			foundMultiBlockWarning = true
+			break
+		}
+	}
+	if !foundMultiBlockWarning {
+		t.Error("Expected a diagnostic warning about multiple dynamic 'domains' blocks being merged")
+	}
+}
+
+// TestMixedStaticAndDynamicDomainsMerge verifies that when both static domains
+// blocks and dynamic "domains" blocks are present, they are merged correctly
+// via concat() rather than the dynamic result being silently overwritten.
+func TestMixedStaticAndDynamicDomainsMerge(t *testing.T) {
+	input := `
+resource "cloudflare_zero_trust_local_fallback_domain" "example" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+
+  domains {
+    suffix = "static.example.com"
+  }
+
+  dynamic "domains" {
+    for_each = local.dynamic_entries
+    content {
+      suffix = domains.value
+    }
+  }
+
+  domains {
+    suffix      = "other.example.com"
+    description = "other static"
+  }
+}
+`
+
+	migrator := NewV4ToV5Migrator()
+
+	file, diags := hclwrite.ParseConfig([]byte(input), "test.tf", hcl.InitialPos)
+	if diags.HasErrors() {
+		t.Fatalf("Failed to parse input HCL: %v", diags)
+	}
+
+	ctx := &transform.Context{
+		Content:  []byte(input),
+		Filename: "test.tf",
+		CFGFile:  file,
+	}
+
+	body := file.Body()
+	for _, block := range body.Blocks() {
+		if block.Type() == "resource" && len(block.Labels()) >= 2 {
+			resourceType := block.Labels()[0]
+			if migrator.CanHandle(resourceType) {
+				result, err := migrator.TransformConfig(ctx, block)
+				if err != nil {
+					t.Fatalf("TransformConfig returned error: %v", err)
+				}
+				if result != nil && result.RemoveOriginal {
+					body.RemoveBlock(block)
+					for _, newBlock := range result.Blocks {
+						body.AppendBlock(newBlock)
+					}
+				}
+			}
+		}
+	}
+
+	output := string(file.Bytes())
+
+	// Must use concat to merge both static and dynamic
+	if !strings.Contains(output, "concat(") {
+		t.Errorf("Expected concat() to merge static and dynamic domains, got:\n%s", output)
+	}
+
+	// Dynamic for-expression must be present
+	if !strings.Contains(output, "local.dynamic_entries") {
+		t.Errorf("Expected dynamic for-expression in output, got:\n%s", output)
+	}
+
+	// Both static entries must be present
+	if !strings.Contains(output, "static.example.com") {
+		t.Errorf("Expected static.example.com in output, got:\n%s", output)
+	}
+	if !strings.Contains(output, "other.example.com") {
+		t.Errorf("Expected other.example.com in output, got:\n%s", output)
+	}
+
+	// No dynamic blocks should remain
+	if strings.Contains(output, `dynamic "domains"`) {
+		t.Error("Output still contains dynamic block")
+	}
+
+	// Should have a mixed-merge diagnostic
+	foundMixedWarning := false
+	for _, d := range ctx.Diagnostics {
+		if strings.Contains(d.Summary, "Mixed static and dynamic") {
+			foundMixedWarning = true
+			break
+		}
+	}
+	if !foundMixedWarning {
+		t.Error("Expected a diagnostic warning about mixed static and dynamic domains")
 	}
 }
 

--- a/internal/transform/hcl/blocks.go
+++ b/internal/transform/hcl/blocks.go
@@ -342,6 +342,44 @@ func ConvertBlocksToAttributeList(body *hclwrite.Body, blockType string, preProc
 	return true
 }
 
+// MergeStaticBlocksIntoAttribute merges static blocks of the given type with an
+// existing attribute expression (typically produced by ConvertDynamicBlocksToForExpression)
+// using concat(). The static blocks are converted to an inline array and the final
+// attribute becomes: concat(<existingExpr>, [<staticObj1>, <staticObj2>, ...])
+//
+// This handles the mixed static + dynamic domains case:
+//
+//	Before (after dynamic conversion):
+//	  domains = [for value in local.entries : { suffix = value }]
+//	  domains { suffix = "static.example.com" }
+//
+//	After:
+//	  domains = concat(
+//	    [for value in local.entries : { suffix = value }],
+//	    [{ suffix = "static.example.com" }],
+//	  )
+func MergeStaticBlocksIntoAttribute(body *hclwrite.Body, blockType string, existingExprTokens hclwrite.Tokens) {
+	blocks := FindBlocksByType(body, blockType)
+	if len(blocks) == 0 {
+		return
+	}
+
+	// Build static blocks as an array: [{ ... }, { ... }]
+	var objectTokens []hclwrite.Tokens
+	for _, block := range blocks {
+		objTokens := BuildObjectFromBlock(block)
+		objectTokens = append(objectTokens, objTokens)
+	}
+	staticArrayTokens := BuildArrayFromObjects(objectTokens)
+
+	// Wrap both in concat()
+	merged := buildConcatExpression([]hclwrite.Tokens{existingExprTokens, staticArrayTokens})
+	body.SetAttributeRaw(blockType, merged)
+
+	// Remove the static blocks
+	RemoveBlocksByType(body, blockType)
+}
+
 // CreateMovedBlock creates a moved block for resource migration
 // This is used when resources are renamed or restructured between provider versions
 func CreateMovedBlock(from, to string) *hclwrite.Block {
@@ -845,10 +883,13 @@ func copyMetaArguments(original, newBlock *hclwrite.Block, attributeRenames map[
 	}
 }
 
-// ConvertDynamicBlocksToForExpression converts dynamic blocks to for expressions
-// This handles the case where v4 used dynamic blocks and v5 uses array attributes with for expressions
+// ConvertDynamicBlocksToForExpression converts dynamic blocks to for expressions.
+// This handles the case where v4 used dynamic blocks and v5 uses array attributes with for expressions.
 //
-// Example:
+// When multiple dynamic blocks of the same type exist, they are merged using concat()
+// so that no data is silently lost.
+//
+// Example (single dynamic block):
 //
 // Before:
 //
@@ -866,9 +907,33 @@ func copyMetaArguments(original, newBlock *hclwrite.Block, attributeRenames map[
 //	  name    = value.name
 //	  address = value.address
 //	}]
+//
+// Example (multiple dynamic blocks):
+//
+// Before:
+//
+//	dynamic "domains" {
+//	  for_each = local.primary_entries
+//	  content { suffix = domains.value }
+//	}
+//	dynamic "domains" {
+//	  for_each = local.secondary_entries
+//	  content { suffix = domains.value }
+//	}
+//
+// After:
+//
+//	domains = concat(
+//	  [for value in local.primary_entries : { suffix = value }],
+//	  [for value in local.secondary_entries : { suffix = value }],
+//	)
 func ConvertDynamicBlocksToForExpression(body *hclwrite.Body, targetBlockType string) {
 	// Find all dynamic blocks
 	dynamicBlocks := FindBlocksByType(body, "dynamic")
+
+	// First pass: collect all matching dynamic blocks and build their for-expressions.
+	var forExprs []hclwrite.Tokens
+	var matchedBlocks []*hclwrite.Block
 
 	for _, dynamicBlock := range dynamicBlocks {
 		// Check if this dynamic block's label matches our target
@@ -877,97 +942,128 @@ func ConvertDynamicBlocksToForExpression(body *hclwrite.Body, targetBlockType st
 			continue
 		}
 
-		dynamicBody := dynamicBlock.Body()
-
-		// Get the for_each expression
-		forEachAttr := dynamicBody.GetAttribute("for_each")
-		if forEachAttr == nil {
+		forExprTokens := buildForExprFromDynamicBlock(dynamicBlock, targetBlockType)
+		if forExprTokens == nil {
 			continue
 		}
-		forEachTokens := forEachAttr.Expr().BuildTokens(nil)
 
-		// Get the iterator name (default is the block label)
-		iteratorName := targetBlockType
-		if iteratorAttr := dynamicBody.GetAttribute("iterator"); iteratorAttr != nil {
-			// Extract the iterator name from the attribute
-			iterTokens := iteratorAttr.Expr().BuildTokens(nil)
-			for _, token := range iterTokens {
-				if token.Type == hclsyntax.TokenIdent {
-					iteratorName = string(token.Bytes)
-					break
-				}
+		forExprs = append(forExprs, forExprTokens)
+		matchedBlocks = append(matchedBlocks, dynamicBlock)
+	}
+
+	if len(forExprs) == 0 {
+		return
+	}
+
+	// Second pass: set the attribute and remove the original blocks.
+	if len(forExprs) == 1 {
+		// Single dynamic block — set directly (preserves existing behavior).
+		body.SetAttributeRaw(targetBlockType, forExprs[0])
+	} else {
+		// Multiple dynamic blocks — wrap in concat() so nothing is lost.
+		body.SetAttributeRaw(targetBlockType, buildConcatExpression(forExprs))
+	}
+
+	for _, block := range matchedBlocks {
+		body.RemoveBlock(block)
+	}
+}
+
+// buildForExprFromDynamicBlock converts a single dynamic block into a for-expression
+// token sequence, e.g. [for value in <expr> : { ... }]. Returns nil if the block
+// is missing required elements (for_each, content).
+func buildForExprFromDynamicBlock(dynamicBlock *hclwrite.Block, targetBlockType string) hclwrite.Tokens {
+	dynamicBody := dynamicBlock.Body()
+
+	// Get the for_each expression
+	forEachAttr := dynamicBody.GetAttribute("for_each")
+	if forEachAttr == nil {
+		return nil
+	}
+	forEachTokens := forEachAttr.Expr().BuildTokens(nil)
+
+	// Get the iterator name (default is the block label)
+	iteratorName := targetBlockType
+	if iteratorAttr := dynamicBody.GetAttribute("iterator"); iteratorAttr != nil {
+		iterTokens := iteratorAttr.Expr().BuildTokens(nil)
+		for _, token := range iterTokens {
+			if token.Type == hclsyntax.TokenIdent {
+				iteratorName = string(token.Bytes)
+				break
 			}
 		}
-
-		// Find the content block
-		contentBlock := FindBlockByType(dynamicBody, "content")
-		if contentBlock == nil {
-			continue
-		}
-
-		// Before building the object, convert any nested blocks to attributes
-		contentBody := contentBlock.Body()
-
-		// Convert nested blocks to attributes (e.g., header block -> header attribute)
-		for _, nestedBlock := range contentBody.Blocks() {
-			nestedBlockType := nestedBlock.Type()
-			objTokens := BuildObjectFromBlock(nestedBlock)
-			contentBody.SetAttributeRaw(nestedBlockType, objTokens)
-			contentBody.RemoveBlock(nestedBlock)
-		}
-
-		// Build the for expression
-		var forExprTokens hclwrite.Tokens
-
-		// Opening bracket
-		forExprTokens = append(forExprTokens, &hclwrite.Token{
-			Type:  hclsyntax.TokenOBrack,
-			Bytes: []byte("["),
-		})
-
-		// "for value in"
-		forExprTokens = append(forExprTokens, &hclwrite.Token{
-			Type:  hclsyntax.TokenIdent,
-			Bytes: []byte("for"),
-		})
-		forExprTokens = append(forExprTokens, &hclwrite.Token{
-			Type:  hclsyntax.TokenIdent,
-			Bytes: []byte("value"),
-		})
-		forExprTokens = append(forExprTokens, &hclwrite.Token{
-			Type:  hclsyntax.TokenIdent,
-			Bytes: []byte("in"),
-		})
-
-		// Add the for_each expression
-		forExprTokens = append(forExprTokens, forEachTokens...)
-
-		// Add colon
-		forExprTokens = append(forExprTokens, &hclwrite.Token{
-			Type:  hclsyntax.TokenColon,
-			Bytes: []byte(":"),
-		})
-
-		// Build the object from content block
-		objTokens := BuildObjectFromBlock(contentBlock)
-
-		// Replace iterator references (e.g., origins.value -> value)
-		objTokens = replaceIteratorReferences(objTokens, iteratorName)
-
-		forExprTokens = append(forExprTokens, objTokens...)
-
-		// Closing bracket
-		forExprTokens = append(forExprTokens, &hclwrite.Token{
-			Type:  hclsyntax.TokenCBrack,
-			Bytes: []byte("]"),
-		})
-
-		// Set the attribute with the for expression
-		body.SetAttributeRaw(targetBlockType, forExprTokens)
-
-		// Remove the dynamic block
-		body.RemoveBlock(dynamicBlock)
 	}
+
+	// Find the content block
+	contentBlock := FindBlockByType(dynamicBody, "content")
+	if contentBlock == nil {
+		return nil
+	}
+
+	// Before building the object, convert any nested blocks to attributes
+	contentBody := contentBlock.Body()
+	for _, nestedBlock := range contentBody.Blocks() {
+		nestedBlockType := nestedBlock.Type()
+		objTokens := BuildObjectFromBlock(nestedBlock)
+		contentBody.SetAttributeRaw(nestedBlockType, objTokens)
+		contentBody.RemoveBlock(nestedBlock)
+	}
+
+	// Build the for expression: [for value in <expr> : { ... }]
+	var tokens hclwrite.Tokens
+
+	tokens = append(tokens, &hclwrite.Token{Type: hclsyntax.TokenOBrack, Bytes: []byte("[")})
+	tokens = append(tokens, &hclwrite.Token{Type: hclsyntax.TokenIdent, Bytes: []byte("for")})
+	tokens = append(tokens, &hclwrite.Token{Type: hclsyntax.TokenIdent, Bytes: []byte("value")})
+	tokens = append(tokens, &hclwrite.Token{Type: hclsyntax.TokenIdent, Bytes: []byte("in")})
+
+	tokens = append(tokens, forEachTokens...)
+
+	tokens = append(tokens, &hclwrite.Token{Type: hclsyntax.TokenColon, Bytes: []byte(":")})
+
+	objTokens := BuildObjectFromBlock(contentBlock)
+	objTokens = replaceIteratorReferences(objTokens, iteratorName)
+	tokens = append(tokens, objTokens...)
+
+	tokens = append(tokens, &hclwrite.Token{Type: hclsyntax.TokenCBrack, Bytes: []byte("]")})
+
+	return tokens
+}
+
+// buildConcatExpression wraps multiple token sequences in a concat(...) call.
+// Each element is placed on its own line for readability.
+//
+// Output shape:
+//
+//	concat(
+//	  <expr1>,
+//	  <expr2>,
+//	)
+func buildConcatExpression(exprs []hclwrite.Tokens) hclwrite.Tokens {
+	var tokens hclwrite.Tokens
+
+	// "concat("
+	tokens = append(tokens, &hclwrite.Token{Type: hclsyntax.TokenIdent, Bytes: []byte("concat")})
+	tokens = append(tokens, &hclwrite.Token{Type: hclsyntax.TokenOParen, Bytes: []byte("(")})
+
+	for i, expr := range exprs {
+		// Newline before each element
+		tokens = append(tokens, &hclwrite.Token{Type: hclsyntax.TokenNewline, Bytes: []byte("\n")})
+		tokens = append(tokens, expr...)
+
+		// Trailing comma after every element (including last — valid HCL)
+		if i < len(exprs)-1 {
+			tokens = append(tokens, &hclwrite.Token{Type: hclsyntax.TokenComma, Bytes: []byte(",")})
+		} else {
+			tokens = append(tokens, &hclwrite.Token{Type: hclsyntax.TokenComma, Bytes: []byte(",")})
+		}
+	}
+
+	// Closing newline + paren
+	tokens = append(tokens, &hclwrite.Token{Type: hclsyntax.TokenNewline, Bytes: []byte("\n")})
+	tokens = append(tokens, &hclwrite.Token{Type: hclsyntax.TokenCParen, Bytes: []byte(")")})
+
+	return tokens
 }
 
 // replaceIteratorReferences replaces iterator references in tokens

--- a/internal/transform/hcl/blocks_test.go
+++ b/internal/transform/hcl/blocks_test.go
@@ -135,12 +135,12 @@ data "cloudflare_zone" "my_zone" {
 
 func TestConvertBlocksToAttribute(t *testing.T) {
 	tests := []struct {
-		name       string
-		input      string
-		blockType  string
-		attrName   string
-		preProcess func(*hclwrite.Block)
-		contains   string
+		name        string
+		input       string
+		blockType   string
+		attrName    string
+		preProcess  func(*hclwrite.Block)
+		contains    string
 		notContains string
 	}{
 		{
@@ -155,9 +155,9 @@ resource "cloudflare_dns_record" "caa" {
     tag   = "issue"
   }
 }`,
-			blockType: "data",
-			attrName:  "data",
-			contains:  "data =",
+			blockType:   "data",
+			attrName:    "data",
+			contains:    "data =",
 			notContains: "data {",
 		},
 		{
@@ -198,12 +198,12 @@ resource "cloudflare_dns_record" "caa" {
 
 func TestHoistAttributeFromBlock(t *testing.T) {
 	tests := []struct {
-		name     string
-		input    string
+		name      string
+		input     string
 		blockType string
-		attrName string
-		expected bool
-		contains string
+		attrName  string
+		expected  bool
+		contains  string
 	}{
 		{
 			name: "Hoist attribute from block",
@@ -610,12 +610,12 @@ resource "test" "example" {
 
 func TestCreateDerivedBlock(t *testing.T) {
 	tests := []struct {
-		name      string
-		input     string
-		newType   string
-		newName   string
-		transform AttributeTransform
-		contains  []string
+		name        string
+		input       string
+		newType     string
+		newName     string
+		transform   AttributeTransform
+		contains    []string
 		notContains []string
 	}{
 		{
@@ -751,10 +751,10 @@ resource "test" "example" {
 			transform: AttributeTransform{
 				Copy: []string{"zone_id"},
 				Set: map[string]interface{}{
-					"string_val":  "test",
-					"int_val":     42,
-					"float_val":   3.14,
-					"bool_val":    true,
+					"string_val": "test",
+					"int_val":    42,
+					"float_val":  3.14,
+					"bool_val":   true,
 				},
 			},
 			contains: []string{
@@ -878,17 +878,17 @@ resource "cloudflare_argo" "main" {
 
 func TestApplyAttributeRenamesInLifecycle(t *testing.T) {
 	tests := []struct {
-		name     string
-		input    string
-		renames  map[string]string
-		contains []string
+		name        string
+		input       string
+		renames     map[string]string
+		contains    []string
 		notContains []string
 	}{
 		{
-			name:  "Rename single identifier in array",
-			input: `[smart_routing]`,
-			renames: map[string]string{"smart_routing": "value"},
-			contains: []string{"value"},
+			name:        "Rename single identifier in array",
+			input:       `[smart_routing]`,
+			renames:     map[string]string{"smart_routing": "value"},
+			contains:    []string{"value"},
 			notContains: []string{"smart_routing"},
 		},
 		{
@@ -898,20 +898,20 @@ func TestApplyAttributeRenamesInLifecycle(t *testing.T) {
 				"smart_routing":  "value",
 				"tiered_caching": "enabled",
 			},
-			contains: []string{"value", "enabled"},
+			contains:    []string{"value", "enabled"},
 			notContains: []string{"smart_routing", "tiered_caching"},
 		},
 		{
-			name:  "Only rename matching identifiers",
-			input: `[smart_routing, other_field]`,
-			renames: map[string]string{"smart_routing": "value"},
-			contains: []string{"value", "other_field"},
+			name:        "Only rename matching identifiers",
+			input:       `[smart_routing, other_field]`,
+			renames:     map[string]string{"smart_routing": "value"},
+			contains:    []string{"value", "other_field"},
 			notContains: []string{"smart_routing"},
 		},
 		{
-			name:  "Preserve non-identifier tokens",
-			input: `["string_value", 123, true]`,
-			renames: map[string]string{"string_value": "renamed"},
+			name:     "Preserve non-identifier tokens",
+			input:    `["string_value", 123, true]`,
+			renames:  map[string]string{"string_value": "renamed"},
 			contains: []string{`"string_value"`, "123", "true"},
 			// String literals are not renamed, only identifiers
 		},
@@ -1009,15 +1009,15 @@ resource "cloudflare_argo" "test" {
 			},
 			contains: []string{
 				"lifecycle",
-				"ignore_changes = [value]",  // tiered_caching filtered out (not in Copy or Rename)
+				"ignore_changes = [value]", // tiered_caching filtered out (not in Copy or Rename)
 			},
 			notContains: []string{
-				"smart_routing =",      // Check attribute assignment doesn't use old name
-				"[smart_routing",       // Check lifecycle arrays don't use old name
-				", smart_routing",      // Check lifecycle arrays don't use old name
-				"smart_routing,",       // Check lifecycle arrays don't use old name
-				"smart_routing]",       // Check lifecycle arrays don't use old name
-				"tiered_caching",       // Filtered out because not in valid attributes
+				"smart_routing =", // Check attribute assignment doesn't use old name
+				"[smart_routing",  // Check lifecycle arrays don't use old name
+				", smart_routing", // Check lifecycle arrays don't use old name
+				"smart_routing,",  // Check lifecycle arrays don't use old name
+				"smart_routing]",  // Check lifecycle arrays don't use old name
+				"tiered_caching",  // Filtered out because not in valid attributes
 			},
 		},
 		{
@@ -1069,11 +1069,11 @@ resource "cloudflare_argo" "test" {
 				"create_before_destroy = true",
 			},
 			notContains: []string{
-				"smart_routing =",      // Check attribute assignment doesn't use old name
-				"[smart_routing",       // Check lifecycle arrays don't use old name
-				", smart_routing",      // Check lifecycle arrays don't use old name
-				"smart_routing,",       // Check lifecycle arrays don't use old name
-				"smart_routing]",       // Check lifecycle arrays don't use old name
+				"smart_routing =", // Check attribute assignment doesn't use old name
+				"[smart_routing",  // Check lifecycle arrays don't use old name
+				", smart_routing", // Check lifecycle arrays don't use old name
+				"smart_routing,",  // Check lifecycle arrays don't use old name
+				"smart_routing]",  // Check lifecycle arrays don't use old name
 			},
 		},
 		{
@@ -1124,7 +1124,7 @@ resource "cloudflare_argo" "test" {
 			},
 			contains: []string{
 				"lifecycle",
-				"ignore_changes = [routing_value, caching_value]",  // other_field filtered out
+				"ignore_changes = [routing_value, caching_value]", // other_field filtered out
 			},
 			notContains: []string{
 				"smart_routing =",
@@ -1137,7 +1137,7 @@ resource "cloudflare_argo" "test" {
 				", tiered_caching",
 				"tiered_caching,",
 				"tiered_caching]",
-				"other_field",  // Filtered out because not in valid attributes
+				"other_field", // Filtered out because not in valid attributes
 			},
 		},
 	}
@@ -1469,5 +1469,167 @@ resource "original" "test" {
 				assert.NotContains(t, output, notContains, "Output should not contain: %s", notContains)
 			}
 		})
+	}
+}
+
+func TestConvertDynamicBlocksToForExpression_Single(t *testing.T) {
+	input := `
+resource "cloudflare_example" "test" {
+  account_id = "abc123"
+
+  dynamic "origins" {
+    for_each = local.origin_configs
+    content {
+      name    = origins.value.name
+      address = origins.value.address
+    }
+  }
+}
+`
+	file, diags := hclwrite.ParseConfig([]byte(input), "test.tf", hcl.InitialPos)
+	require.False(t, diags.HasErrors(), "parse error: %v", diags)
+
+	body := file.Body().Blocks()[0].Body()
+	ConvertDynamicBlocksToForExpression(body, "origins")
+
+	output := string(file.Bytes())
+	assert.NotContains(t, output, `dynamic "origins"`, "dynamic block should be removed")
+	assert.Contains(t, output, "for value in", "should contain for expression")
+	assert.Contains(t, output, "local.origin_configs", "should reference the for_each collection")
+	// Single block should NOT use concat
+	assert.NotContains(t, output, "concat", "single dynamic block should not use concat")
+}
+
+func TestConvertDynamicBlocksToForExpression_Multiple(t *testing.T) {
+	input := `
+resource "cloudflare_example" "test" {
+  account_id = "abc123"
+
+  dynamic "domains" {
+    for_each = local.primary_entries
+    content {
+      suffix = domains.value
+    }
+  }
+
+  dynamic "domains" {
+    for_each = local.secondary_entries
+    content {
+      suffix      = domains.value
+      description = "secondary"
+    }
+  }
+
+  dynamic "domains" {
+    for_each = local.dev_entries
+    content {
+      suffix     = domains.value
+      dns_server = "1.1.1.1"
+    }
+  }
+}
+`
+	file, diags := hclwrite.ParseConfig([]byte(input), "test.tf", hcl.InitialPos)
+	require.False(t, diags.HasErrors(), "parse error: %v", diags)
+
+	body := file.Body().Blocks()[0].Body()
+	ConvertDynamicBlocksToForExpression(body, "domains")
+
+	output := string(file.Bytes())
+
+	// All dynamic blocks should be removed
+	assert.NotContains(t, output, `dynamic "domains"`, "dynamic blocks should be removed")
+
+	// Should use concat to merge multiple for-expressions
+	assert.Contains(t, output, "concat(", "multiple dynamic blocks should be merged with concat()")
+
+	// All three for_each collections must be present
+	assert.Contains(t, output, "local.primary_entries", "should contain primary_entries")
+	assert.Contains(t, output, "local.secondary_entries", "should contain secondary_entries")
+	assert.Contains(t, output, "local.dev_entries", "should contain dev_entries")
+
+	// Each for-expression should be present
+	count := 0
+	for i := 0; i+len("for value in") <= len(output); i++ {
+		if output[i:i+len("for value in")] == "for value in" {
+			count++
+		}
+	}
+	assert.Equal(t, 3, count, "should contain exactly 3 for-expressions")
+}
+
+func TestConvertDynamicBlocksToForExpression_SkipsNonMatching(t *testing.T) {
+	input := `
+resource "cloudflare_example" "test" {
+  dynamic "origins" {
+    for_each = local.origin_configs
+    content {
+      name = origins.value.name
+    }
+  }
+
+  dynamic "headers" {
+    for_each = local.header_configs
+    content {
+      name = headers.value
+    }
+  }
+}
+`
+	file, diags := hclwrite.ParseConfig([]byte(input), "test.tf", hcl.InitialPos)
+	require.False(t, diags.HasErrors(), "parse error: %v", diags)
+
+	body := file.Body().Blocks()[0].Body()
+	ConvertDynamicBlocksToForExpression(body, "origins")
+
+	output := string(file.Bytes())
+
+	// origins dynamic block should be converted
+	assert.NotContains(t, output, `dynamic "origins"`, "origins dynamic block should be removed")
+	assert.Contains(t, output, "local.origin_configs", "should contain origins for-expression")
+
+	// headers dynamic block should remain untouched
+	assert.Contains(t, output, `dynamic "headers"`, "headers dynamic block should be preserved")
+}
+
+func TestMergeStaticBlocksIntoAttribute(t *testing.T) {
+	input := `
+resource "cloudflare_example" "test" {
+  account_id = "abc123"
+
+  domains = [for value in local.entries : { suffix = value }]
+
+  domains {
+    suffix = "static.example.com"
+  }
+
+  domains {
+    suffix      = "other.example.com"
+    description = "other"
+  }
+}
+`
+	file, diags := hclwrite.ParseConfig([]byte(input), "test.tf", hcl.InitialPos)
+	require.False(t, diags.HasErrors(), "parse error: %v", diags)
+
+	body := file.Body().Blocks()[0].Body()
+	existingTokens := body.GetAttribute("domains").Expr().BuildTokens(nil)
+	MergeStaticBlocksIntoAttribute(body, "domains", existingTokens)
+
+	output := string(file.Bytes())
+
+	// Should use concat to merge
+	assert.Contains(t, output, "concat(", "should merge with concat()")
+
+	// Dynamic for-expression should be preserved
+	assert.Contains(t, output, "for value in local.entries", "should preserve dynamic for-expression")
+
+	// Static values should be preserved
+	assert.Contains(t, output, "static.example.com", "should preserve static domains")
+	assert.Contains(t, output, "other.example.com", "should preserve other static domain")
+
+	// Static blocks should be removed (only resource block remains)
+	for _, block := range body.Blocks() {
+		assert.NotEqual(t, "domains", block.Type(), "static domains blocks should be removed")
 	}
 }


### PR DESCRIPTION
## Description

Fix silent data loss in ConvertDynamicBlocksToForExpression where multiple dynamic blocks of the same type within a single resource caused only the last block's for-expression to survive — all earlier ones were silently dropped. The fix accumulates all matching dynamic blocks and merges them via concat(). Also fixes the related case where mixed static + dynamic blocks of the same type would overwrite each other.

## Motivation

Fixes #288

Fixes #

## Type of change

- [ ] New resource transformer
- [x] Fix to an existing transformer
- [ ] CLI / framework change
- [ ] Documentation
- [ ] Test / CI
- [ ] Refactoring (no behaviour change)

## Testing

- [x] Unit tests (`make test-unit`)
- [x] Integration tests (`make test-integration`)
- [x] E2E tests (if applicable)
- [x] `make lint-testdata` passes

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] New resource transformers are registered in `internal/registry/registry.go`
- [x] Testdata resource names use the `cftftest` prefix
- [x] Any `# MIGRATION WARNING` comments are documented in `DIAGNOSTICS.md`
