### PR TITLE
fix(cli): preflight listing of resources

### DIFF
--- a/cmd/tf-migrate/preflight.go
+++ b/cmd/tf-migrate/preflight.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/hcl/v2/hclwrite"
 
 	"github.com/cloudflare/tf-migrate/internal/transform"
+	tfhcl "github.com/cloudflare/tf-migrate/internal/transform/hcl"
 )
 
 // resourceClassification describes how a resource will be handled during migration.
@@ -157,6 +158,11 @@ func classifyResource(block *hclwrite.Block, file string, providers transform.Mi
 
 	// Check if this resource will be renamed
 	if newType, ok := renames[resourceType]; ok {
+		// Conditional renames: some v4 types map to one of two v5 types
+		// depending on block attributes. Override the static rename target
+		// with the per-instance target based on attribute inspection.
+		newType = resolveConditionalRename(resourceType, newType, block)
+
 		return &scannedResource{
 			File:         file,
 			ResourceType: resourceType,
@@ -174,6 +180,51 @@ func classifyResource(block *hclwrite.Block, file string, providers transform.Mi
 		ResourceName: resourceName,
 		Class:        classAutoMigrated,
 	}
+}
+
+// resolveConditionalRename overrides the static rename target for resource types
+// where the v5 target depends on per-instance block attributes.
+//
+// Currently handles:
+//   - cloudflare_zero_trust_device_profiles / cloudflare_device_settings_policy:
+//     Routes to cloudflare_zero_trust_device_custom_profile when the block has
+//     match + precedence and is not explicitly default=true.
+//   - cloudflare_zero_trust_local_fallback_domain / cloudflare_fallback_domain:
+//     Routes to cloudflare_zero_trust_device_custom_profile_local_domain_fallback
+//     when the block has a non-empty policy_id.
+func resolveConditionalRename(resourceType, staticNewType string, block *hclwrite.Block) string {
+	body := block.Body()
+
+	switch resourceType {
+	case "cloudflare_zero_trust_device_profiles", "cloudflare_device_settings_policy":
+		// Mirror the routing logic from zero_trust_device_profiles TransformConfig:
+		// custom if !default && match && precedence, else default.
+		isExplicitDefault := false
+		if attr := body.GetAttribute("default"); attr != nil {
+			val, ok := tfhcl.ExtractBoolFromAttribute(attr)
+			if ok {
+				isExplicitDefault = val
+			}
+		}
+		hasMatch := body.GetAttribute("match") != nil
+		hasPrecedence := body.GetAttribute("precedence") != nil
+
+		if !isExplicitDefault && hasMatch && hasPrecedence {
+			return "cloudflare_zero_trust_device_custom_profile"
+		}
+
+	case "cloudflare_zero_trust_local_fallback_domain", "cloudflare_fallback_domain":
+		// Mirror the routing logic from zero_trust_local_fallback_domain TransformConfig:
+		// custom if policy_id is present and non-empty, else default.
+		if attr := body.GetAttribute("policy_id"); attr != nil {
+			val := tfhcl.ExtractStringFromAttribute(attr)
+			if val != "" || tfhcl.IsExpressionAttribute(attr) {
+				return "cloudflare_zero_trust_device_custom_profile_local_domain_fallback"
+			}
+		}
+	}
+
+	return staticNewType
 }
 
 // parseMovedBlock extracts from/to information from a moved block.

--- a/cmd/tf-migrate/preflight_test.go
+++ b/cmd/tf-migrate/preflight_test.go
@@ -381,6 +381,96 @@ func TestRunPreMigrationScan_EmptyDirectory(t *testing.T) {
 	}
 }
 
+// TestPreflightScan_ConditionalRenames verifies that the pre-migration scan
+// correctly distinguishes default vs custom device profiles and fallback domains.
+// Regression test for https://github.com/cloudflare/tf-migrate/issues/290.
+func TestPreflightScan_ConditionalRenames(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	content := `
+resource "cloudflare_zero_trust_device_profiles" "default_profile" {
+  account_id = "abc123"
+  default    = true
+}
+
+resource "cloudflare_zero_trust_device_profiles" "custom_profile" {
+  account_id = "abc123"
+  name       = "Custom"
+  match      = "identity.email == \"user@example.com\""
+  precedence = 100
+  default    = false
+}
+
+resource "cloudflare_zero_trust_device_profiles" "custom_implicit" {
+  account_id = "abc123"
+  name       = "Custom Implicit"
+  match      = "identity.email == \"other@example.com\""
+  precedence = 200
+}
+
+resource "cloudflare_fallback_domain" "default_fallback" {
+  account_id = "abc123"
+  domains {
+    suffix = "example.com"
+  }
+}
+
+resource "cloudflare_fallback_domain" "custom_fallback" {
+  account_id = "abc123"
+  policy_id  = cloudflare_zero_trust_device_profiles.custom_profile.id
+  domains {
+    suffix = "example.com"
+  }
+}
+`
+	if err := os.WriteFile(filepath.Join(tmpDir, "main.tf"), []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	log := hclog.NewNullLogger()
+	cfg := config{
+		configDir:     tmpDir,
+		sourceVersion: "v4",
+		targetVersion: "v5",
+	}
+
+	report, err := runPreMigrationScan(log, cfg)
+	if err != nil {
+		t.Fatalf("runPreMigrationScan error: %v", err)
+	}
+
+	// Build a map of resource name → NewType for renamed resources
+	renames := make(map[string]string)
+	for _, r := range report.Resources {
+		if r.Class == classRenamed {
+			renames[r.ResourceName] = r.NewType
+		}
+	}
+
+	tests := []struct {
+		name     string
+		expected string
+	}{
+		{"default_profile", "cloudflare_zero_trust_device_default_profile"},
+		{"custom_profile", "cloudflare_zero_trust_device_custom_profile"},
+		{"custom_implicit", "cloudflare_zero_trust_device_custom_profile"},
+		{"default_fallback", "cloudflare_zero_trust_device_default_profile_local_domain_fallback"},
+		{"custom_fallback", "cloudflare_zero_trust_device_custom_profile_local_domain_fallback"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := renames[tt.name]
+			if !ok {
+				t.Fatalf("Resource %q not found in rename results", tt.name)
+			}
+			if got != tt.expected {
+				t.Errorf("Resource %q: got NewType=%q, want %q", tt.name, got, tt.expected)
+			}
+		})
+	}
+}
+
 func contains(s, substr string) bool {
 	return len(s) >= len(substr) && searchString(s, substr)
 }


### PR DESCRIPTION
## Description

Fix the pre-migration scan rename summary to show the correct v5 target type for resources that conditionally route to one of two types based on block attributes.
Previously, GetResourceRename() returns a single static target per migrator. For cloudflare_zero_trust_device_profiles, this was always cloudflare_zero_trust_device_default_profile — even for resources with match + precedence + default = false that actually migrate to cloudflare_zero_trust_device_custom_profile. The same issue affected cloudflare_fallback_domain (default vs custom local domain fallback based on policy_id).
The fix adds resolveConditionalRename() in preflight.go which inspects block attributes to override the static rename target, mirroring the routing logic in each migrator's TransformConfig. No interface changes.
Affected resources:
- cloudflare_zero_trust_device_profiles / cloudflare_device_settings_policy
- cloudflare_zero_trust_local_fallback_domain / cloudflare_fallback_domain

## Motivation

The rename summary is the first thing users see, and for --dry-run it's often the only output. Showing "your 9 custom profiles → default profile" when the actual migration correctly produces custom profiles erodes trust in the tool and leads users to either avoid the tool or create manual workarounds.

Fixes #290 

Fixes #

## Type of change

- [ ] New resource transformer
- [ ] Fix to an existing transformer
- [x] CLI / framework change
- [ ] Documentation
- [ ] Test / CI
- [ ] Refactoring (no behaviour change)

## Testing

- [x] Unit tests (`make test-unit`)
- [ ] Integration tests (`make test-integration`)
- [ ] E2E tests (if applicable)
- [x] `make lint-testdata` passes

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] New resource transformers are registered in `internal/registry/registry.go`
- [x] Testdata resource names use the `cftftest` prefix
- [x] Any `# MIGRATION WARNING` comments are documented in `DIAGNOSTICS.md`
