### PR TITLE
chore(zero_trust_access_group): e2e test case

### DIFF
--- a/e2e-v5/testdata/zero_trust_access_group/zero_trust_access_group.tf
+++ b/e2e-v5/testdata/zero_trust_access_group/zero_trust_access_group.tf
@@ -470,6 +470,41 @@ resource "cloudflare_zero_trust_access_group" "child" {
 }
 
 
+# Pattern 23: Already-renamed v4 resource (exercises UpgradeState path, not MoveState)
+resource "cloudflare_zero_trust_access_group" "cftftest_upgrade_state_boolean" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix} UpgradeState Boolean Group"
+
+  include = [
+    {
+      any_valid_service_token = {}
+    },
+  ]
+}
+
+# Pattern 24: Already-renamed v4 resource with multiple selectors (UpgradeState path)
+resource "cloudflare_zero_trust_access_group" "cftftest_upgrade_state_mixed" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix} UpgradeState Mixed Group"
+
+
+  include = [
+    {
+      email = {
+        email = "admin@example.com"
+      }
+    },
+    {
+      everyone = {}
+    },
+  ]
+  exclude = [
+    {
+      certificate = {}
+    },
+  ]
+}
+
 variable "from_version" {
   description = "Provider version under test, used to namespace resource names"
   type        = string

--- a/integration/v4_to_v5/testdata/zero_trust_access_group/expected/zero_trust_access_group.tf
+++ b/integration/v4_to_v5/testdata/zero_trust_access_group/expected/zero_trust_access_group.tf
@@ -39,6 +39,45 @@ locals {
 
 
 
+# Pattern 23: Already-renamed v4 resource (exercises UpgradeState path, not MoveState)
+# When the v4 config already uses cloudflare_zero_trust_access_group (the newer v4 name),
+# tf-migrate does NOT generate a moved {} block. During v5 apply, Terraform triggers
+# UpgradeState (not MoveState) to migrate the v4 state. This is the exact scenario
+# that fails in APIX-741 when any_valid_service_token is a boolean in state.
+resource "cloudflare_zero_trust_access_group" "cftftest_upgrade_state_boolean" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix} UpgradeState Boolean Group"
+
+  include = [
+    {
+      any_valid_service_token = {}
+    },
+  ]
+}
+
+# Pattern 24: Already-renamed v4 resource with multiple selectors (UpgradeState path)
+resource "cloudflare_zero_trust_access_group" "cftftest_upgrade_state_mixed" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix} UpgradeState Mixed Group"
+
+
+  include = [
+    {
+      email = {
+        email = "admin@example.com"
+      }
+    },
+    {
+      everyone = {}
+    },
+  ]
+  exclude = [
+    {
+      certificate = {}
+    },
+  ]
+}
+
 # Pattern 1: Simple email selector
 resource "cloudflare_zero_trust_access_group" "simple_email" {
   account_id = var.cloudflare_account_id

--- a/integration/v4_to_v5/testdata/zero_trust_access_group/input/zero_trust_access_group.tf
+++ b/integration/v4_to_v5/testdata/zero_trust_access_group/input/zero_trust_access_group.tf
@@ -296,3 +296,32 @@ resource "cloudflare_access_group" "auth_context" {
     }
   }
 }
+
+# Pattern 23: Already-renamed v4 resource (exercises UpgradeState path, not MoveState)
+# When the v4 config already uses cloudflare_zero_trust_access_group (the newer v4 name),
+# tf-migrate does NOT generate a moved {} block. During v5 apply, Terraform triggers
+# UpgradeState (not MoveState) to migrate the v4 state. This is the exact scenario
+# that fails in APIX-741 when any_valid_service_token is a boolean in state.
+resource "cloudflare_zero_trust_access_group" "cftftest_upgrade_state_boolean" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix} UpgradeState Boolean Group"
+
+  include {
+    any_valid_service_token = true
+  }
+}
+
+# Pattern 24: Already-renamed v4 resource with multiple selectors (UpgradeState path)
+resource "cloudflare_zero_trust_access_group" "cftftest_upgrade_state_mixed" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix} UpgradeState Mixed Group"
+
+  include {
+    email    = ["admin@example.com"]
+    everyone = true
+  }
+
+  exclude {
+    certificate = true
+  }
+}


### PR DESCRIPTION
## Description

Adds test scenarios for zero trust access group

## Motivation

increase the test coverage for zero trust access group migration

Fixes #

## Type of change

- [ ] New resource transformer
- [ ] Fix to an existing transformer
- [ ] CLI / framework change
- [ ] Documentation
- [x] Test / CI
- [ ] Refactoring (no behaviour change)

## Testing

- [x] Unit tests (`make test-unit`)
- [x] Integration tests (`make test-integration`)
- [x] E2E tests (if applicable)
- [x] `make lint-testdata` passes

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] New resource transformers are registered in `internal/registry/registry.go`
- [x] Testdata resource names use the `cftftest` prefix
- [x] Any `# MIGRATION WARNING` comments are documented in `DIAGNOSTICS.md`
