### PR TITLE
ci(e2e): bump TARGET_PROVIDER_VERSION to 5.22.0

### DIFF
--- a/.github/workflows/e2e-tests-next.yml
+++ b/.github/workflows/e2e-tests-next.yml
@@ -26,7 +26,7 @@ on:
       target_provider_version:
         description: "Version string written into v5 required_providers"
         required: false
-        default: "5.21.1"
+        default: "5.22.0"
 
 env:
   CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -25,7 +25,7 @@ env:
   #   2. `--target-provider-version` on the runner (writes this into the
   #      generated v5 config's required_providers block)
   # Keep them in sync.
-  TARGET_PROVIDER_VERSION: "5.21.1"
+  TARGET_PROVIDER_VERSION: "5.22.0"
 
   CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
   CLOUDFLARE_ZONE_ID: ${{ secrets.CLOUDFLARE_ZONE_ID }}


### PR DESCRIPTION
## Summary

Bump the pinned provider version from 5.21.1 to 5.22.0 in both E2E workflow files.

## Problem

The E2E CI run on main ([#29279540132](https://github.com/cloudflare/tf-migrate/actions/runs/29279540132)) is failing because v5.21.1 is missing two upstream state upgrader fixes:

- **`cloudflare_load_balancer_pool`**: `flatten_cname` Value Conversion Error during v5 plan
- **`cloudflare_ruleset`**: `unsupported attribute asset_name` — the v4.52.8 release added `asset_name` to rulesets, but v5.21.1's state upgrader doesn't know about it

Both were fixed in [v5.22.0](https://github.com/cloudflare/terraform-provider-cloudflare/releases/tag/v5.22.0) (released 2026-07-10):
- `load_balancer_pool`: remove phantom `flatten_cname` from v4 source model (`baa1b92`)
- `ruleset`: add `asset_name` to v4 source schema (`baa1b92`)

## Changes

- `.github/workflows/e2e-tests.yml`: `TARGET_PROVIDER_VERSION` 5.21.1 → 5.22.0
- `.github/workflows/e2e-tests-next.yml`: default `target_provider_version` 5.21.1 → 5.22.0