### PR TITLE
Support OpenTofu Cloudflare lock-file provider

### DIFF
--- a/cmd/tf-migrate/version_check.go
+++ b/cmd/tf-migrate/version_check.go
@@ -90,12 +90,8 @@ func parseVersionFromLockFile(configDir string) (string, error) {
 			continue
 		}
 
-		// Check for registry.terraform.io/cloudflare/cloudflare
-		// or just cloudflare/cloudflare (older formats)
 		providerLabel := labels[0]
-		if providerLabel == "registry.terraform.io/cloudflare/cloudflare" ||
-			providerLabel == "cloudflare/cloudflare" {
-
+		if isCloudflareProviderAddress(providerLabel) {
 			versionAttr := block.Body().GetAttribute("version")
 			if versionAttr == nil {
 				continue
@@ -109,6 +105,17 @@ func parseVersionFromLockFile(configDir string) (string, error) {
 	}
 
 	return "", nil
+}
+
+func isCloudflareProviderAddress(providerLabel string) bool {
+	switch providerLabel {
+	case "registry.terraform.io/cloudflare/cloudflare",
+		"registry.opentofu.org/cloudflare/cloudflare",
+		"cloudflare/cloudflare":
+		return true
+	default:
+		return false
+	}
 }
 
 // parseVersionFromRequiredProviders scans all .tf files for the required_providers

--- a/cmd/tf-migrate/version_check_test.go
+++ b/cmd/tf-migrate/version_check_test.go
@@ -116,6 +116,27 @@ provider "registry.terraform.io/cloudflare/cloudflare" {
 		t.Errorf("Expected version 4.52.5, got %s", version)
 	}
 
+	// Test with OpenTofu registry lock file
+	tempDirOpenTofu := t.TempDir()
+	lockContentOpenTofu := `provider "registry.opentofu.org/cloudflare/cloudflare" {
+  version     = "4.52.7"
+  constraints = "~> 4.0"
+}
+`
+	lockFileOpenTofu := filepath.Join(tempDirOpenTofu, ".terraform.lock.hcl")
+	err = os.WriteFile(lockFileOpenTofu, []byte(lockContentOpenTofu), 0644)
+	if err != nil {
+		t.Fatalf("Failed to write lock file: %v", err)
+	}
+
+	version, err = parseVersionFromLockFile(tempDirOpenTofu)
+	if err != nil {
+		t.Fatalf("parseVersionFromLockFile failed: %v", err)
+	}
+	if version != "4.52.7" {
+		t.Errorf("Expected version 4.52.7, got %s", version)
+	}
+
 	// Test with lock file without cloudflare provider
 	lockContentNoCF := `# This file is maintained automatically by "terraform init".
 provider "registry.terraform.io/hashicorp/aws" {


### PR DESCRIPTION
Closes #299

Summary:
- accept OpenTofu lock-file provider addresses for the Cloudflare provider version check
- keep the existing Terraform Registry and shorthand provider-address handling
- add a regression test for `registry.opentofu.org/cloudflare/cloudflare`

Verification:
- `go test ./cmd/tf-migrate -run TestParseVersionFromLockFile -count=1`
- `go test ./cmd/tf-migrate -count=1`
- `go test ./...`
- `git diff --check`