### PR TITLE
fix(logpush_ownership_challenge): rewrite filename references

### DIFF
--- a/integration/v4_to_v5/testdata/logpush_ownership_challenge/expected/logpush_ownership_challenge.tf
+++ b/integration/v4_to_v5/testdata/logpush_ownership_challenge/expected/logpush_ownership_challenge.tf
@@ -215,6 +215,10 @@ resource "cloudflare_logpush_ownership_challenge" "ignore_changes" {
   }
 }
 
+output "with_lifecycle_ownership_challenge_path" {
+  value = "cloudflare/${cloudflare_logpush_ownership_challenge.with_lifecycle.filename}"
+}
+
 # =============================================================================
 # Pattern 10: toset() conversion
 # =============================================================================

--- a/integration/v4_to_v5/testdata/logpush_ownership_challenge/input/logpush_ownership_challenge.tf
+++ b/integration/v4_to_v5/testdata/logpush_ownership_challenge/input/logpush_ownership_challenge.tf
@@ -215,6 +215,10 @@ resource "cloudflare_logpush_ownership_challenge" "ignore_changes" {
   }
 }
 
+output "with_lifecycle_ownership_challenge_path" {
+  value = "cloudflare/${cloudflare_logpush_ownership_challenge.with_lifecycle.ownership_challenge_filename}"
+}
+
 # =============================================================================
 # Pattern 10: toset() conversion
 # =============================================================================

--- a/internal/resources/logpush_ownership_challenge/v4_to_v5.go
+++ b/internal/resources/logpush_ownership_challenge/v4_to_v5.go
@@ -30,6 +30,16 @@ func (m *V4ToV5Migrator) Preprocess(content string) string {
 	return content
 }
 
+func (m *V4ToV5Migrator) GetAttributeRenames() []transform.AttributeRename {
+	return []transform.AttributeRename{
+		{
+			ResourceType: "cloudflare_logpush_ownership_challenge",
+			OldAttribute: "ownership_challenge_filename",
+			NewAttribute: "filename",
+		},
+	}
+}
+
 // This resource does not rename, so we return the same name for both old and new
 func (m *V4ToV5Migrator) GetResourceRename() ([]string, string) {
 	return []string{"cloudflare_logpush_ownership_challenge"}, "cloudflare_logpush_ownership_challenge"
@@ -48,4 +58,3 @@ func (m *V4ToV5Migrator) TransformConfig(ctx *transform.Context, block *hclwrite
 		RemoveOriginal: false,
 	}, nil
 }
-


### PR DESCRIPTION
# Summary

Add the `cloudflare_logpush_ownership_challenge` attribute rename for `ownership_challenge_filename` to `filename`.

Fixes #301

# Test Plan

- `TEST_RESOURCE=logpush_ownership_challenge go test -run TestSingleResource ./integration/v4_to_v5`
- `make test`
- `make lint-testdata`
- Also tested with a freshly built `tf-migrate` binary in a scratch Terraform config.