### PR TITLE
fix: preserve native HCL bool for http_only_cookie_attribute during migration

### DIFF
--- a/e2e-v5/testdata/zero_trust_access_application/zero_trust_access_application.tf
+++ b/e2e-v5/testdata/zero_trust_access_application/zero_trust_access_application.tf
@@ -47,7 +47,7 @@ resource "cloudflare_zero_trust_access_application" "minimal" {
   name                       = "${local.name_prefix} Minimal App"
   domain                     = "${local.name_prefix}-minimal.${local.app_domain_suffix}"
   type                       = "self_hosted"
-  http_only_cookie_attribute = "false"
+  http_only_cookie_attribute = false
 }
 
 # 2. Minimal with type specification
@@ -56,7 +56,7 @@ resource "cloudflare_zero_trust_access_application" "minimal_self_hosted" {
   name                       = "${local.name_prefix} Self Hosted"
   domain                     = "${local.name_prefix}-self-hosted.${local.app_domain_suffix}"
   type                       = "self_hosted"
-  http_only_cookie_attribute = "false"
+  http_only_cookie_attribute = false
 }
 
 # 3. Maximal self-hosted app - all common fields
@@ -186,7 +186,7 @@ resource "cloudflare_zero_trust_access_application" "ssh_basic" {
   name                       = "${local.name_prefix} SSH Basic"
   type                       = "ssh"
   domain                     = "${local.name_prefix}-ssh-basic.${local.app_domain_suffix}"
-  http_only_cookie_attribute = "false"
+  http_only_cookie_attribute = false
 }
 
 # 10. SSH app (multi)
@@ -195,7 +195,7 @@ resource "cloudflare_zero_trust_access_application" "ssh_multi_criteria" {
   name                       = "${local.name_prefix} SSH Multi"
   type                       = "ssh"
   domain                     = "${local.name_prefix}-ssh-multi.${local.app_domain_suffix}"
-  http_only_cookie_attribute = "false"
+  http_only_cookie_attribute = false
 }
 
 # ============================================================================
@@ -297,7 +297,7 @@ resource "cloudflare_zero_trust_access_application" "with_self_hosted_domains" {
   name                       = "${local.name_prefix} Self Hosted Domains"
   type                       = "self_hosted"
   self_hosted_domains        = ["${local.name_prefix}-legacy1.${local.app_domain_suffix}", "${local.name_prefix}-legacy2.${local.app_domain_suffix}"]
-  http_only_cookie_attribute = "false"
+  http_only_cookie_attribute = false
 }
 
 # ============================================================================
@@ -311,7 +311,7 @@ resource "cloudflare_zero_trust_access_application" "with_domain_type" {
   name                       = "${local.name_prefix} Domain Type"
   domain                     = "${local.name_prefix}-domain-type.${local.app_domain_suffix}"
   type                       = "self_hosted"
-  http_only_cookie_attribute = "false"
+  http_only_cookie_attribute = false
 }
 
 # ============================================================================
@@ -326,7 +326,7 @@ resource "cloudflare_zero_trust_access_application" "with_count" {
   name                       = "${local.name_prefix} Count ${count.index}"
   domain                     = "${local.name_prefix}-count-${count.index}.${local.app_domain_suffix}"
   type                       = "self_hosted"
-  http_only_cookie_attribute = "false"
+  http_only_cookie_attribute = false
 }
 
 # ============================================================================
@@ -342,7 +342,7 @@ resource "cloudflare_zero_trust_access_application" "with_for_each" {
   domain                     = "${local.name_prefix}-${each.key}.${local.app_domain_suffix}"
   session_duration           = each.key == "prod" ? "8h" : "24h"
   type                       = "self_hosted"
-  http_only_cookie_attribute = "false"
+  http_only_cookie_attribute = false
 }
 
 # ============================================================================
@@ -357,7 +357,7 @@ resource "cloudflare_zero_trust_access_application" "complex_nested" {
   session_duration = "12h"
 
   type                       = "self_hosted"
-  http_only_cookie_attribute = "false"
+  http_only_cookie_attribute = false
   cors_headers = {
     allowed_methods   = ["GET", "POST"]
     allowed_origins   = ["*"]
@@ -372,7 +372,7 @@ resource "cloudflare_zero_trust_access_application" "with_var_refs" {
   name                       = "${local.name_prefix} Variable Refs"
   domain                     = "${local.name_prefix}-var-refs.${local.app_domain_suffix}"
   type                       = "self_hosted"
-  http_only_cookie_attribute = "false"
+  http_only_cookie_attribute = false
 }
 
 # ============================================================================
@@ -385,7 +385,7 @@ resource "cloudflare_zero_trust_access_application" "empty_policies" {
   name                       = "${local.name_prefix} Empty Policies"
   domain                     = "${local.name_prefix}-empty-policies.${local.app_domain_suffix}"
   type                       = "self_hosted"
-  http_only_cookie_attribute = "false"
+  http_only_cookie_attribute = false
 }
 
 # 26. App with only required fields and null optionals
@@ -394,7 +394,7 @@ resource "cloudflare_zero_trust_access_application" "sparse" {
   name                       = "${local.name_prefix} Sparse"
   domain                     = "${local.name_prefix}-sparse.${local.app_domain_suffix}"
   type                       = "self_hosted"
-  http_only_cookie_attribute = "false"
+  http_only_cookie_attribute = false
 }
 
 # 27. Conditional app
@@ -405,7 +405,7 @@ resource "cloudflare_zero_trust_access_application" "conditional" {
   name                       = "${local.name_prefix} Conditional"
   domain                     = "${local.name_prefix}-conditional.${local.app_domain_suffix}"
   type                       = "self_hosted"
-  http_only_cookie_attribute = "false"
+  http_only_cookie_attribute = false
 }
 
 # ============================================================================
@@ -419,7 +419,7 @@ resource "cloudflare_zero_trust_access_application" "special_chars" {
   domain                     = "${local.name_prefix}-special.${local.app_domain_suffix}"
   custom_deny_message        = "Access denied - contact support"
   type                       = "self_hosted"
-  http_only_cookie_attribute = "false"
+  http_only_cookie_attribute = false
 }
 
 # ============================================================================
@@ -437,7 +437,7 @@ resource "cloudflare_zero_trust_access_application" "resourcename_opt2" {
   name                       = "${local.name_prefix} Pattern9 Option2"
   domain                     = "${local.name_prefix}-pattern9-opt2.${local.app_domain_suffix}"
   type                       = "self_hosted"
-  http_only_cookie_attribute = "false"
+  http_only_cookie_attribute = false
 }
 
 # NOTE: cloudflare_access_policy with application_id CANNOT be migrated to v5.
@@ -449,7 +449,7 @@ resource "cloudflare_zero_trust_access_application" "resourcename_opt1" {
   name                       = "${local.name_prefix} Pattern9 Option1"
   domain                     = "${local.name_prefix}-pattern9-opt1.${local.app_domain_suffix}"
   type                       = "self_hosted"
-  http_only_cookie_attribute = "false"
+  http_only_cookie_attribute = false
 }
 
 

--- a/e2e-v5/testdata/zero_trust_access_service_token/zero_trust_access_service_token.tf
+++ b/e2e-v5/testdata/zero_trust_access_service_token/zero_trust_access_service_token.tf
@@ -252,7 +252,7 @@ resource "cloudflare_zero_trust_access_application" "ref_opt1" {
   type       = "self_hosted"
 
   depends_on                 = [cloudflare_zero_trust_access_service_token.resourcename_opt1]
-  http_only_cookie_attribute = "false"
+  http_only_cookie_attribute = false
 }
 
 # Dependent resource that references option 2 via depends_on
@@ -263,7 +263,7 @@ resource "cloudflare_zero_trust_access_application" "ref_opt2" {
   type       = "self_hosted"
 
   depends_on                 = [cloudflare_zero_trust_access_service_token.resourcename_opt2]
-  http_only_cookie_attribute = "false"
+  http_only_cookie_attribute = false
 }
 
 # Legacy resource name (cloudflare_access_service_token - deprecated)

--- a/integration/v4_to_v5/testdata/zero_trust_access_application/expected/zero_trust_access_application.tf
+++ b/integration/v4_to_v5/testdata/zero_trust_access_application/expected/zero_trust_access_application.tf
@@ -47,7 +47,7 @@ resource "cloudflare_zero_trust_access_application" "minimal" {
   name                       = "${local.name_prefix} Minimal App"
   domain                     = "minimal.${local.app_domain_suffix}"
   type                       = "self_hosted"
-  http_only_cookie_attribute = "false"
+  http_only_cookie_attribute = false
 }
 
 # 2. Minimal with type specification
@@ -56,7 +56,7 @@ resource "cloudflare_zero_trust_access_application" "minimal_self_hosted" {
   name                       = "${local.name_prefix} Self Hosted"
   domain                     = "self-hosted.${local.app_domain_suffix}"
   type                       = "self_hosted"
-  http_only_cookie_attribute = "false"
+  http_only_cookie_attribute = false
 }
 
 # 3. Maximal self-hosted app - all common fields
@@ -186,7 +186,7 @@ resource "cloudflare_zero_trust_access_application" "ssh_basic" {
   name                       = "${local.name_prefix} SSH Basic"
   type                       = "ssh"
   domain                     = "ssh-basic.${local.app_domain_suffix}"
-  http_only_cookie_attribute = "false"
+  http_only_cookie_attribute = false
 }
 
 # 10. SSH app (multi)
@@ -195,7 +195,7 @@ resource "cloudflare_zero_trust_access_application" "ssh_multi_criteria" {
   name                       = "${local.name_prefix} SSH Multi"
   type                       = "ssh"
   domain                     = "ssh-multi.${local.app_domain_suffix}"
-  http_only_cookie_attribute = "false"
+  http_only_cookie_attribute = false
 }
 
 # ============================================================================
@@ -297,7 +297,7 @@ resource "cloudflare_zero_trust_access_application" "with_self_hosted_domains" {
   name                       = "${local.name_prefix} Self Hosted Domains"
   type                       = "self_hosted"
   self_hosted_domains        = ["legacy1.${local.app_domain_suffix}", "legacy2.${local.app_domain_suffix}"]
-  http_only_cookie_attribute = "false"
+  http_only_cookie_attribute = false
 }
 
 # ============================================================================
@@ -311,7 +311,7 @@ resource "cloudflare_zero_trust_access_application" "with_domain_type" {
   name                       = "${local.name_prefix} Domain Type"
   domain                     = "domain-type.${local.app_domain_suffix}"
   type                       = "self_hosted"
-  http_only_cookie_attribute = "false"
+  http_only_cookie_attribute = false
 }
 
 # ============================================================================
@@ -326,7 +326,7 @@ resource "cloudflare_zero_trust_access_application" "with_count" {
   name                       = "${local.name_prefix} Count ${count.index}"
   domain                     = "count-${count.index}.${local.app_domain_suffix}"
   type                       = "self_hosted"
-  http_only_cookie_attribute = "false"
+  http_only_cookie_attribute = false
 }
 
 # ============================================================================
@@ -342,7 +342,7 @@ resource "cloudflare_zero_trust_access_application" "with_for_each" {
   domain                     = "${each.key}.${local.app_domain_suffix}"
   session_duration           = each.key == "prod" ? "8h" : "24h"
   type                       = "self_hosted"
-  http_only_cookie_attribute = "false"
+  http_only_cookie_attribute = false
 }
 
 # ============================================================================
@@ -357,7 +357,7 @@ resource "cloudflare_zero_trust_access_application" "complex_nested" {
   session_duration = "12h"
 
   type                       = "self_hosted"
-  http_only_cookie_attribute = "false"
+  http_only_cookie_attribute = false
   cors_headers = {
     allowed_methods   = ["GET", "POST"]
     allowed_origins   = ["*"]
@@ -372,7 +372,7 @@ resource "cloudflare_zero_trust_access_application" "with_var_refs" {
   name                       = "${local.name_prefix} Variable Refs"
   domain                     = "var-refs.${local.app_domain_suffix}"
   type                       = "self_hosted"
-  http_only_cookie_attribute = "false"
+  http_only_cookie_attribute = false
 }
 
 # ============================================================================
@@ -385,7 +385,7 @@ resource "cloudflare_zero_trust_access_application" "empty_policies" {
   name                       = "${local.name_prefix} Empty Policies"
   domain                     = "empty-policies.${local.app_domain_suffix}"
   type                       = "self_hosted"
-  http_only_cookie_attribute = "false"
+  http_only_cookie_attribute = false
 }
 
 # 26. App with only required fields and null optionals
@@ -394,7 +394,7 @@ resource "cloudflare_zero_trust_access_application" "sparse" {
   name                       = "${local.name_prefix} Sparse"
   domain                     = "sparse.${local.app_domain_suffix}"
   type                       = "self_hosted"
-  http_only_cookie_attribute = "false"
+  http_only_cookie_attribute = false
 }
 
 # 27. Conditional app
@@ -405,7 +405,7 @@ resource "cloudflare_zero_trust_access_application" "conditional" {
   name                       = "${local.name_prefix} Conditional"
   domain                     = "conditional.${local.app_domain_suffix}"
   type                       = "self_hosted"
-  http_only_cookie_attribute = "false"
+  http_only_cookie_attribute = false
 }
 
 # ============================================================================
@@ -419,7 +419,7 @@ resource "cloudflare_zero_trust_access_application" "special_chars" {
   domain                     = "special.${local.app_domain_suffix}"
   custom_deny_message        = "Access denied - contact support"
   type                       = "self_hosted"
-  http_only_cookie_attribute = "false"
+  http_only_cookie_attribute = false
 }
 
 # ============================================================================
@@ -437,7 +437,7 @@ resource "cloudflare_zero_trust_access_application" "resourcename_opt2" {
   name                       = "${local.name_prefix} Pattern9 Option2"
   domain                     = "pattern9-opt2.${local.app_domain_suffix}"
   type                       = "self_hosted"
-  http_only_cookie_attribute = "false"
+  http_only_cookie_attribute = false
 }
 
 # NOTE: cloudflare_access_policy with application_id CANNOT be migrated to v5.
@@ -452,7 +452,7 @@ resource "cloudflare_zero_trust_access_application" "self_hosted_with_saas_app" 
   name       = "${local.name_prefix} Self Hosted With SaaS App"
   type       = "self_hosted"
 
-  http_only_cookie_attribute = "false"
+  http_only_cookie_attribute = false
 }
 
 # Resource using v4 name option 1
@@ -461,7 +461,7 @@ resource "cloudflare_zero_trust_access_application" "resourcename_opt1" {
   name                       = "${local.name_prefix} Pattern9 Option1"
   domain                     = "pattern9-opt1.${local.app_domain_suffix}"
   type                       = "self_hosted"
-  http_only_cookie_attribute = "false"
+  http_only_cookie_attribute = false
 }
 
 moved {

--- a/integration/v4_to_v5/testdata/zero_trust_access_mtls_certificate/expected/zero_trust_access_mtls_certificate.tf
+++ b/integration/v4_to_v5/testdata/zero_trust_access_mtls_certificate/expected/zero_trust_access_mtls_certificate.tf
@@ -484,7 +484,7 @@ resource "cloudflare_zero_trust_access_application" "ref_opt1" {
   type       = "self_hosted"
 
   depends_on                 = [cloudflare_zero_trust_access_mtls_certificate.resourcename_opt1]
-  http_only_cookie_attribute = "false"
+  http_only_cookie_attribute = false
 }
 
 moved {
@@ -500,7 +500,7 @@ resource "cloudflare_zero_trust_access_application" "ref_opt2" {
   type       = "self_hosted"
 
   depends_on                 = [cloudflare_zero_trust_access_mtls_certificate.resourcename_opt2]
-  http_only_cookie_attribute = "false"
+  http_only_cookie_attribute = false
 }
 
 moved {

--- a/integration/v4_to_v5/testdata/zero_trust_access_policy/expected/zero_trust_access_policy.tf
+++ b/integration/v4_to_v5/testdata/zero_trust_access_policy/expected/zero_trust_access_policy.tf
@@ -76,7 +76,7 @@ resource "cloudflare_zero_trust_access_application" "test_app" {
   name                       = "${local.name_prefix}-test-app"
   domain                     = "test.${var.cloudflare_domain}"
   type                       = "self_hosted"
-  http_only_cookie_attribute = "false"
+  http_only_cookie_attribute = false
 }
 
 

--- a/integration/v4_to_v5/testdata/zero_trust_access_service_token/expected/zero_trust_access_service_token.tf
+++ b/integration/v4_to_v5/testdata/zero_trust_access_service_token/expected/zero_trust_access_service_token.tf
@@ -252,7 +252,7 @@ resource "cloudflare_zero_trust_access_application" "ref_opt1" {
   type       = "self_hosted"
 
   depends_on                 = [cloudflare_zero_trust_access_service_token.resourcename_opt1]
-  http_only_cookie_attribute = "false"
+  http_only_cookie_attribute = false
 }
 
 # Dependent resource that references option 2 via depends_on
@@ -263,7 +263,7 @@ resource "cloudflare_zero_trust_access_application" "ref_opt2" {
   type       = "self_hosted"
 
   depends_on                 = [cloudflare_zero_trust_access_service_token.resourcename_opt2]
-  http_only_cookie_attribute = "false"
+  http_only_cookie_attribute = false
 }
 
 # Legacy resource name (cloudflare_access_service_token - deprecated)

--- a/integration/v4_to_v5/testdata/zero_trust_organization/expected/zero_trust_organization.tf
+++ b/integration/v4_to_v5/testdata/zero_trust_organization/expected/zero_trust_organization.tf
@@ -576,7 +576,7 @@ resource "cloudflare_zero_trust_access_application" "ref_opt1" {
   type       = "self_hosted"
 
   depends_on                 = [cloudflare_zero_trust_organization.resourcename_opt1]
-  http_only_cookie_attribute = "false"
+  http_only_cookie_attribute = false
 }
 
 moved {
@@ -592,7 +592,7 @@ resource "cloudflare_zero_trust_access_application" "ref_opt2" {
   type       = "self_hosted"
 
   depends_on                 = [cloudflare_zero_trust_organization.resourcename_opt2]
-  http_only_cookie_attribute = "false"
+  http_only_cookie_attribute = false
 }
 
 moved {

--- a/internal/resources/zero_trust_access_application/v4_to_v5.go
+++ b/internal/resources/zero_trust_access_application/v4_to_v5.go
@@ -75,7 +75,7 @@ func (m *V4ToV5Migrator) TransformConfig(ctx *transform.Context, block *hclwrite
 	// Explicitly set to false to maintain v4 behavior when not specified
 	// Only applicable for types: self_hosted, ssh, vnc, rdp, mcp_portal
 	if appType == "self_hosted" || appType == "ssh" || appType == "vnc" || appType == "rdp" || appType == "mcp_portal" {
-		tfhcl.EnsureAttribute(body, "http_only_cookie_attribute", "false")
+		tfhcl.EnsureAttribute(body, "http_only_cookie_attribute", false)
 	}
 
 	// Strip type-gated attributes that are invalid for the application type

--- a/internal/resources/zero_trust_access_application/v4_to_v5_test.go
+++ b/internal/resources/zero_trust_access_application/v4_to_v5_test.go
@@ -41,7 +41,7 @@ func TestV4ToV5Transformation(t *testing.T) {
       precedence = 2
     }
   ]
-  http_only_cookie_attribute = "false"
+  http_only_cookie_attribute = false
 }`,
 			},
 			{
@@ -70,7 +70,7 @@ func TestV4ToV5Transformation(t *testing.T) {
       precedence = 2
     }
   ]
-  http_only_cookie_attribute = "false"
+  http_only_cookie_attribute = false
 }`,
 			},
 			{
@@ -107,7 +107,7 @@ func TestV4ToV5Transformation(t *testing.T) {
       precedence = 3
     }
   ]
-  http_only_cookie_attribute = "false"
+  http_only_cookie_attribute = false
 }`,
 			},
 			{
@@ -134,7 +134,7 @@ func TestV4ToV5Transformation(t *testing.T) {
       precedence = 1
     }
   ]
-  http_only_cookie_attribute = "false"
+  http_only_cookie_attribute = false
 }`,
 			},
 			{
@@ -151,7 +151,7 @@ func TestV4ToV5Transformation(t *testing.T) {
   name                       = "Test App"
   domain                     = "test.example.com"
   type                       = "self_hosted"
-  http_only_cookie_attribute = "false"
+  http_only_cookie_attribute = false
 }`,
 			},
 			{
@@ -174,7 +174,7 @@ func TestV4ToV5Transformation(t *testing.T) {
   session_duration = "24h"
 
   type                       = "self_hosted"
-  http_only_cookie_attribute = "false"
+  http_only_cookie_attribute = false
   cors_headers = {
     allow_all_origins = true
   }
@@ -193,7 +193,7 @@ func TestV4ToV5Transformation(t *testing.T) {
   name                       = "Test App"
   domain                     = "test.example.com"
   type                       = "self_hosted"
-  http_only_cookie_attribute = "false"
+  http_only_cookie_attribute = false
 }`,
 			},
 			{
@@ -288,7 +288,7 @@ func TestV4ToV5Transformation(t *testing.T) {
   name                       = "Test App"
   domain                     = "test.example.com"
   type                       = "self_hosted"
-  http_only_cookie_attribute = "false"
+  http_only_cookie_attribute = false
 }`,
 			},
 			{
@@ -424,7 +424,7 @@ func TestV4ToV5Transformation(t *testing.T) {
   domain                     = "test.example.com"
   type                       = "self_hosted"
   allowed_idps               = ["idp-1", "idp-2", "idp-3"]
-  http_only_cookie_attribute = "false"
+  http_only_cookie_attribute = false
 }`,
 			},
 			{
@@ -442,7 +442,7 @@ func TestV4ToV5Transformation(t *testing.T) {
   domain                     = "test.example.com"
   type                       = "self_hosted"
   allowed_idps               = ["idp-1", "idp-2"]
-  http_only_cookie_attribute = "false"
+  http_only_cookie_attribute = false
 }`,
 			},
 			{
@@ -460,7 +460,7 @@ func TestV4ToV5Transformation(t *testing.T) {
   domain                     = "test.example.com"
   type                       = "self_hosted"
   custom_pages               = ["page1", "page2"]
-  http_only_cookie_attribute = "false"
+  http_only_cookie_attribute = false
 }`,
 			},
 			{
@@ -478,7 +478,7 @@ func TestV4ToV5Transformation(t *testing.T) {
   domain                     = "test.example.com"
   type                       = "self_hosted"
   self_hosted_domains        = ["page1", "page2"]
-  http_only_cookie_attribute = "false"
+  http_only_cookie_attribute = false
 }`,
 			},
 			{
@@ -496,7 +496,7 @@ func TestV4ToV5Transformation(t *testing.T) {
   domain                     = "test.example.com"
   type                       = "self_hosted"
   policies                   = []
-  http_only_cookie_attribute = "false"
+  http_only_cookie_attribute = false
 }`,
 			},
 			{
@@ -635,7 +635,7 @@ func TestV4ToV5Transformation(t *testing.T) {
 				Expected: `resource "cloudflare_zero_trust_access_application" "rename" {
   account_id                 = "f037e56e89293a057740de681ac9abbe"
   type                       = "self_hosted"
-  http_only_cookie_attribute = "false"
+  http_only_cookie_attribute = false
 }
 moved {
   from = cloudflare_access_application.rename
@@ -650,7 +650,7 @@ moved {
 				Expected: `resource "cloudflare_zero_trust_access_application" "no_rename" {
   account_id                 = "f037e56e89293a057740de681ac9abbe"
   type                       = "self_hosted"
-  http_only_cookie_attribute = "false"
+  http_only_cookie_attribute = false
 }`,
 			},
 			{
@@ -727,7 +727,7 @@ moved {
   custom_pages               = ["1234", "5678"]
   self_hosted_domains        = ["1234", "5678"]
   tags                       = ["1234", "5678"]
-  http_only_cookie_attribute = "false"
+  http_only_cookie_attribute = false
 }`,
 			},
 			{
@@ -740,7 +740,7 @@ moved {
 				Expected: `resource "cloudflare_zero_trust_access_application" "remove_domain_type" {
   account_id                 = "1234"
   type                       = "self_hosted"
-  http_only_cookie_attribute = "false"
+  http_only_cookie_attribute = false
 }`,
 			},
 			{
@@ -762,7 +762,7 @@ moved {
 				Expected: `resource "cloudflare_zero_trust_access_application" "cors_headers" {
   account_id                 = "1234"
   type                       = "self_hosted"
-  http_only_cookie_attribute = "false"
+  http_only_cookie_attribute = false
   cors_headers = {
     allow_all_headers = true
     allow_all_methods = true
@@ -792,7 +792,7 @@ moved {
 				Expected: `resource "cloudflare_zero_trust_access_application" "single_destinations" {
   account_id                 = "1234"
   type                       = "self_hosted"
-  http_only_cookie_attribute = "false"
+  http_only_cookie_attribute = false
   destinations = [
     {
       cidr        = "10.5.0.0/24"
@@ -826,7 +826,7 @@ moved {
 				Expected: `resource "cloudflare_zero_trust_access_application" "multiple_destinations" {
   account_id                 = "1234"
   type                       = "self_hosted"
-  http_only_cookie_attribute = "false"
+  http_only_cookie_attribute = false
   destinations = [
     {
       type = "public"
@@ -888,7 +888,7 @@ moved {
 				Expected: `resource "cloudflare_zero_trust_access_application" "landing_page_design" {
   account_id                 = "1234"
   type                       = "self_hosted"
-  http_only_cookie_attribute = "false"
+  http_only_cookie_attribute = false
   landing_page_design = {
     button_color      = "#000000"
     button_text_color = "#000000"
@@ -1035,7 +1035,7 @@ moved {
       precedence = 2
     }
   ]
-  http_only_cookie_attribute = "false"
+  http_only_cookie_attribute = false
 }`,
 			},
 			// TODO scim_config
@@ -1158,7 +1158,7 @@ moved {
   type       = "ssh"
 
 
-  http_only_cookie_attribute = "false"
+  http_only_cookie_attribute = false
   target_criteria = [
     {
       port     = 22
@@ -1193,7 +1193,7 @@ moved {
   account_id = "1234"
   type       = "self_hosted"
 
-  http_only_cookie_attribute = "false"
+  http_only_cookie_attribute = false
   destinations = [
     {
       uri = "https://example.com"
@@ -1215,7 +1215,7 @@ moved {
   account_id = "1234"
   type       = "self_hosted"
 
-  http_only_cookie_attribute = "false"
+  http_only_cookie_attribute = false
   landing_page_design = {
     message = "Welcome to our app"
   }
@@ -1257,7 +1257,7 @@ moved {
   account_id = "1234"
   type       = "self_hosted"
 
-  http_only_cookie_attribute = "false"
+  http_only_cookie_attribute = false
   cors_headers = {
     allowed_methods = ["GET", "POST"]
     max_age         = 3600
@@ -1279,7 +1279,7 @@ moved {
   domain                     = "test.example.com"
   session_duration           = "12h"
   type                       = "self_hosted"
-  http_only_cookie_attribute = "false"
+  http_only_cookie_attribute = false
 }`,
 			},
 			{
@@ -1299,7 +1299,7 @@ moved {
   domain     = "test.example.com"
 
   type                       = "self_hosted"
-  http_only_cookie_attribute = "false"
+  http_only_cookie_attribute = false
   cors_headers = {
     allowed_methods = ["GET", "POST"]
   }
@@ -1320,7 +1320,7 @@ moved {
   domain                     = "test.example.com"
   type                       = "ssh"
   session_duration           = "8h"
-  http_only_cookie_attribute = "false"
+  http_only_cookie_attribute = false
 }`,
 			},
 			{
@@ -1335,7 +1335,7 @@ moved {
   name                       = "Test App"
   domain                     = "test.example.com"
   type                       = "self_hosted"
-  http_only_cookie_attribute = "false"
+  http_only_cookie_attribute = false
 }`,
 			},
 			{
@@ -1350,7 +1350,7 @@ moved {
   name                       = "Test App"
   self_hosted_domains        = ["app1.example.com", "app2.example.com"]
   type                       = "self_hosted"
-  http_only_cookie_attribute = "false"
+  http_only_cookie_attribute = false
 }`,
 			},
 			{
@@ -1363,7 +1363,7 @@ moved {
   account_id                 = "1234"
   name                       = "My Application"
   type                       = "self_hosted"
-  http_only_cookie_attribute = "false"
+  http_only_cookie_attribute = false
 }`,
 			},
 		}
@@ -1397,7 +1397,7 @@ moved {
       precedence = 1
     }
   ]
-  http_only_cookie_attribute = "false"
+  http_only_cookie_attribute = false
 }
 moved {
   from = cloudflare_access_application.apps
@@ -1432,7 +1432,7 @@ moved {
       precedence = 2
     }
   ]
-  http_only_cookie_attribute = "false"
+  http_only_cookie_attribute = false
 }
 moved {
   from = cloudflare_access_application.apps
@@ -1481,7 +1481,7 @@ moved {
   name                       = "Test App"
   domain                     = "test.example.com"
   type                       = "self_hosted"
-  http_only_cookie_attribute = "false"
+  http_only_cookie_attribute = false
 }
 moved {
   from = cloudflare_access_application.app
@@ -1503,7 +1503,7 @@ moved {
   custom_deny_message        = "Access denied: contact admin@example.com\nFor help: https://help.example.com"
   domain                     = "test.example.com"
   type                       = "self_hosted"
-  http_only_cookie_attribute = "false"
+  http_only_cookie_attribute = false
 }`,
 			},
 			{
@@ -1635,7 +1635,7 @@ func TestSaasAppStripping(t *testing.T) {
   account_id                 = "abc123"
   name                       = "Test App"
   type                       = "self_hosted"
-  http_only_cookie_attribute = "false"
+  http_only_cookie_attribute = false
 }`,
 		},
 		{
@@ -1655,7 +1655,7 @@ func TestSaasAppStripping(t *testing.T) {
   name                       = "SSH App"
   type                       = "ssh"
   domain                     = "ssh.example.com"
-  http_only_cookie_attribute = "false"
+  http_only_cookie_attribute = false
 }`,
 		},
 		{
@@ -1866,7 +1866,7 @@ func TestSaasAppStripping(t *testing.T) {
     allow_headers     = ["X-Custom-Header"]
     max_age           = 86400
   }
-  http_only_cookie_attribute = "false"
+  http_only_cookie_attribute = false
 }`,
 			Expected: `resource "cloudflare_zero_trust_access_application" "self_hosted_app" {
   account_id = "abc123"
@@ -1879,7 +1879,7 @@ func TestSaasAppStripping(t *testing.T) {
     allow_headers     = ["X-Custom-Header"]
     max_age           = 86400
   }
-  http_only_cookie_attribute = "false"
+  http_only_cookie_attribute = false
 }`,
 		},
 		{
@@ -1918,7 +1918,7 @@ func TestSaasAppStripping(t *testing.T) {
   landing_page_design = {
     title = "Wrong Place"
   }
-  http_only_cookie_attribute = "false"
+  http_only_cookie_attribute = false
 }`,
 			Expected: `resource "cloudflare_zero_trust_access_application" "self_hosted_app" {
   account_id = "abc123"
@@ -1926,7 +1926,7 @@ func TestSaasAppStripping(t *testing.T) {
   domain     = "app.example.com"
   type       = "self_hosted"
 
-  http_only_cookie_attribute = "false"
+  http_only_cookie_attribute = false
 }`,
 		},
 		{


### PR DESCRIPTION
## Summary

During v4 to v5 migration, `tf-migrate` converts `http_only_cookie_attribute` boolean values to quoted strings (`"false"` instead of `false`). The string `"false"` is truthy in HCL/Terraform, which silently inverts the intended boolean value.

## Root Cause

In `internal/resources/zero_trust_access_application/v4_to_v5.go:78`:

```go
// Before (bug): passes Go string "false"
tfhcl.EnsureAttribute(body, "http_only_cookie_attribute", "false")

// After (fix): passes Go bool false
tfhcl.EnsureAttribute(body, "http_only_cookie_attribute", false)
```

`TokensForSimpleValue` dispatches on Go type:
- `string` -> `cty.StringVal("false")` -> HCL `"false"` (quoted string, **truthy**)
- `bool` -> `cty.BoolVal(false)` -> HCL `false` (native keyword, **correct**)

## Impact

- Affects `cloudflare_zero_trust_access_application` resources where `http_only_cookie_attribute` was not explicitly set in the v4 config
- The v5 provider changed the default from `false` to `true`, so tf-migrate adds an explicit `false` to preserve v4 behavior -- but the quoted string form silently sets it to truthy
- Discovered via OPA compliance failure on `cloudflare_zero_trust_access_application.default_secure` during internal migration

## Fix

One-character change: remove quotes around `false` so Go dispatches to the `bool` type branch.

All unit tests (56), integration tests (87 resources), and e2e golden files updated.

## E2E Tests
```
========================================
✓ E2E Test Complete!
========================================

Summary:

  Step 1: v4 terraform apply
    Status: ✓ SUCCESS

  Step 2: Migration (v4 → v5)
    Status: ✓ SUCCESS

  Step 3: v5 plan (before apply)
    Status: ✓ No material changes
    Result: 0 material changes
    Terraform: Plan: 0 to add, 0 to change, 0 to destroy.

  Step 4: v5 terraform apply
    Status: ✓ SUCCESS

  Step 5: v5 plan (after apply)
    Status: ✓ SUCCESS - Stable state achieved
    Result: No changes detected
```