### PR TITLE
fix(zone_setting): phase 1 silent failure with inline comments

### DIFF
--- a/cmd/tf-migrate/main.go
+++ b/cmd/tf-migrate/main.go
@@ -756,9 +756,17 @@ func runPhaseOne(log hclog.Logger, cfg config, phaseOneResources map[string][]st
 			Resources:     cfg.resourcesToMigrate,
 		}
 
+		// Snapshot the normalized file bytes BEFORE calling BuildTokens on
+		// any block. hclwrite.File.Bytes() normalizes whitespace around
+		// inline comments as a side effect on the shared token list, while
+		// BuildTokens preserves original spacing. Calling Bytes() first
+		// ensures both representations use the same normalized form so the
+		// subsequent strings.Replace can find the match.
+		normalizedFile := string(parsed.Bytes())
+
 		// Collect (block text, removed block) pairs for this file.
 		type phaseOnePair struct {
-			blockText    string // raw bytes of the original resource block
+			blockText    string // normalized bytes of the original resource block
 			removedBlock *hclwrite.Block
 		}
 		var pairs []phaseOnePair
@@ -800,10 +808,7 @@ func runPhaseOne(log hclog.Logger, cfg config, phaseOneResources map[string][]st
 			continue
 		}
 
-		// Use the parsed (normalized) file bytes as the base — both blockText
-		// from BuildTokens and the file bytes come from the same hclwrite
-		// tokenizer, so replacements match exactly.
-		newContent := string(parsed.Bytes())
+		newContent := normalizedFile
 		for _, pair := range pairs {
 			commented := commentOutBlock(pair.blockText)
 			// Build the removed {} block text
@@ -811,7 +816,17 @@ func runPhaseOne(log hclog.Logger, cfg config, phaseOneResources map[string][]st
 			scratch.Body().AppendNewline()
 			scratch.Body().AppendBlock(pair.removedBlock)
 			removedText := string(hclwrite.Format(scratch.Bytes()))
+			before := newContent
 			newContent = strings.Replace(newContent, pair.blockText, commented+removedText, 1)
+			if newContent == before {
+				return fmt.Errorf(
+					"phase-1 replacement failed for block in %s: "+
+						"could not locate block text in normalized file content — "+
+						"this is a tf-migrate bug, please file an issue at "+
+						"https://github.com/cloudflare/tf-migrate/issues",
+					filepath.Base(file),
+				)
+			}
 		}
 
 		if cfg.backup {

--- a/integration/v4_to_v5/phased_migration_test.go
+++ b/integration/v4_to_v5/phased_migration_test.go
@@ -227,4 +227,123 @@ func TestPhasedMigration_ZoneSettingsOverride(t *testing.T) {
 		assert.Contains(t, string(content), `resource "cloudflare_dns_record"`)
 		assert.NotContains(t, string(content), markerPrefix)
 	})
+
+	// -------------------------------------------------------------------------
+	// Regression: inline comments with extra whitespace (#296)
+	//
+	// hclwrite.File.Bytes() normalizes whitespace around inline comments,
+	// while Block.BuildTokens preserves original spacing. If Bytes() is
+	// called after BuildTokens, the two representations diverge and the
+	// strings.Replace in runPhaseOne silently fails — the tool claims
+	// success but the file is unchanged.
+	// -------------------------------------------------------------------------
+	t.Run("Phase1_InlineComments_Issue296", func(t *testing.T) {
+		const inputWithComments = `resource "cloudflare_zone_settings_override" "widerivers_com" {
+  zone_id = "444f5d541a6bf40a524b9a78cb223c93"
+
+  settings {
+    http3            = "on"        # Enable HTTP/3
+    webp             = "on"        # Enable WebP
+    early_hints      = "on"        # Enable Early Hints
+    brotli           = "on"        # Enable Brotli compression
+    always_use_https = "on"        # Force HTTPS
+    ssl              = "strict"    # SSL mode
+    min_tls_version  = "1.2"       # Minimum TLS version
+    tls_1_3          = "zrt"       # TLS 1.3 with 0-RTT
+    security_level   = "high"      # Security level
+  }
+}
+`
+		dir := t.TempDir()
+		inputFile := filepath.Join(dir, "zone_setting.tf")
+		require.NoError(t, os.WriteFile(inputFile, []byte(inputWithComments), 0644))
+
+		migrateCmd := exec.Command(binaryPath,
+			"migrate",
+			"--config-dir", dir,
+			"--source-version", "v4",
+			"--target-version", "v5",
+			"--backup=false",
+			"--skip-version-check",
+		)
+		migrateCmd.Dir = dir
+		cmdOut, err := migrateCmd.CombinedOutput()
+		require.NoError(t, err, "tf-migrate phase 1 failed: %s", string(cmdOut))
+
+		content, err := os.ReadFile(inputFile)
+		require.NoError(t, err)
+		result := string(content)
+
+		// Resource block must be commented out with the marker prefix
+		assert.Contains(t, result, markerPrefix+`resource "cloudflare_zone_settings_override" "widerivers_com" {`,
+			"resource block should be commented out with marker prefix")
+
+		// A removed {} block must be present
+		assert.Contains(t, result, `removed {`)
+		assert.Contains(t, result, `cloudflare_zone_settings_override.widerivers_com`)
+		assert.Contains(t, result, `destroy = false`)
+
+		// No uncommented resource block visible to Terraform
+		for _, line := range strings.Split(result, "\n") {
+			trimmed := strings.TrimSpace(line)
+			if strings.HasPrefix(trimmed, `resource "cloudflare_zone_settings_override"`) {
+				t.Errorf("resource block must be commented out, found uncommented: %s", line)
+			}
+		}
+	})
+
+	// -------------------------------------------------------------------------
+	// Phase 1 with inline comments followed by full Phase 2
+	// Ensures the end-to-end flow works when inline comments are present.
+	// -------------------------------------------------------------------------
+	t.Run("Phase1Then2_InlineComments_FullMigration", func(t *testing.T) {
+		const inputWithComments = `resource "cloudflare_zone_settings_override" "example" {
+  zone_id = "0da42c8d2132a9ddaf714f9e7c920711"
+
+  settings {
+    always_online = "on"   # keep site online
+    ssl           = "full" # SSL mode
+  }
+}
+`
+		dir := t.TempDir()
+		inputFile := filepath.Join(dir, "zone_setting.tf")
+		require.NoError(t, os.WriteFile(inputFile, []byte(inputWithComments), 0644))
+
+		// Phase 1
+		p1 := exec.Command(binaryPath,
+			"migrate", "--config-dir", dir,
+			"--source-version", "v4", "--target-version", "v5", "--backup=false", "--skip-version-check",
+		)
+		p1.Dir = dir
+		p1Out, err := p1.CombinedOutput()
+		require.NoError(t, err, "phase 1 failed: %s", string(p1Out))
+
+		// Verify phase 1 output
+		p1Content, err := os.ReadFile(inputFile)
+		require.NoError(t, err)
+		assert.Contains(t, string(p1Content), markerPrefix,
+			"phase 1 must produce commented-out blocks")
+		assert.Contains(t, string(p1Content), `removed {`,
+			"phase 1 must produce removed {} block")
+
+		// Phase 2 — confirm with "y"
+		p2 := exec.Command(binaryPath,
+			"migrate", "--config-dir", dir,
+			"--source-version", "v4", "--target-version", "v5", "--backup=false", "--skip-version-check",
+		)
+		p2.Dir = dir
+		p2.Stdin = strings.NewReader("y\n")
+		p2Out, err := p2.CombinedOutput()
+		require.NoError(t, err, "phase 2 failed: %s", string(p2Out))
+
+		p2Content, err := os.ReadFile(inputFile)
+		require.NoError(t, err)
+		result := string(p2Content)
+
+		assert.NotContains(t, result, `resource "cloudflare_zone_settings_override"`)
+		assert.NotContains(t, result, markerPrefix, "no phase-1 markers should remain")
+		assert.Contains(t, result, `resource "cloudflare_zone_setting"`)
+		assert.Contains(t, result, `import {`)
+	})
 }


### PR DESCRIPTION
## Summary

Fixes #296.

Phase 1 of `tf-migrate` claims success generating a `removed {}` block for
`cloudflare_zone_settings_override`, but when the `.tf` file contains inline
comments with alignment whitespace (e.g. `http3 = "on"        # Enable HTTP/3`),
the file is left unmodified. The tool prints
`✓ commented out 1 resource block(s), added removed {} block(s)` when nothing
actually changed.

## Root cause

Call-order bug in `runPhaseOne()`:

1. `block.BuildTokens(nil).Bytes()` captures block text with **original** spacing
2. `parsed.Bytes()` is called **after**, normalizing whitespace around inline
   comments as a side effect on the shared hclwrite token list
3. `strings.Replace` tries to find original-spacing text in the normalized
   content -- mismatch, replacement silently fails
4. Success message prints unconditionally because `len(pairs) > 0`

## Fix

1. **Call `parsed.Bytes()` before `BuildTokens`** so both the block text
   extraction and the file content use the same normalized token representation.

2. **Add a defensive guard** after `strings.Replace` that returns a hard error
   if the replacement did not actually modify the content, preventing silent
   failures in the future.

## Testing

- Two new integration tests added:
  - `Phase1_InlineComments_APIX974` -- reproduces the exact bug from the issue
  - `Phase1Then2_InlineComments_FullMigration` -- verifies full Phase 1 -> Phase 2
    flow with inline comments
- All existing unit and integration tests pass
- Manual reproduction confirmed: bug present on `main`, fixed on this branch

### E2E Tests
```
========================================
✓ E2E Test Complete!
========================================

Summary:

  Step 1: v4 terraform apply
    Status: ✓ SUCCESS

  Step 2: Migration (v4 → v5)
    Status: ✓ SUCCESS

  Step 3: v5 plan (before apply)
    Status: ✓ SUCCESS - Drift matched exemptions
    Result: 4 material changes (4 matched exemptions, 0 unmatched)
    Terraform: Plan: 16 to import, 4 to add, 0 to change, 0 to destroy.

  Step 4: v5 terraform apply
    Status: ✓ SUCCESS

  Step 5: v5 plan (after apply)
    Status: ✓ SUCCESS - Stable state achieved
    Result: No changes detected
```