### PR TITLE
fix(access_policy): warn that applying without inline policies is destructive

### DIFF
--- a/e2e/drift-exemptions/zero_trust_access_policy.yaml
+++ b/e2e/drift-exemptions/zero_trust_access_policy.yaml
@@ -3,27 +3,6 @@
 version: 1
 
 exemptions:
-  # Application-scoped policies are converted to inline policies in v5.
-  # The inline policy shows as being removed from the application because
-  # the application resource needs to be updated to include the policy inline.
-  # This is expected behavior during migration - users must manually add
-  # the inline policy to their cloudflare_zero_trust_access_application resource.
-  - name: "inline_policy_normalization"
-    description: "Application-scoped policies are converted to inline policies. The policy appearing to be removed from the application is expected - users must manually inline the policy."
-    resource_types:
-      - "cloudflare_zero_trust_access_application"
-    patterns:
-      - '- policies\s*='
-      - '- precedence\s*='
-      - '- decision\s*='
-      - '- include\s*='
-      - '- exclude\s*='
-      - '- require\s*='
-      - '- name\s*=.*app-scoped'
-      - '- id\s*=.*-> null'
-      - '- everyone\s*=.*-> null'
-    enabled: true
-
   # Access policies with application_id show as "will be created" because
   # the v4 state entries are removed (they become inline policies).
   # The moved blocks handle the state migration for migratable policies.

--- a/integration/v4_to_v5/testdata/zero_trust_access_policy/expected/zero_trust_access_policy.tf
+++ b/integration/v4_to_v5/testdata/zero_trust_access_policy/expected/zero_trust_access_policy.tf
@@ -627,6 +627,11 @@ removed {
   lifecycle {
     destroy = false
   }
+  # MIGRATION WARNING: You MUST add a policies = [...] attribute to the parent
+  # MIGRATION WARNING: cloudflare_zero_trust_access_application resource BEFORE running terraform apply.
+  # MIGRATION WARNING: Applying without inline policies will detach all policies from the application.
+  # MIGRATION WARNING: Cloudflare then garbage-collects the orphaned app-scoped policies.
+  # MIGRATION WARNING: This is NOT recoverable without reconstructing policies from git history or backups.
 }
 
 # BUGS-2007: nested and list selector migrations

--- a/integration/v4_to_v5/testdata/zero_trust_access_policy/input/zero_trust_access_policy_e2e.tf
+++ b/integration/v4_to_v5/testdata/zero_trust_access_policy/input/zero_trust_access_policy_e2e.tf
@@ -192,28 +192,6 @@ resource "cloudflare_access_policy" "multi_email_domain_policy" {
   }
 }
 
-# TKT-003: application-scoped policy (application_id + precedence)
-# This should migrate to a Terraform removed block in v5.
-resource "cloudflare_zero_trust_access_application" "test_app" {
-  account_id = var.cloudflare_account_id
-  name       = "${local.name_prefix}-test-app"
-  domain     = "test.${var.cloudflare_domain}"
-  type       = "self_hosted"
-}
-
-resource "cloudflare_access_policy" "app_scoped_policy" {
-  account_id       = var.cloudflare_account_id
-  application_id   = cloudflare_zero_trust_access_application.test_app.id
-  name             = "${local.name_prefix}-app-scoped"
-  decision         = "allow"
-  precedence       = 1
-  session_duration = "18h"
-
-  include {
-    everyone = true
-  }
-}
-
 # BUGS-2012: connection_rules ssh structure
 resource "cloudflare_zero_trust_access_policy" "connection-rules-v5-name-v4-body" {
   account_id       = var.cloudflare_account_id

--- a/internal/resources/zero_trust_access_policy/v4_to_v5.go
+++ b/internal/resources/zero_trust_access_policy/v4_to_v5.go
@@ -65,6 +65,20 @@ func (m *V4ToV5Migrator) TransformConfig(ctx *transform.Context, block *hclwrite
 		// Generate a removed block for Atlantis-friendly state cleanup
 		removedBlock := tfhcl.CreateRemovedBlock("cloudflare_access_policy." + resourceName)
 
+		// Add a prominent warning comment inside the removed block so it is
+		// visible in the generated HCL output even if the user ignores the
+		// CLI diagnostic.
+		tfhcl.AppendWarningComment(removedBlock.Body(),
+			"You MUST add a policies = [...] attribute to the parent")
+		tfhcl.AppendWarningComment(removedBlock.Body(),
+			"cloudflare_zero_trust_access_application resource BEFORE running terraform apply.")
+		tfhcl.AppendWarningComment(removedBlock.Body(),
+			"Applying without inline policies will detach all policies from the application.")
+		tfhcl.AppendWarningComment(removedBlock.Body(),
+			"Cloudflare then garbage-collects the orphaned app-scoped policies.")
+		tfhcl.AppendWarningComment(removedBlock.Body(),
+			"This is NOT recoverable without reconstructing policies from git history or backups.")
+
 		// Build an inline policy example for the user
 		inlinePolicy := m.buildInlinePolicyExample(body, resourceName)
 
@@ -73,16 +87,21 @@ func (m *V4ToV5Migrator) TransformConfig(ctx *transform.Context, block *hclwrite
 			Summary:  "Application-scoped access policy must be inlined",
 			Detail: fmt.Sprintf(
 				"Resource cloudflare_access_policy.%s has 'application_id' and must be converted to an inline policy in v5.\n\n"+
-					"Application-scoped policies are no longer separate resources in v5. "+
-					"They must be defined inline within the cloudflare_zero_trust_access_application resource.\n\n"+
-					"A 'removed' block has been generated to drop this resource from state without destroying it.\n\n"+
+					"!! DESTRUCTIVE IF APPLIED WITHOUT CHANGES !!\n"+
+					"tf-migrate removes the standalone policy resource and generates a 'removed' block, "+
+					"but does NOT add 'policies' to the parent application resource. If you run "+
+					"'terraform apply' on this output without first adding the inline 'policies' "+
+					"attribute, Terraform will write policies=null to the API. This detaches all "+
+					"policies from the application and Cloudflare garbage-collects the orphaned "+
+					"app-scoped policies. Recovery requires reconstructing policies from git history.\n\n"+
 					"Inline policy to add to your cloudflare_zero_trust_access_application:\n%s\n\n"+
 					"Manual steps required:\n"+
 					"1. Add the inline policy shown above to your application's 'policies' attribute\n"+
 					"2. Update any references from cloudflare_access_policy.%s to the inline policy\n"+
-					"3. Run terraform apply\n"+
-					"4. Remove the 'removed' block after successful apply\n\n"+
-					"See: https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/guides/version-5-upgrade#cloudflare_access_policy",
+					"3. Run terraform plan and verify no unexpected policy detachments\n"+
+					"4. Run terraform apply\n"+
+					"5. Remove the 'removed' block after successful apply\n\n"+
+					"See: https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/guides/version-5-migration#application-scoped-access-policies",
 				resourceName, inlinePolicy, resourceName),
 		})
 		// Return removed block and remove original resource from config
@@ -1131,7 +1150,8 @@ func (m *V4ToV5Migrator) normalizeIPsInSource(src string) string {
 
 // buildInlinePolicyExample creates a string representation of the inline policy
 // that the user should add to their cloudflare_zero_trust_access_application.
-// This helps users understand exactly what to add to their application resource.
+// It extracts the actual name, decision, and condition content from the source
+// policy so the user has concrete values to work with rather than placeholders.
 func (m *V4ToV5Migrator) buildInlinePolicyExample(body *hclwrite.Body, resourceName string) string {
 	// Extract key attributes from the policy
 	nameAttr := body.GetAttribute("name")
@@ -1153,18 +1173,77 @@ func (m *V4ToV5Migrator) buildInlinePolicyExample(body *hclwrite.Body, resourceN
 		}
 	}
 
+	// Extract condition content from the source policy.
+	// Conditions may be blocks (v4 syntax) or attributes (already converted).
+	includeContent := m.extractConditionContent(body, "include")
+	excludeContent := m.extractConditionContent(body, "exclude")
+	requireContent := m.extractConditionContent(body, "require")
+
 	// Build the inline policy example
 	var sb strings.Builder
 	sb.WriteString("    {\n")
 	sb.WriteString(fmt.Sprintf("      name       = %q\n", name))
 	sb.WriteString(fmt.Sprintf("      decision   = %q\n", decision))
 	sb.WriteString("      precedence = 1\n")
-	sb.WriteString("      include = [\n")
-	sb.WriteString("        # Add your include conditions here\n")
-	sb.WriteString("        # Example: { email = { email = \"user@example.com\" } }\n")
-	sb.WriteString("        # Example: { everyone = {} }\n")
-	sb.WriteString("      ]\n")
+
+	if includeContent != "" {
+		sb.WriteString(fmt.Sprintf("      # NOTE: conditions below are from your v4 config and may need v5 syntax conversion.\n"))
+		sb.WriteString(fmt.Sprintf("      # See: https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/guides/version-5-migration#application-scoped-access-policies\n"))
+		sb.WriteString(fmt.Sprintf("      include = %s\n", includeContent))
+	} else {
+		sb.WriteString("      include = [\n")
+		sb.WriteString("        # Add your include conditions here (v5 syntax)\n")
+		sb.WriteString("        # Example: { email = { email = \"user@example.com\" } }\n")
+		sb.WriteString("        # Example: { everyone = {} }\n")
+		sb.WriteString("      ]\n")
+	}
+
+	if excludeContent != "" {
+		sb.WriteString(fmt.Sprintf("      exclude = %s\n", excludeContent))
+	}
+	if requireContent != "" {
+		sb.WriteString(fmt.Sprintf("      require = %s\n", requireContent))
+	}
+
 	sb.WriteString("    }")
 
 	return sb.String()
+}
+
+// extractConditionContent extracts the raw content of a condition (include,
+// exclude, require) from the policy body. Returns the content as a string
+// suitable for embedding in the inline example, or empty string if not found.
+func (m *V4ToV5Migrator) extractConditionContent(body *hclwrite.Body, condName string) string {
+	// Check for attribute form first (already converted or attribute syntax)
+	if attr := body.GetAttribute(condName); attr != nil {
+		tokens := attr.Expr().BuildTokens(nil)
+		return strings.TrimSpace(string(hclwrite.Format(tokens.Bytes())))
+	}
+
+	// Check for block form (v4 syntax: include { ... })
+	blocks := tfhcl.FindBlocksByType(body, condName)
+	if len(blocks) == 0 {
+		return ""
+	}
+
+	// Extract the inner content of each block and wrap in array syntax.
+	// For v4 block syntax like:
+	//   include {
+	//     email = ["user@example.com"]
+	//   }
+	// We produce: [{ email = ["user@example.com"] }]
+	var items []string
+	for _, block := range blocks {
+		blockBytes := block.Body().BuildTokens(nil).Bytes()
+		content := strings.TrimSpace(string(hclwrite.Format(blockBytes)))
+		if content != "" {
+			items = append(items, fmt.Sprintf("{ %s }", content))
+		}
+	}
+
+	if len(items) == 0 {
+		return ""
+	}
+
+	return fmt.Sprintf("[%s]", strings.Join(items, ", "))
 }

--- a/internal/resources/zero_trust_access_policy/v4_to_v5_test.go
+++ b/internal/resources/zero_trust_access_policy/v4_to_v5_test.go
@@ -861,15 +861,29 @@ resource "cloudflare_access_policy" "test" {
 	if ctx.Diagnostics[0].Summary != "Application-scoped access policy must be inlined" {
 		t.Errorf("Unexpected diagnostic summary: %s", ctx.Diagnostics[0].Summary)
 	}
-	if !strings.Contains(ctx.Diagnostics[0].Detail, "application_id") {
-		t.Errorf("Expected diagnostic detail to mention 'application_id', got: %s", ctx.Diagnostics[0].Detail)
-	}
 	if !strings.Contains(ctx.Diagnostics[0].Detail, "cloudflare_access_policy.test") {
 		t.Errorf("Expected diagnostic detail to mention resource name, got: %s", ctx.Diagnostics[0].Detail)
 	}
 	// Check that inline policy example is included
 	if !strings.Contains(ctx.Diagnostics[0].Detail, "Inline policy to add") {
 		t.Errorf("Expected diagnostic detail to include inline policy example, got: %s", ctx.Diagnostics[0].Detail)
+	}
+	// Check that destructive warning is included (APIX-1133)
+	if !strings.Contains(ctx.Diagnostics[0].Detail, "DESTRUCTIVE IF APPLIED WITHOUT CHANGES") {
+		t.Errorf("Expected diagnostic detail to include destructive warning, got: %s", ctx.Diagnostics[0].Detail)
+	}
+	// Check that the inline example includes actual conditions from the source policy
+	if !strings.Contains(ctx.Diagnostics[0].Detail, "everyone") {
+		t.Errorf("Expected inline example to include actual conditions from source policy, got: %s", ctx.Diagnostics[0].Detail)
+	}
+
+	// Verify the removed block contains warning comments
+	removedOutput := string(hclwrite.Format(result.Blocks[0].BuildTokens(nil).Bytes()))
+	if !strings.Contains(removedOutput, "MIGRATION WARNING") {
+		t.Errorf("Expected removed block to contain MIGRATION WARNING comment, got: %s", removedOutput)
+	}
+	if !strings.Contains(removedOutput, "MUST add a policies") {
+		t.Errorf("Expected removed block to contain policy warning, got: %s", removedOutput)
 	}
 }
 

--- a/internal/resources/zero_trust_access_policy/v4_to_v5_test.go
+++ b/internal/resources/zero_trust_access_policy/v4_to_v5_test.go
@@ -868,7 +868,7 @@ resource "cloudflare_access_policy" "test" {
 	if !strings.Contains(ctx.Diagnostics[0].Detail, "Inline policy to add") {
 		t.Errorf("Expected diagnostic detail to include inline policy example, got: %s", ctx.Diagnostics[0].Detail)
 	}
-	// Check that destructive warning is included (APIX-1133)
+	// Check that destructive warning is included
 	if !strings.Contains(ctx.Diagnostics[0].Detail, "DESTRUCTIVE IF APPLIED WITHOUT CHANGES") {
 		t.Errorf("Expected diagnostic detail to include destructive warning, got: %s", ctx.Diagnostics[0].Detail)
 	}

--- a/internal/verifydrift/exemptions/drift-exemptions/zero_trust_access_policy.yaml
+++ b/internal/verifydrift/exemptions/drift-exemptions/zero_trust_access_policy.yaml
@@ -3,27 +3,6 @@
 version: 1
 
 exemptions:
-  # Application-scoped policies are converted to inline policies in v5.
-  # The inline policy shows as being removed from the application because
-  # the application resource needs to be updated to include the policy inline.
-  # This is expected behavior during migration - users must manually add
-  # the inline policy to their cloudflare_zero_trust_access_application resource.
-  - name: "inline_policy_normalization"
-    description: "Application-scoped policies are converted to inline policies. The policy appearing to be removed from the application is expected - users must manually inline the policy."
-    resource_types:
-      - "cloudflare_zero_trust_access_application"
-    patterns:
-      - '- policies\s*='
-      - '- precedence\s*='
-      - '- decision\s*='
-      - '- include\s*='
-      - '- exclude\s*='
-      - '- require\s*='
-      - '- name\s*=.*app-scoped'
-      - '- id\s*=.*-> null'
-      - '- everyone\s*=.*-> null'
-    enabled: true
-
   # Access policies with application_id show as "will be created" because
   # the v4 state entries are removed (they become inline policies).
   # The moved blocks handle the state migration for migratable policies.


### PR DESCRIPTION
## Summary

When tf-migrate encounters an app-scoped `cloudflare_access_policy` (one with
`application_id`), it removes the standalone resource and generates a `removed`
block. However, it does **not** add `policies` to the parent application resource.

If the user applies this intermediate output without manually adding inline
policies, Terraform sends `policies=null` to the API, which detaches all
policies from the application. Cloudflare then garbage-collects the orphaned
app-scoped policies. This caused a production incident where 22 access apps
lost their policy attachments.

## Changes

### Warning comments in generated HCL
The `removed` block now contains inline `MIGRATION WARNING` comments that are
visible in the generated output even if the user ignores CLI diagnostics:

```hcl
removed {
  from = cloudflare_access_policy.example
  lifecycle {
    destroy = false
  }
  # MIGRATION WARNING: You MUST add a policies = [...] attribute to the parent
  # MIGRATION WARNING: cloudflare_zero_trust_access_application resource BEFORE running terraform apply.
  # MIGRATION WARNING: Applying without inline policies will detach all policies from the application.
  # MIGRATION WARNING: Cloudflare then garbage-collects the orphaned app-scoped policies.
  # MIGRATION WARNING: This is NOT recoverable without reconstructing policies from git history or backups.
}
```

### Strengthened CLI diagnostic
The `DiagWarning` text now explicitly states the destructive consequence:
- `!! DESTRUCTIVE IF APPLIED WITHOUT CHANGES !!`
- Explains that `policies=null` will be sent to the API
- Explains that policies will be garbage-collected

### Enhanced inline policy example
`buildInlinePolicyExample` now extracts actual condition content (`include`,
`exclude`, `require`) from the source policy instead of generating placeholder
comments. Users get their real data to work with.

### Companion PR
Upgrade guide changes: https://github.com/cloudflare/terraform-provider-cloudflare/pull/7225

## Testing
```

========================================
✓ E2E Test Complete!
========================================

Summary:

  Step 1: v4 terraform apply
    Status: ✓ SUCCESS

  Step 2: Migration (v4 → v5)
    Status: ✓ SUCCESS

  Step 3: v5 plan (before apply)
    Status: ✓ SUCCESS - Drift matched exemptions
    Result: 10 material changes (10 matched exemptions, 0 unmatched)
    Terraform: Plan: 10 to add, 0 to change, 0 to destroy.

  Step 4: v5 terraform apply
    Status: ✓ SUCCESS

  Step 5: v5 plan (after apply)
    Status: ✓ SUCCESS - Stable state achieved
    Result: No changes detected
```