### PR TITLE
fix(access_policy): emit warning when zone_id removed without account_id

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @cloudflare/sdk

--- a/agents.md
+++ b/agents.md
@@ -753,6 +753,19 @@ make test-integration
 make lint-testdata
 ```
 
+**Step 7: Update the Terraform provider migration guides**
+
+When a migration emits a new `DiagWarning` (especially one requiring manual user
+action), the corresponding guidance must also be added to the Terraform provider's
+upgrade and migration docs:
+
+- `templates/guides/version-5-upgrade.md` — under the resource's `##` section
+- `templates/guides/version-5-migration.md` — under the relevant `####` subsection
+- Copy both templates to `docs/guides/` after editing
+
+These live in the `cloudflare/terraform-provider-cloudflare` repo. Open a
+separate PR there alongside the tf-migrate PR.
+
 ### Makefile Targets
 
 ```bash

--- a/integration/v4_to_v5/testdata/zero_trust_access_policy/expected/zero_trust_access_policy.tf
+++ b/integration/v4_to_v5/testdata/zero_trust_access_policy/expected/zero_trust_access_policy.tf
@@ -122,6 +122,8 @@ resource "cloudflare_zero_trust_access_policy" "bugs2006_everyone" {
 
 
 
+
+
 # Basic test cases
 resource "cloudflare_zero_trust_access_policy" "example" {
   account_id       = var.cloudflare_account_id
@@ -687,4 +689,33 @@ resource "cloudflare_zero_trust_access_policy" "bugs2007_auth_context" {
 moved {
   from = cloudflare_access_policy.bugs2007_auth_context
   to   = cloudflare_zero_trust_access_policy.bugs2007_auth_context
+}
+
+# zone_id-only policy (no account_id)
+# In v4, access policies could be zone-scoped. In v5, they are account-level only.
+# tf-migrate must remove zone_id and emit a warning that account_id is required.
+resource "cloudflare_zero_trust_access_policy" "zone_scoped_only" {
+  name     = "${local.name_prefix}-zone-scoped-policy"
+  decision = "allow"
+
+  include = [{ email = { email = "user@example.com" } }]
+}
+
+moved {
+  from = cloudflare_access_policy.zone_scoped_only
+  to   = cloudflare_zero_trust_access_policy.zone_scoped_only
+}
+
+# zone_id + account_id policy (zone_id removed, account_id kept, no warning)
+resource "cloudflare_zero_trust_access_policy" "zone_and_account" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-zone-and-account-policy"
+  decision   = "allow"
+
+  include = [{ everyone = {} }]
+}
+
+moved {
+  from = cloudflare_access_policy.zone_and_account
+  to   = cloudflare_zero_trust_access_policy.zone_and_account
 }

--- a/integration/v4_to_v5/testdata/zero_trust_access_policy/input/zero_trust_access_policy.tf
+++ b/integration/v4_to_v5/testdata/zero_trust_access_policy/input/zero_trust_access_policy.tf
@@ -578,3 +578,28 @@ resource "cloudflare_access_policy" "bugs2007_auth_context" {
     }
   }
 }
+
+# zone_id-only policy (no account_id)
+# In v4, access policies could be zone-scoped. In v5, they are account-level only.
+# tf-migrate must remove zone_id and emit a warning that account_id is required.
+resource "cloudflare_access_policy" "zone_scoped_only" {
+  zone_id  = var.cloudflare_zone_id
+  name     = "${local.name_prefix}-zone-scoped-policy"
+  decision = "allow"
+
+  include {
+    email = ["user@example.com"]
+  }
+}
+
+# zone_id + account_id policy (zone_id removed, account_id kept, no warning)
+resource "cloudflare_access_policy" "zone_and_account" {
+  account_id = var.cloudflare_account_id
+  zone_id    = var.cloudflare_zone_id
+  name       = "${local.name_prefix}-zone-and-account-policy"
+  decision   = "allow"
+
+  include {
+    everyone = true
+  }
+}

--- a/internal/resources/zero_trust_access_policy/README.md
+++ b/internal/resources/zero_trust_access_policy/README.md
@@ -9,7 +9,7 @@ This guide explains how `cloudflare_access_policy` resources migrate to `cloudfl
 | Resource name | `cloudflare_access_policy` | `cloudflare_zero_trust_access_policy` | Renamed |
 | `application_id` | Required | Removed | Moved to application |
 | `precedence` | Supported | Removed | Moved to application |
-| `zone_id` | Supported | Removed | Use on application |
+| `zone_id` | Supported | Removed | **Requires `account_id`** (see below) |
 | `session_duration` | Supported | Removed | Moved to application |
 | `include/exclude/require` | Blocks | Array attributes | Structure change |
 | Condition arrays | `email = ["a", "b"]` | Multiple condition objects | **EXPLOSION** |
@@ -18,6 +18,40 @@ This guide explains how `cloudflare_access_policy` resources migrate to `cloudfl
 | `approval_group` | Block | `approval_groups` array | Renamed + structure change |
 | `connection_rules` | Block | Attribute object | Syntax change |
 
+
+---
+
+## Zone-Scoped Policies Require `account_id`
+
+In v4, `cloudflare_access_policy` resources could be scoped to a zone using `zone_id`.
+In v5, **all access policies are account-level** and require `account_id` -- `zone_id` is
+not a valid attribute on `cloudflare_zero_trust_access_policy`.
+
+tf-migrate removes `zone_id` during migration. If the resource already has `account_id`,
+no action is needed. If the resource only had `zone_id` (no `account_id`), tf-migrate
+emits a **MIGRATION WARNING** and you must manually add `account_id`:
+
+```hcl
+# Before (v4 -- zone-scoped):
+resource "cloudflare_access_policy" "example" {
+  zone_id  = var.zone_id
+  name     = "My Policy"
+  decision = "allow"
+  # ...
+}
+
+# After tf-migrate (v5 -- account_id required, add manually):
+resource "cloudflare_zero_trust_access_policy" "example" {
+  account_id = var.cloudflare_account_id  # <-- YOU MUST ADD THIS
+  name       = "My Policy"
+  decision   = "allow"
+  # ...
+}
+```
+
+> **Note:** A zone ID is not the same as an account ID. tf-migrate cannot automatically
+> infer the correct account ID from a zone ID. Check your Cloudflare dashboard or use
+> `cloudflare_zone` data source to look up the owning account.
 
 ---
 

--- a/internal/resources/zero_trust_access_policy/v4_to_v5.go
+++ b/internal/resources/zero_trust_access_policy/v4_to_v5.go
@@ -110,7 +110,33 @@ func (m *V4ToV5Migrator) TransformConfig(ctx *transform.Context, block *hclwrite
 
 	// 2. Simple field operations
 	// Remove deprecated fields that are not valid in v5
-	tfhcl.RemoveAttributes(body, "application_id", "precedence", "zone_id")
+	tfhcl.RemoveAttributes(body, "application_id", "precedence")
+
+	// Handle zone_id -> account_id conversion.
+	// In v4, access policies could be scoped to a zone via zone_id.
+	// In v5, all access policies are account-level and require account_id.
+	// If the resource has zone_id but no account_id, emit a migration warning
+	// because the user must manually supply the correct account_id value.
+	hasZoneID := body.GetAttribute("zone_id") != nil
+	hasAccountID := body.GetAttribute("account_id") != nil
+	if hasZoneID {
+		tfhcl.RemoveAttributes(body, "zone_id")
+		if !hasAccountID {
+			ctx.Diagnostics = append(ctx.Diagnostics, &hcl.Diagnostic{
+				Severity: hcl.DiagWarning,
+				Summary:  "MIGRATION WARNING: zone_id removed, account_id required",
+				Detail: fmt.Sprintf(
+					"Resource %s.%s used zone_id in v4, but v5 access policies are account-level only "+
+						"and require account_id. The zone_id attribute has been removed.\n\n"+
+						"You must add the correct account_id to this resource. For example:\n\n"+
+						"  account_id = var.cloudflare_account_id\n\n"+
+						"Without account_id, terraform validate will fail with:\n"+
+						"  Error: Required attribute \"account_id\" not specified\n\n"+
+						"See: https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/guides/version-5-upgrade#cloudflare_access_policy",
+					"cloudflare_zero_trust_access_policy", resourceName),
+			})
+		}
+	}
 
 	// Convert approval_group block to approval_groups attribute array
 	// In v4: approval_group { approvals_needed = 1 }

--- a/internal/resources/zero_trust_access_policy/v4_to_v5_test.go
+++ b/internal/resources/zero_trust_access_policy/v4_to_v5_test.go
@@ -42,7 +42,7 @@ moved {
 }`,
 		},
 		{
-			Name: "policy with deprecated fields removed (zone_id, precedence), session_duration preserved",
+			Name: "policy with deprecated fields removed (zone_id + account_id present, precedence), session_duration preserved",
 			Input: `
 resource "cloudflare_access_policy" "test" {
   account_id       = "account-123"
@@ -148,6 +148,148 @@ moved {
 	}
 
 	testhelpers.RunConfigTransformTests(t, tests, migrator)
+}
+
+func TestConfigTransformation_ZoneIDOnlyEmitsWarning(t *testing.T) {
+	migrator := NewV4ToV5Migrator()
+
+	input := `
+resource "cloudflare_access_policy" "zone_scoped" {
+  zone_id  = var.zone_id
+  name     = "Zone Scoped Policy"
+  decision = "allow"
+
+  include {
+    everyone = true
+  }
+}`
+
+	// Parse the input HCL
+	file, diags := hclwrite.ParseConfig([]byte(input), "test.tf", hcl.InitialPos)
+	if diags.HasErrors() {
+		t.Fatalf("Failed to parse input HCL: %v", diags)
+	}
+
+	ctx := &transform.Context{
+		Content:     []byte(input),
+		Filename:    "test.tf",
+		CFGFile:     file,
+		Diagnostics: hcl.Diagnostics{},
+	}
+
+	// Get the resource block
+	body := file.Body()
+	var resourceBlock *hclwrite.Block
+	for _, block := range body.Blocks() {
+		if block.Type() == "resource" {
+			resourceBlock = block
+			break
+		}
+	}
+	if resourceBlock == nil {
+		t.Fatal("Resource block not found")
+	}
+
+	// Transform
+	result, err := migrator.TransformConfig(ctx, resourceBlock)
+	if err != nil {
+		t.Fatalf("TransformConfig returned error: %v", err)
+	}
+
+	if result == nil {
+		t.Fatal("Expected non-nil result")
+	}
+
+	// Should have a warning diagnostic about zone_id -> account_id
+	if len(ctx.Diagnostics) != 1 {
+		t.Fatalf("Expected 1 diagnostic, got %d", len(ctx.Diagnostics))
+	}
+	diag := ctx.Diagnostics[0]
+	if diag.Severity != hcl.DiagWarning {
+		t.Errorf("Expected DiagWarning severity, got %v", diag.Severity)
+	}
+	if !strings.Contains(diag.Summary, "zone_id removed") {
+		t.Errorf("Expected summary to mention 'zone_id removed', got: %s", diag.Summary)
+	}
+	if !strings.Contains(diag.Summary, "account_id required") {
+		t.Errorf("Expected summary to mention 'account_id required', got: %s", diag.Summary)
+	}
+	if !strings.Contains(diag.Detail, "zone_scoped") {
+		t.Errorf("Expected detail to mention resource name 'zone_scoped', got: %s", diag.Detail)
+	}
+
+	// Verify zone_id was removed from the output
+	outputBody := resourceBlock.Body()
+	if outputBody.GetAttribute("zone_id") != nil {
+		t.Error("Expected zone_id to be removed from output")
+	}
+	// Verify account_id was NOT added (user must add it manually)
+	if outputBody.GetAttribute("account_id") != nil {
+		t.Error("Expected account_id to NOT be auto-added (user must add manually)")
+	}
+}
+
+func TestConfigTransformation_ZoneIDWithAccountIDNoWarning(t *testing.T) {
+	migrator := NewV4ToV5Migrator()
+
+	input := `
+resource "cloudflare_access_policy" "both_ids" {
+  account_id = "account-123"
+  zone_id    = "zone-456"
+  name       = "Both IDs Policy"
+  decision   = "allow"
+
+  include {
+    everyone = true
+  }
+}`
+
+	// Parse the input HCL
+	file, diags := hclwrite.ParseConfig([]byte(input), "test.tf", hcl.InitialPos)
+	if diags.HasErrors() {
+		t.Fatalf("Failed to parse input HCL: %v", diags)
+	}
+
+	ctx := &transform.Context{
+		Content:     []byte(input),
+		Filename:    "test.tf",
+		CFGFile:     file,
+		Diagnostics: hcl.Diagnostics{},
+	}
+
+	// Get the resource block
+	body := file.Body()
+	var resourceBlock *hclwrite.Block
+	for _, block := range body.Blocks() {
+		if block.Type() == "resource" {
+			resourceBlock = block
+			break
+		}
+	}
+	if resourceBlock == nil {
+		t.Fatal("Resource block not found")
+	}
+
+	// Transform
+	_, err := migrator.TransformConfig(ctx, resourceBlock)
+	if err != nil {
+		t.Fatalf("TransformConfig returned error: %v", err)
+	}
+
+	// Should have NO diagnostics when both account_id and zone_id are present
+	if len(ctx.Diagnostics) != 0 {
+		t.Errorf("Expected 0 diagnostics when account_id is present, got %d", len(ctx.Diagnostics))
+	}
+
+	// Verify zone_id was removed
+	outputBody := resourceBlock.Body()
+	if outputBody.GetAttribute("zone_id") != nil {
+		t.Error("Expected zone_id to be removed from output")
+	}
+	// Verify account_id was preserved
+	if outputBody.GetAttribute("account_id") == nil {
+		t.Error("Expected account_id to be preserved")
+	}
 }
 
 func TestConfigTransformation_Conditions(t *testing.T) {


### PR DESCRIPTION
## Summary

In v4, `cloudflare_access_policy` could be zone-scoped via `zone_id`. In v5, all access policies are account-level and require `account_id`. Previously `tf-migrate` silently removed `zone_id`, leaving resources without any scope identifier and causing `terraform validate` to fail with:

```
Error: Required attribute "account_id" not specified
```

## Changes

- **`v4_to_v5.go`**: Split `zone_id` removal from the bulk `RemoveAttributes` call. Now checks if `account_id` is present; if not, emits a `MIGRATION WARNING` diagnostic instructing the user to add `account_id` manually. When both `zone_id` and `account_id` are present, `zone_id` is removed silently (no warning needed).
- **`v4_to_v5_test.go`**: Added 2 unit tests: `TestConfigTransformation_ZoneIDOnlyEmitsWarning` and `TestConfigTransformation_ZoneIDWithAccountIDNoWarning`.
- **Integration testdata**: Added `zone_scoped_only` (zone_id only) and `zone_and_account` (both) test resources with expected output.
- **`README.md`**: Added "Zone-Scoped Policies Require `account_id`" section.
- **`agents.md`**: Added note to update Terraform provider migration guides when adding new warnings.
- **`.github/CODEOWNERS`**: Added `@cloudflare/sdk` as owner.

## Design decision

`zone_id` cannot be automatically renamed to `account_id` because they are different identifiers (a zone ID is not an account ID). The fix emits a clear warning with actionable instructions instead of silently dropping the attribute.

## Testing

- All unit tests pass (6 test groups, 25+ subtests)
- All 87 integration tests pass
- `make test` passes