### PR TITLE
feat(d1_database): add migration support for cloudflare_d1_database

### DIFF
--- a/integration/v4_to_v5/testdata/d1_database/expected/d1_database.tf
+++ b/integration/v4_to_v5/testdata/d1_database/expected/d1_database.tf
@@ -1,0 +1,90 @@
+# Integration test for cloudflare_d1_database migration (v4 -> v5)
+# The resource name and all user-configurable attributes are identical
+# between v4 and v5, so the output should match the input exactly.
+
+# Standard variables provided by test infrastructure
+variable "cloudflare_account_id" {
+  description = "Cloudflare account ID"
+  type        = string
+}
+
+variable "cloudflare_zone_id" {
+  description = "Cloudflare zone ID"
+  type        = string
+}
+
+variable "cloudflare_domain" {
+  description = "Cloudflare domain for testing"
+  type        = string
+}
+
+# Locals for DRY configuration
+locals {
+  common_account = var.cloudflare_account_id
+  name_prefix    = "cftftest"
+  environment    = "test"
+}
+
+# ============================================================================
+# Basic Resources with Variables and Locals
+# ============================================================================
+
+# Minimal D1 database with required fields only
+resource "cloudflare_d1_database" "minimal" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-minimal-db"
+}
+
+# D1 database using locals
+resource "cloudflare_d1_database" "with_locals" {
+  account_id = local.common_account
+  name       = "${local.name_prefix}-locals-db"
+}
+
+# D1 database with string interpolation
+resource "cloudflare_d1_database" "with_interpolation" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-${local.environment}-db"
+}
+
+# ============================================================================
+# Lifecycle Meta-arguments
+# ============================================================================
+
+resource "cloudflare_d1_database" "with_lifecycle" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-lifecycle-db"
+
+  lifecycle {
+    create_before_destroy = true
+    prevent_destroy       = false
+  }
+}
+
+resource "cloudflare_d1_database" "ignore_changes" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-ignore-changes-db"
+
+  lifecycle {
+    ignore_changes = [name]
+  }
+}
+
+# ============================================================================
+# Terraform Functions
+# ============================================================================
+
+resource "cloudflare_d1_database" "with_join" {
+  account_id = var.cloudflare_account_id
+  name       = join("-", [local.name_prefix, "joined", "db"])
+}
+
+resource "cloudflare_d1_database" "with_lower" {
+  account_id = var.cloudflare_account_id
+  name       = lower("${local.name_prefix}-LOWERCASE-DB")
+}
+
+resource "cloudflare_d1_database" "with_format" {
+  account_id = var.cloudflare_account_id
+  name       = format("%s-formatted-db-%02d", local.name_prefix, 42)
+}

--- a/integration/v4_to_v5/testdata/d1_database/input/d1_database.tf
+++ b/integration/v4_to_v5/testdata/d1_database/input/d1_database.tf
@@ -1,0 +1,90 @@
+# Integration test for cloudflare_d1_database migration (v4 -> v5)
+# The resource name and all user-configurable attributes are identical
+# between v4 and v5, so the output should match the input exactly.
+
+# Standard variables provided by test infrastructure
+variable "cloudflare_account_id" {
+  description = "Cloudflare account ID"
+  type        = string
+}
+
+variable "cloudflare_zone_id" {
+  description = "Cloudflare zone ID"
+  type        = string
+}
+
+variable "cloudflare_domain" {
+  description = "Cloudflare domain for testing"
+  type        = string
+}
+
+# Locals for DRY configuration
+locals {
+  common_account = var.cloudflare_account_id
+  name_prefix    = "cftftest"
+  environment    = "test"
+}
+
+# ============================================================================
+# Basic Resources with Variables and Locals
+# ============================================================================
+
+# Minimal D1 database with required fields only
+resource "cloudflare_d1_database" "minimal" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-minimal-db"
+}
+
+# D1 database using locals
+resource "cloudflare_d1_database" "with_locals" {
+  account_id = local.common_account
+  name       = "${local.name_prefix}-locals-db"
+}
+
+# D1 database with string interpolation
+resource "cloudflare_d1_database" "with_interpolation" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-${local.environment}-db"
+}
+
+# ============================================================================
+# Lifecycle Meta-arguments
+# ============================================================================
+
+resource "cloudflare_d1_database" "with_lifecycle" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-lifecycle-db"
+
+  lifecycle {
+    create_before_destroy = true
+    prevent_destroy       = false
+  }
+}
+
+resource "cloudflare_d1_database" "ignore_changes" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.name_prefix}-ignore-changes-db"
+
+  lifecycle {
+    ignore_changes = [name]
+  }
+}
+
+# ============================================================================
+# Terraform Functions
+# ============================================================================
+
+resource "cloudflare_d1_database" "with_join" {
+  account_id = var.cloudflare_account_id
+  name       = join("-", [local.name_prefix, "joined", "db"])
+}
+
+resource "cloudflare_d1_database" "with_lower" {
+  account_id = var.cloudflare_account_id
+  name       = lower("${local.name_prefix}-LOWERCASE-DB")
+}
+
+resource "cloudflare_d1_database" "with_format" {
+  account_id = var.cloudflare_account_id
+  name       = format("%s-formatted-db-%02d", local.name_prefix, 42)
+}

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cloudflare/tf-migrate/internal/resources/custom_hostname_fallback_origin"
 	"github.com/cloudflare/tf-migrate/internal/resources/custom_pages"
 	"github.com/cloudflare/tf-migrate/internal/resources/custom_ssl"
+	"github.com/cloudflare/tf-migrate/internal/resources/d1_database"
 	"github.com/cloudflare/tf-migrate/internal/resources/dns_record"
 	"github.com/cloudflare/tf-migrate/internal/resources/healthcheck"
 	"github.com/cloudflare/tf-migrate/internal/resources/leaked_credential_check"
@@ -116,6 +117,7 @@ func RegisterAllMigrations() {
 	byo_ip_prefix.NewV4ToV5Migrator()
 	certificate_pack.NewV4ToV5Migrator()
 	custom_ssl.NewV4ToV5Migrator()
+	d1_database.NewV4ToV5Migrator()
 	custom_hostname.NewV4ToV5Migrator()
 	custom_hostname_fallback_origin.NewV4ToV5Migrator()
 	custom_pages.NewV4ToV5Migrator()

--- a/internal/resources/d1_database/v4_to_v5.go
+++ b/internal/resources/d1_database/v4_to_v5.go
@@ -1,0 +1,47 @@
+package d1_database
+
+import (
+	"github.com/cloudflare/tf-migrate/internal"
+	"github.com/cloudflare/tf-migrate/internal/transform"
+	"github.com/hashicorp/hcl/v2/hclwrite"
+)
+
+// V4ToV5Migrator handles migration of D1 Database resources from v4 to v5.
+// The resource name and all user-configurable attributes are identical between
+// v4 and v5. V5 adds new optional attributes (jurisdiction, primary_location_hint,
+// read_replication) and new computed attributes (uuid, created_at, file_size,
+// num_tables), but no existing attributes were renamed, removed, or restructured.
+type V4ToV5Migrator struct{}
+
+func NewV4ToV5Migrator() transform.ResourceTransformer {
+	migrator := &V4ToV5Migrator{}
+	internal.RegisterMigrator("cloudflare_d1_database", "v4", "v5", migrator)
+	return migrator
+}
+
+func (m *V4ToV5Migrator) GetResourceType() string {
+	return "cloudflare_d1_database"
+}
+
+func (m *V4ToV5Migrator) CanHandle(resourceType string) bool {
+	return resourceType == "cloudflare_d1_database"
+}
+
+func (m *V4ToV5Migrator) Preprocess(content string) string {
+	return content
+}
+
+// GetResourceRename implements the ResourceRenamer interface.
+// The resource name is unchanged between v4 and v5.
+func (m *V4ToV5Migrator) GetResourceRename() ([]string, string) {
+	return []string{"cloudflare_d1_database"}, "cloudflare_d1_database"
+}
+
+// TransformConfig transforms the HCL configuration from v4 to v5.
+// No transformations are needed -- the config is identical between v4 and v5.
+func (m *V4ToV5Migrator) TransformConfig(ctx *transform.Context, block *hclwrite.Block) (*transform.TransformResult, error) {
+	return &transform.TransformResult{
+		Blocks:         []*hclwrite.Block{block},
+		RemoveOriginal: false,
+	}, nil
+}

--- a/internal/resources/d1_database/v4_to_v5_test.go
+++ b/internal/resources/d1_database/v4_to_v5_test.go
@@ -1,0 +1,109 @@
+package d1_database
+
+import (
+	"testing"
+
+	"github.com/cloudflare/tf-migrate/internal/testhelpers"
+)
+
+func TestV4ToV5Migration(t *testing.T) {
+	migrator := NewV4ToV5Migrator()
+
+	t.Run("ConfigTransformation", func(t *testing.T) {
+		tests := []testhelpers.ConfigTestCase{
+			{
+				Name: "basic d1 database with required fields",
+				Input: `
+resource "cloudflare_d1_database" "test" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+  name       = "my-database"
+}`,
+				Expected: `
+resource "cloudflare_d1_database" "test" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+  name       = "my-database"
+}`,
+			},
+			{
+				Name: "d1 database with variable references",
+				Input: `
+variable "account_id" {
+  type = string
+}
+
+resource "cloudflare_d1_database" "test" {
+  account_id = var.account_id
+  name       = "my-database"
+}`,
+				Expected: `
+variable "account_id" {
+  type = string
+}
+
+resource "cloudflare_d1_database" "test" {
+  account_id = var.account_id
+  name       = "my-database"
+}`,
+			},
+			{
+				Name: "multiple d1 databases",
+				Input: `
+resource "cloudflare_d1_database" "db1" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+  name       = "database-one"
+}
+
+resource "cloudflare_d1_database" "db2" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+  name       = "database-two"
+}`,
+				Expected: `
+resource "cloudflare_d1_database" "db1" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+  name       = "database-one"
+}
+
+resource "cloudflare_d1_database" "db2" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+  name       = "database-two"
+}`,
+			},
+			{
+				Name: "d1 database with string interpolation",
+				Input: `
+resource "cloudflare_d1_database" "test" {
+  account_id = var.account_id
+  name       = "${var.environment}-database"
+}`,
+				Expected: `
+resource "cloudflare_d1_database" "test" {
+  account_id = var.account_id
+  name       = "${var.environment}-database"
+}`,
+			},
+			{
+				Name: "d1 database with lifecycle",
+				Input: `
+resource "cloudflare_d1_database" "test" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+  name       = "lifecycle-database"
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}`,
+				Expected: `
+resource "cloudflare_d1_database" "test" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+  name       = "lifecycle-database"
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}`,
+			},
+		}
+
+		testhelpers.RunConfigTransformTests(t, tests, migrator)
+	})
+}


### PR DESCRIPTION
## Description

Add v4-to-v5 migration support for cloudflare_d1_database. The resource name and all user-configurable attributes are identical between v4 and v5, so the migrator is a passthrough (no HCL transformations needed).

V5 adds new optional attributes (jurisdiction, primary_location_hint, read_replication) and new computed attributes (uuid, created_at, file_size, num_tables), but none require migration handling.

- Add passthrough migrator in internal/resources/d1_database/
- Register migrator in internal/registry/registry.go
- Add unit tests (5 cases) and integration test fixtures

Ref: APIX-1155

## Motivation

This is part of scheduled stabilization and resource support for the d1_database.

## Type of change

- [x] New resource transformer
- [ ] Fix to an existing transformer
- [ ] CLI / framework change
- [ ] Documentation
- [ ] Test / CI
- [ ] Refactoring (no behaviour change)

## Testing

- [x] Unit tests (`make test-unit`)
- [x] Integration tests (`make test-integration`)
- [x] E2E tests (if applicable)
- [x] `make lint-testdata` passes

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] New resource transformers are registered in `internal/registry/registry.go`
- [x] Testdata resource names use the `cftftest` prefix
- [x] Any `# MIGRATION WARNING` comments are documented in `DIAGNOSTICS.md`

## E2E Testing
```
========================================
✓ E2E Test Complete!
========================================

Summary:

  Step 1: v4 terraform apply
    Status: ✓ SUCCESS

  Step 2: Migration (v4 → v5)
    Status: ✓ SUCCESS

  Step 3: v5 plan (before apply)
    Status: ✓ No changes needed

  Step 4: v5 terraform apply
    Status: ✓ SUCCESS

  Step 5: v5 plan (after apply)
    Status: ✓ SUCCESS - Stable state achieved
    Result: No changes detected
```