### PR TITLE
chore(test): isolate test data

### DIFF
--- a/integration/v4_to_v5/testdata/zone/expected/zone_cross_refs.tf
+++ b/integration/v4_to_v5/testdata/zone/expected/zone_cross_refs.tf
@@ -9,29 +9,29 @@ locals {
 }
 
 # Pattern: Direct .zone reference in another resource
-resource "cloudflare_dns_record" "cftftest_zone_ref" {
+resource "cloudflare_dns_record" "cftftest_zone_xref" {
   zone_id = cloudflare_zone.minimal.id
-  name    = cloudflare_zone.minimal.name
-  type    = "CNAME"
-  content = "example.com"
+  name    = "cftftest-xref.${cloudflare_zone.minimal.name}"
+  type    = "TXT"
+  content = cloudflare_zone.minimal.name
   ttl     = 1
 }
 
 moved {
-  from = cloudflare_record.cftftest_zone_ref
-  to   = cloudflare_dns_record.cftftest_zone_ref
+  from = cloudflare_record.cftftest_zone_xref
+  to   = cloudflare_dns_record.cftftest_zone_xref
 }
 
 # Pattern: .zone reference in string interpolation
-resource "cloudflare_dns_record" "cftftest_zone_interpolation" {
+resource "cloudflare_dns_record" "cftftest_zone_xref_interp" {
   zone_id = cloudflare_zone.minimal.id
-  name    = "cftftest-sub.${cloudflare_zone.minimal.name}"
-  type    = "CNAME"
-  content = "example.com"
+  name    = "cftftest-xref-interp.${cloudflare_zone.minimal.name}"
+  type    = "TXT"
+  content = "zone=${cloudflare_zone.minimal.name}"
   ttl     = 1
 }
 
 moved {
-  from = cloudflare_record.cftftest_zone_interpolation
-  to   = cloudflare_dns_record.cftftest_zone_interpolation
+  from = cloudflare_record.cftftest_zone_xref_interp
+  to   = cloudflare_dns_record.cftftest_zone_xref_interp
 }

--- a/integration/v4_to_v5/testdata/zone/input/zone_cross_refs.tf
+++ b/integration/v4_to_v5/testdata/zone/input/zone_cross_refs.tf
@@ -2,19 +2,19 @@
 # These should be rewritten to .name after migration
 
 # Pattern: Direct .zone reference in another resource
-resource "cloudflare_record" "cftftest_zone_ref" {
+resource "cloudflare_record" "cftftest_zone_xref" {
   zone_id = cloudflare_zone.minimal.id
-  name    = cloudflare_zone.minimal.zone
-  type    = "CNAME"
-  content = "example.com"
+  name    = "cftftest-xref.${cloudflare_zone.minimal.zone}"
+  type    = "TXT"
+  content = cloudflare_zone.minimal.zone
 }
 
 # Pattern: .zone reference in string interpolation
-resource "cloudflare_record" "cftftest_zone_interpolation" {
+resource "cloudflare_record" "cftftest_zone_xref_interp" {
   zone_id = cloudflare_zone.minimal.id
-  name    = "cftftest-sub.${cloudflare_zone.minimal.zone}"
-  type    = "CNAME"
-  content = "example.com"
+  name    = "cftftest-xref-interp.${cloudflare_zone.minimal.zone}"
+  type    = "TXT"
+  content = "zone=${cloudflare_zone.minimal.zone}"
 }
 
 # Pattern: .zone reference in a local


### PR DESCRIPTION
## Description

Isolate zone cross-reference test data to avoid collisions with other test resources. Renames `cftftest_zone_ref` → `cftftest_zone_xref` and `cftftest_zone_interpolation` → `cftftest_zone_xref_interp`, and changes the record types from CNAME to TXT with unique names to prevent conflicts with existing dns_record test data.

## Motivation

The zone cross-reference test records (added in #295) used generic names and CNAME types that could collide with records from the dns_record test module during E2E runs. Using distinct `xref` prefixed names and TXT records avoids `already exists` errors when both modules are applied to the same zone.

Fixes #

## Type of change

- [ ] New resource transformer
- [ ] Fix to an existing transformer
- [ ] CLI / framework change
- [ ] Documentation
- [x] Test / CI
- [ ] Refactoring (no behaviour change)

## Testing

- [x] Unit tests (`make test-unit`)
- [x] Integration tests (`make test-integration`)
- [x] E2E tests (if applicable)
- [x] `make lint-testdata` passes

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] New resource transformers are registered in `internal/registry/registry.go`
- [x] Testdata resource names use the `cftftest` prefix
- [x] Any `# MIGRATION WARNING` comments are documented in `DIAGNOSTICS.md`
