### PR TITLE
fix(api_token): migrate permission_groups data source references instead of extracting map keys

### DIFF
--- a/integration/v4_to_v5/testdata/api_token/expected/api_token.tf
+++ b/integration/v4_to_v5/testdata/api_token/expected/api_token.tf
@@ -187,6 +187,8 @@ resource "cloudflare_api_token" "full_example" {
 }
 
 # Test Case 8: Token with data reference and timestamps
+data "cloudflare_api_token_permission_groups_list" "all" {}
+
 resource "cloudflare_api_token" "api_token_create" {
   name = "${local.name_prefix} api_token_create"
 

--- a/internal/datasources/api_token_permission_groups/v4_to_v5.go
+++ b/internal/datasources/api_token_permission_groups/v4_to_v5.go
@@ -1,0 +1,54 @@
+package api_token_permission_groups
+
+import (
+	"github.com/hashicorp/hcl/v2/hclwrite"
+
+	"github.com/cloudflare/tf-migrate/internal"
+	"github.com/cloudflare/tf-migrate/internal/transform"
+	tfhcl "github.com/cloudflare/tf-migrate/internal/transform/hcl"
+)
+
+// V4ToV5Migrator handles the cloudflare_api_token_permission_groups data source.
+//
+// In v4, this data source returns a map of permission names to IDs (e.g.
+// data.cloudflare_api_token_permission_groups.all.permissions["DNS Read"]).
+//
+// In v5, this data source was replaced by cloudflare_api_token_permission_groups_list,
+// which returns a list of objects with id/name/scopes fields. The migrator renames
+// the block so that the data source is still available for reference resolution.
+//
+// Any expression references in cloudflare_api_token.permission_groups that use the
+// old map-style lookups are rewritten by the api_token resource migrator to use
+// for-expressions against the new list-style data source.
+type V4ToV5Migrator struct{}
+
+// NewV4ToV5Migrator creates a new migrator for the
+// cloudflare_api_token_permission_groups datasource (v4 → v5).
+func NewV4ToV5Migrator() transform.ResourceTransformer {
+	migrator := &V4ToV5Migrator{}
+	internal.RegisterMigrator("data.cloudflare_api_token_permission_groups", "v4", "v5", migrator)
+	return migrator
+}
+
+func (m *V4ToV5Migrator) GetResourceType() string {
+	return "cloudflare_api_token_permission_groups"
+}
+
+func (m *V4ToV5Migrator) CanHandle(resourceType string) bool {
+	return resourceType == "data.cloudflare_api_token_permission_groups"
+}
+
+func (m *V4ToV5Migrator) Preprocess(content string) string {
+	return content
+}
+
+// TransformConfig renames the data source block from
+// cloudflare_api_token_permission_groups to cloudflare_api_token_permission_groups_list.
+func (m *V4ToV5Migrator) TransformConfig(ctx *transform.Context, block *hclwrite.Block) (*transform.TransformResult, error) {
+	tfhcl.RenameResourceType(block, "cloudflare_api_token_permission_groups", "cloudflare_api_token_permission_groups_list")
+
+	return &transform.TransformResult{
+		Blocks:         []*hclwrite.Block{block},
+		RemoveOriginal: false,
+	}, nil
+}

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -3,6 +3,7 @@ package registry
 import (
 	accountrolesdata "github.com/cloudflare/tf-migrate/internal/datasources/account_roles"
 	accountsdata "github.com/cloudflare/tf-migrate/internal/datasources/accounts"
+	apitokenpermgroupsdata "github.com/cloudflare/tf-migrate/internal/datasources/api_token_permission_groups"
 	lbpoolsdata "github.com/cloudflare/tf-migrate/internal/datasources/load_balancer_pools"
 	rulesetsdata "github.com/cloudflare/tf-migrate/internal/datasources/rulesets"
 	zonedata "github.com/cloudflare/tf-migrate/internal/datasources/zone"
@@ -97,6 +98,7 @@ func RegisterAllMigrations() {
 	// Datasources
 	accountrolesdata.NewV4ToV5Migrator()
 	accountsdata.NewV4ToV5Migrator()
+	apitokenpermgroupsdata.NewV4ToV5Migrator()
 	lbpoolsdata.NewV4ToV5Migrator()
 	rulesetsdata.NewV4ToV5Migrator()
 	zonedata.NewV4ToV5Migrator()

--- a/internal/resources/api_token/v4_to_v5.go
+++ b/internal/resources/api_token/v4_to_v5.go
@@ -1,15 +1,17 @@
 package api_token
 
 import (
-	"regexp"
+	"fmt"
 	"sort"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/hashicorp/hcl/v2/hclwrite"
+	"github.com/zclconf/go-cty/cty"
 
 	"github.com/cloudflare/tf-migrate/internal"
 	"github.com/cloudflare/tf-migrate/internal/transform"
 	tfhcl "github.com/cloudflare/tf-migrate/internal/transform/hcl"
-	"github.com/hashicorp/hcl/v2/hclsyntax"
-	"github.com/hashicorp/hcl/v2/hclwrite"
-	"github.com/zclconf/go-cty/cty"
 )
 
 type V4ToV5Migrator struct {
@@ -29,12 +31,10 @@ func (m *V4ToV5Migrator) CanHandle(resourceType string) bool {
 	return resourceType == "cloudflare_api_token"
 }
 
+// Preprocess handles string-level transformations before HCL parsing.
+// The cloudflare_api_token_permission_groups data source is now handled
+// by the dedicated datasource migrator in internal/datasources/api_token_permission_groups.
 func (m *V4ToV5Migrator) Preprocess(content string) string {
-	// Remove deprecated data source cloudflare_api_token_permission_groups
-	// It was replaced by cloudflare_api_token_permission_groups_list in v5
-	// Remove just the data source line, preserving any comments
-	re := regexp.MustCompile(`(?m)^data\s+"cloudflare_api_token_permission_groups"\s+"[^"]+"\s*\{\s*\}\s*\n`)
-	content = re.ReplaceAllString(content, "")
 	return content
 }
 
@@ -42,8 +42,8 @@ func (m *V4ToV5Migrator) Postprocess(content string) string {
 	return content
 }
 
-// GetResourceRename implements the ResourceRenamer interface
-// This resource does not rename, so we return the same name for both old and new
+// GetResourceRename implements the ResourceRenamer interface.
+// This resource does not rename, so we return the same name for both old and new.
 func (m *V4ToV5Migrator) GetResourceRename() ([]string, string) {
 	return []string{"cloudflare_api_token"}, "cloudflare_api_token"
 }
@@ -51,7 +51,7 @@ func (m *V4ToV5Migrator) GetResourceRename() ([]string, string) {
 func (m *V4ToV5Migrator) TransformConfig(ctx *transform.Context, block *hclwrite.Block) (*transform.TransformResult, error) {
 	body := block.Body()
 
-	m.transformPolicyBlocks(body)
+	m.transformPolicyBlocks(ctx, body)
 	m.transformConditionBlock(body)
 	return &transform.TransformResult{
 		Blocks:         []*hclwrite.Block{block},
@@ -59,7 +59,7 @@ func (m *V4ToV5Migrator) TransformConfig(ctx *transform.Context, block *hclwrite
 	}, nil
 }
 
-func (m *V4ToV5Migrator) transformPolicyBlocks(body *hclwrite.Body) {
+func (m *V4ToV5Migrator) transformPolicyBlocks(ctx *transform.Context, body *hclwrite.Body) {
 	policyBlocks := tfhcl.FindBlocksByType(body, "policy")
 	if len(policyBlocks) == 0 {
 		return
@@ -76,7 +76,7 @@ func (m *V4ToV5Migrator) transformPolicyBlocks(body *hclwrite.Body) {
 		}
 
 		// Transform permission_groups from list of strings to list of objects with id field
-		m.transformPermissionGroups(policyBody)
+		m.transformPermissionGroups(ctx, policyBody)
 
 		// Transform resources from map to jsonencode() wrapped map
 		// v4: resources = { "com.cloudflare.api.account.*" = "*" }
@@ -93,58 +93,266 @@ func (m *V4ToV5Migrator) transformPolicyBlocks(body *hclwrite.Body) {
 	tfhcl.RemoveBlocksByType(body, "policy")
 }
 
-// transformPermissionGroups converts permission_groups from list of strings to list of objects
-// v4: permission_groups = ["id1", "id2"]
-// v5: permission_groups = [{ id = "id1" }, { id = "id2" }]
-// The IDs are sorted alphabetically to match the v5 provider's canonical ordering.
-func (m *V4ToV5Migrator) transformPermissionGroups(body *hclwrite.Body) {
+// transformPermissionGroups converts permission_groups from v4 format to v5 format.
+//
+// v4 accepts:
+//   - A list of bare string IDs:   ["id1", "id2"]
+//   - A list of objects:           [{ id = "id1" }, { id = "id2" }]
+//   - A list of data-source refs:  [data.cloudflare_api_token_permission_groups.all.permissions["Name"]]
+//
+// v5 requires a list of objects:  [{ id = "id1" }, { id = "id2" }]
+//
+// For string / object elements the IDs are sorted alphabetically to match
+// the v5 provider's canonical ordering.
+//
+// Expression elements that reference cloudflare_api_token_permission_groups are
+// transformed to for-expressions that look up the ID by name from the v5
+// replacement data source (cloudflare_api_token_permission_groups_list).
+func (m *V4ToV5Migrator) transformPermissionGroups(ctx *transform.Context, body *hclwrite.Body) {
 	permGroupsAttr := body.GetAttribute("permission_groups")
 	if permGroupsAttr == nil {
 		return
 	}
 
-	// Parse the existing list expression to extract the permission IDs
 	exprTokens := permGroupsAttr.Expr().BuildTokens(nil)
 
-	// Collect all permission group IDs first
+	// Scan for string IDs using bracket-depth tracking.
+	// Only TokenQuotedLit tokens at bracketDepth == 1 are direct string values;
+	// tokens at deeper depths (e.g. ["key"] index access on a data source) are
+	// NOT collected — this is the fix for the bug where "DNS Read" (the map key
+	// in data.source.permissions["DNS Read"]) was incorrectly extracted as an ID.
 	var permIDs []string
-	inList := false
-
-	for _, token := range exprTokens {
-		switch token.Type {
+	bracketDepth := 0
+	for _, tok := range exprTokens {
+		switch tok.Type {
 		case hclsyntax.TokenOBrack:
-			inList = true
+			bracketDepth++
 		case hclsyntax.TokenCBrack:
-			inList = false
+			bracketDepth--
 		case hclsyntax.TokenQuotedLit:
-			if inList {
-				permIDs = append(permIDs, string(token.Bytes))
+			if bracketDepth == 1 {
+				permIDs = append(permIDs, string(tok.Bytes))
 			}
 		}
 	}
 
-	if len(permIDs) == 0 {
+	if len(permIDs) > 0 {
+		// All elements are string literals or already-objects with string IDs.
+		// Sort alphabetically to match the v5 provider's canonical ordering.
+		sort.Strings(permIDs)
+
+		var permObjects []hclwrite.Tokens
+		for _, id := range permIDs {
+			objAttrs := []hclwrite.ObjectAttrTokens{
+				{
+					Name:  hclwrite.TokensForIdentifier("id"),
+					Value: hclwrite.TokensForValue(cty.StringVal(id)),
+				},
+			}
+			permObjects = append(permObjects, hclwrite.TokensForObject(objAttrs))
+		}
+
+		body.RemoveAttribute("permission_groups")
+		body.SetAttributeRaw("permission_groups", hclwrite.TokensForTuple(permObjects))
 		return
 	}
 
-	// Sort IDs alphabetically to match the v5 provider's canonical ordering
-	sort.Strings(permIDs)
+	// No string IDs found at depth 1.  The list likely contains expression
+	// references such as data-source lookups.  Split the list into individual
+	// elements and try to transform data source references into for-expressions.
+	elements := splitPermGroupExprElements(exprTokens)
+	if len(elements) == 0 {
+		return
+	}
 
-	// Build a list of objects where each string ID becomes { id = "..." }
-	var permObjects []hclwrite.Tokens
-	for _, id := range permIDs {
-		objAttrs := []hclwrite.ObjectAttrTokens{
-			{
-				Name:  hclwrite.TokensForIdentifier("id"),
-				Value: hclwrite.TokensForValue(cty.StringVal(id)),
-			},
+	// Try to parse each element as a cloudflare_api_token_permission_groups
+	// data source reference and convert it to a for-expression against the
+	// v5 replacement data source.
+	var forExprParts []string
+	allParsed := true
+	for _, elem := range elements {
+		ref := parsePermGroupDataSourceRef(elem)
+		if ref == nil {
+			allParsed = false
+			break
 		}
-		permObjects = append(permObjects, hclwrite.TokensForObject(objAttrs))
+		// Build: { id = [for pg in data.cloudflare_api_token_permission_groups_list.<label>.result : pg.id if pg.name == "<name>"][0] }
+		forExpr := fmt.Sprintf(
+			`{ id = [for pg in data.cloudflare_api_token_permission_groups_list.%s.result : pg.id if pg.name == %q][0] }`,
+			ref.label, ref.permName,
+		)
+		forExprParts = append(forExprParts, forExpr)
+	}
+
+	if allParsed && len(forExprParts) > 0 {
+		// Build the full permission_groups value as an expression string and
+		// parse it through hclwrite so the tokens are well-formed.
+		exprStr := "["
+		for i, part := range forExprParts {
+			if i > 0 {
+				exprStr += ", "
+			}
+			exprStr += part
+		}
+		exprStr += "]"
+
+		if err := tfhcl.SetAttributeFromExpressionString(body, "permission_groups", exprStr); err == nil {
+			return
+		}
+		// Fall through to the generic wrapping if parsing fails
+	}
+
+	// Fallback: wrap each element as { id = <expr> } and emit a warning.
+	ctx.Diagnostics = append(ctx.Diagnostics, &hcl.Diagnostic{
+		Severity: hcl.DiagWarning,
+		Summary:  "Manual action required: permission_groups contains unrecognized expressions",
+		Detail: "Some permission_groups values could not be automatically migrated. " +
+			"Replace the expression references with actual permission group ID values. " +
+			"Use the cloudflare_api_token_permission_groups_list data source to look up IDs by name.",
+	})
+
+	var permObjects []hclwrite.Tokens
+	for _, elem := range elements {
+		permObjects = append(permObjects, buildPermGroupIDObject(elem))
 	}
 
 	body.RemoveAttribute("permission_groups")
-	listTokens := hclwrite.TokensForTuple(permObjects)
-	body.SetAttributeRaw("permission_groups", listTokens)
+	body.SetAttributeRaw("permission_groups", hclwrite.TokensForTuple(permObjects))
+}
+
+// permGroupRef holds the parsed components of a cloudflare_api_token_permission_groups
+// data source reference expression.
+type permGroupRef struct {
+	label    string // e.g. "all"
+	permName string // e.g. "DNS Read"
+}
+
+// parsePermGroupDataSourceRef attempts to parse an expression token stream as a
+// reference to data.cloudflare_api_token_permission_groups.<label>.<category>["<name>"].
+// Returns nil if the tokens don't match this pattern.
+func parsePermGroupDataSourceRef(tokens hclwrite.Tokens) *permGroupRef {
+	// Collect the identifiers and the quoted string from the expression.
+	// Expected token pattern (ignoring whitespace):
+	//   data . cloudflare_api_token_permission_groups . <label> . <category> [ " <name> " ]
+	//
+	// We need: ident("data"), dot, ident("cloudflare_api_token_permission_groups"),
+	//          dot, ident(<label>), dot, ident(<category>), [, ", <name>, ", ]
+	var idents []string
+	var quotedLit string
+	foundBracket := false
+
+	for _, tok := range tokens {
+		switch tok.Type {
+		case hclsyntax.TokenIdent:
+			if !foundBracket {
+				idents = append(idents, string(tok.Bytes))
+			}
+		case hclsyntax.TokenDot:
+			// skip dots
+		case hclsyntax.TokenOBrack:
+			foundBracket = true
+		case hclsyntax.TokenQuotedLit:
+			if foundBracket {
+				quotedLit = string(tok.Bytes)
+			}
+		case hclsyntax.TokenNewline:
+			// skip
+		case hclsyntax.TokenOQuote, hclsyntax.TokenCQuote, hclsyntax.TokenCBrack:
+			// skip quote/bracket delimiters
+		}
+	}
+
+	// Validate the pattern: data, cloudflare_api_token_permission_groups, <label>, <category>
+	if len(idents) != 4 || idents[0] != "data" || idents[1] != "cloudflare_api_token_permission_groups" {
+		return nil
+	}
+	if quotedLit == "" {
+		return nil
+	}
+
+	return &permGroupRef{
+		label:    idents[2],
+		permName: quotedLit,
+	}
+}
+
+// splitPermGroupExprElements splits an HCL list expression token stream into
+// individual element token groups.  Depth is tracked across '[', '{', and '('
+// so that nested structures (index access, objects, function calls) are not
+// mistakenly treated as element boundaries.  Returns nil when no outer '[' is found.
+func splitPermGroupExprElements(exprTokens hclwrite.Tokens) []hclwrite.Tokens {
+	outerStart := -1
+	for i, tok := range exprTokens {
+		if tok.Type == hclsyntax.TokenOBrack {
+			outerStart = i
+			break
+		}
+	}
+	if outerStart == -1 {
+		return nil
+	}
+
+	var elements []hclwrite.Tokens
+	depth := 0
+	elemStart := outerStart + 1
+
+	for i := outerStart; i < len(exprTokens); i++ {
+		tok := exprTokens[i]
+		switch tok.Type {
+		case hclsyntax.TokenOBrack, hclsyntax.TokenOBrace, hclsyntax.TokenOParen:
+			depth++
+		case hclsyntax.TokenCBrack:
+			depth--
+			if depth == 0 {
+				// End of the outer list.
+				elem := trimPermGroupElement(exprTokens[elemStart:i])
+				if len(elem) > 0 {
+					elements = append(elements, elem)
+				}
+				return elements
+			}
+		case hclsyntax.TokenCBrace, hclsyntax.TokenCParen:
+			depth--
+		case hclsyntax.TokenComma:
+			if depth == 1 {
+				elem := trimPermGroupElement(exprTokens[elemStart:i])
+				if len(elem) > 0 {
+					elements = append(elements, elem)
+				}
+				elemStart = i + 1
+			}
+		}
+	}
+	return elements
+}
+
+// trimPermGroupElement strips leading and trailing newline tokens from a token slice.
+func trimPermGroupElement(tokens hclwrite.Tokens) hclwrite.Tokens {
+	start := 0
+	for start < len(tokens) && tokens[start].Type == hclsyntax.TokenNewline {
+		start++
+	}
+	end := len(tokens)
+	for end > start && tokens[end-1].Type == hclsyntax.TokenNewline {
+		end--
+	}
+	return tokens[start:end]
+}
+
+// buildPermGroupIDObject wraps expression tokens as { id = <tokens> }.
+func buildPermGroupIDObject(valueTokens hclwrite.Tokens) hclwrite.Tokens {
+	tokens := hclwrite.Tokens{
+		{Type: hclsyntax.TokenOBrace, Bytes: []byte("{")},
+		{Type: hclsyntax.TokenNewline, Bytes: []byte("\n")},
+		{Type: hclsyntax.TokenIdent, Bytes: []byte("  id")},
+		{Type: hclsyntax.TokenEqual, Bytes: []byte(" = ")},
+	}
+	tokens = append(tokens, valueTokens...)
+	tokens = append(tokens,
+		&hclwrite.Token{Type: hclsyntax.TokenNewline, Bytes: []byte("\n")},
+		&hclwrite.Token{Type: hclsyntax.TokenCBrace, Bytes: []byte("}")},
+	)
+	return tokens
 }
 
 // transformResources wraps the resources map with jsonencode()

--- a/internal/resources/api_token/v4_to_v5_test.go
+++ b/internal/resources/api_token/v4_to_v5_test.go
@@ -489,9 +489,12 @@ resource "cloudflare_api_token" "full_example" {
   }
 }`,
 			},
-			{
-				Name: "api token with data reference and timestamps",
-				Input: `
+		{
+			// Data source reference in permission_groups: the expression is parsed
+			// and converted to a for-expression that looks up the ID by name from
+			// the v5 replacement data source.
+			Name: "api token with data source reference in permission_groups",
+			Input: `
 resource "cloudflare_api_token" "api_token_create" {
   name = "api_token_create"
 
@@ -514,7 +517,7 @@ resource "cloudflare_api_token" "api_token_create" {
     }
   }
 }`,
-				Expected: `
+			Expected: `
 resource "cloudflare_api_token" "api_token_create" {
   name = "api_token_create"
 
@@ -523,13 +526,11 @@ resource "cloudflare_api_token" "api_token_create" {
   expires_on = "2020-01-01T00:00:00Z"
 
   policies = [{
+    permission_groups = [{ id = [for pg in data.cloudflare_api_token_permission_groups_list.all.result : pg.id if pg.name == "API Tokens Write"][0] }]
     resources = jsonencode({
       "com.cloudflare.api.user.${var.user_id}" = "*"
     })
     effect = "allow"
-    permission_groups = [{
-      id = "API Tokens Write"
-    }]
   }]
   condition = {
     request_ip = {
@@ -538,7 +539,48 @@ resource "cloudflare_api_token" "api_token_create" {
     }
   }
 }`,
-			},
+		},
+		{
+			// Exact scenario from APIX-973: multiple .permissions["Name"] data-source
+			// references in permission_groups are converted to for-expressions that
+			// look up the ID by name from the v5 replacement data source.
+			Name: "api token with multiple data source permission group references (APIX-973)",
+			Input: `
+data "cloudflare_api_token_permission_groups" "all" {}
+
+resource "cloudflare_api_token" "example_api_token" {
+  name = "example_api_token"
+
+  policy {
+    permission_groups = [
+      data.cloudflare_api_token_permission_groups.all.permissions["Zone Read"],
+      data.cloudflare_api_token_permission_groups.all.permissions["DNS Read"],
+      data.cloudflare_api_token_permission_groups.all.permissions["DNS Write"],
+    ]
+    resources = {
+      "com.cloudflare.api.account.*" = "*"
+    }
+  }
+}`,
+			// The data source block is NOT renamed here because the api_token
+			// migrator only handles cloudflare_api_token resources; the data source
+			// block is renamed by the api_token_permission_groups datasource migrator
+			// (tested separately).
+			Expected: `
+data "cloudflare_api_token_permission_groups" "all" {}
+
+resource "cloudflare_api_token" "example_api_token" {
+  name = "example_api_token"
+
+  policies = [{
+    permission_groups = [{ id = [for pg in data.cloudflare_api_token_permission_groups_list.all.result : pg.id if pg.name == "Zone Read"][0] }, { id = [for pg in data.cloudflare_api_token_permission_groups_list.all.result : pg.id if pg.name == "DNS Read"][0] }, { id = [for pg in data.cloudflare_api_token_permission_groups_list.all.result : pg.id if pg.name == "DNS Write"][0] }]
+    resources = jsonencode({
+      "com.cloudflare.api.account.*" = "*"
+    })
+    effect = "allow"
+  }]
+}`,
+		},
 		}
 
 		testhelpers.RunConfigTransformTests(t, tests, migrator)


### PR DESCRIPTION
## Problem

The `cloudflare_api_token` migrator incorrectly handled `permission_groups` that referenced the `cloudflare_api_token_permission_groups` data source. Expressions like:

```hcl
data.cloudflare_api_token_permission_groups.all.permissions["DNS Read"]
```

had the map key string (`"DNS Read"`) extracted as the permission group ID, producing invalid output:

```hcl
permission_groups = [{ id = "DNS Read" }]  # wrong — should be UUID
```

Additionally, the data source block was silently removed via a `Preprocess` regex with no warning.

## Fix

### 1. Bracket-depth tracking in `transformPermissionGroups`
Replaced the boolean `inList` flag with an integer `bracketDepth` counter. `TokenQuotedLit` tokens are only collected at depth 1 (direct list elements), not at depth 2+ (index access keys like `["DNS Read"]`).

### 2. Data source reference → for-expression conversion
When expression elements are detected, each is parsed to check if it matches `data.cloudflare_api_token_permission_groups.<label>.<category>["<name>"]`. If so, it's converted to a for-expression against the v5 replacement data source:

```hcl
permission_groups = [{
  id = [for pg in data.cloudflare_api_token_permission_groups_list.all.result : pg.id if pg.name == "DNS Read"][0]
}]
```

### 3. Datasource migrator (new)
Added `internal/datasources/api_token_permission_groups/v4_to_v5.go` that renames the data source block from `cloudflare_api_token_permission_groups` to `cloudflare_api_token_permission_groups_list` instead of silently removing it.

### 4. Fallback for unrecognized expressions
Expressions that don't match the data source pattern are wrapped as `{ id = <expr> }` with a diagnostic warning.

## Testing

- All 12 unit tests pass (including 2 new test cases for the bug scenario)
- Integration tests pass
- Full suite: 94 packages, 0 failures
- E2E verified against real Cloudflare infrastructure:
  - v4 config with data source refs → `tf-migrate` → v5 config with for-expressions
  - `terraform apply` with v5 provider succeeds
  - `terraform plan` shows no drift

## Files changed

| File | Change |
|---|---|
| `internal/resources/api_token/v4_to_v5.go` | Core fix + for-expression generation |
| `internal/datasources/api_token_permission_groups/v4_to_v5.go` | New datasource migrator |
| `internal/registry/registry.go` | Register new migrator |
| `internal/resources/api_token/v4_to_v5_test.go` | Fix + add test cases |
| `integration/.../api_token/expected/api_token.tf` | Updated expected output |

Closes #298