### PR TITLE
fix(d1_database): add read_replication default to prevent v5 apply failure

### DIFF
--- a/integration/v4_to_v5/testdata/d1_database/expected/d1_database.tf
+++ b/integration/v4_to_v5/testdata/d1_database/expected/d1_database.tf
@@ -33,18 +33,27 @@ locals {
 resource "cloudflare_d1_database" "minimal" {
   account_id = var.cloudflare_account_id
   name       = "${local.name_prefix}-minimal-db"
+  read_replication = {
+    mode = "disabled"
+  }
 }
 
 # D1 database using locals
 resource "cloudflare_d1_database" "with_locals" {
   account_id = local.common_account
   name       = "${local.name_prefix}-locals-db"
+  read_replication = {
+    mode = "disabled"
+  }
 }
 
 # D1 database with string interpolation
 resource "cloudflare_d1_database" "with_interpolation" {
   account_id = var.cloudflare_account_id
   name       = "${local.name_prefix}-${local.environment}-db"
+  read_replication = {
+    mode = "disabled"
+  }
 }
 
 # ============================================================================
@@ -59,6 +68,9 @@ resource "cloudflare_d1_database" "with_lifecycle" {
     create_before_destroy = true
     prevent_destroy       = false
   }
+  read_replication = {
+    mode = "disabled"
+  }
 }
 
 resource "cloudflare_d1_database" "ignore_changes" {
@@ -67,6 +79,9 @@ resource "cloudflare_d1_database" "ignore_changes" {
 
   lifecycle {
     ignore_changes = [name]
+  }
+  read_replication = {
+    mode = "disabled"
   }
 }
 
@@ -77,14 +92,23 @@ resource "cloudflare_d1_database" "ignore_changes" {
 resource "cloudflare_d1_database" "with_join" {
   account_id = var.cloudflare_account_id
   name       = join("-", [local.name_prefix, "joined", "db"])
+  read_replication = {
+    mode = "disabled"
+  }
 }
 
 resource "cloudflare_d1_database" "with_lower" {
   account_id = var.cloudflare_account_id
   name       = lower("${local.name_prefix}-LOWERCASE-DB")
+  read_replication = {
+    mode = "disabled"
+  }
 }
 
 resource "cloudflare_d1_database" "with_format" {
   account_id = var.cloudflare_account_id
   name       = format("%s-formatted-db-%02d", local.name_prefix, 42)
+  read_replication = {
+    mode = "disabled"
+  }
 }

--- a/internal/resources/d1_database/v4_to_v5.go
+++ b/internal/resources/d1_database/v4_to_v5.go
@@ -3,7 +3,9 @@ package d1_database
 import (
 	"github.com/cloudflare/tf-migrate/internal"
 	"github.com/cloudflare/tf-migrate/internal/transform"
+	tfhcl "github.com/cloudflare/tf-migrate/internal/transform/hcl"
 	"github.com/hashicorp/hcl/v2/hclwrite"
+	"github.com/zclconf/go-cty/cty"
 )
 
 // V4ToV5Migrator handles migration of D1 Database resources from v4 to v5.
@@ -38,8 +40,24 @@ func (m *V4ToV5Migrator) GetResourceRename() ([]string, string) {
 }
 
 // TransformConfig transforms the HCL configuration from v4 to v5.
-// No transformations are needed -- the config is identical between v4 and v5.
+// The only required change is adding `read_replication = { mode = "disabled" }`
+// to match the API default. The D1 API returns read_replication={mode:"disabled"}
+// on read but rejects null on update. Without this, the v5 provider's state
+// upgrader initializes read_replication as null, which causes a 400 Bad Request
+// on the next apply.
 func (m *V4ToV5Migrator) TransformConfig(ctx *transform.Context, block *hclwrite.Block) (*transform.TransformResult, error) {
+	body := block.Body()
+
+	// Set read_replication default if not already present.
+	if !tfhcl.HasAttribute(body, "read_replication") {
+		body.SetAttributeRaw("read_replication", hclwrite.TokensForObject([]hclwrite.ObjectAttrTokens{
+			{
+				Name:  hclwrite.TokensForIdentifier("mode"),
+				Value: hclwrite.TokensForValue(cty.StringVal("disabled")),
+			},
+		}))
+	}
+
 	return &transform.TransformResult{
 		Blocks:         []*hclwrite.Block{block},
 		RemoveOriginal: false,

--- a/internal/resources/d1_database/v4_to_v5_test.go
+++ b/internal/resources/d1_database/v4_to_v5_test.go
@@ -20,8 +20,9 @@ resource "cloudflare_d1_database" "test" {
 }`,
 				Expected: `
 resource "cloudflare_d1_database" "test" {
-  account_id = "f037e56e89293a057740de681ac9abbe"
-  name       = "my-database"
+  account_id       = "f037e56e89293a057740de681ac9abbe"
+  name             = "my-database"
+  read_replication = { mode = "disabled" }
 }`,
 			},
 			{
@@ -41,8 +42,9 @@ variable "account_id" {
 }
 
 resource "cloudflare_d1_database" "test" {
-  account_id = var.account_id
-  name       = "my-database"
+  account_id       = var.account_id
+  name             = "my-database"
+  read_replication = { mode = "disabled" }
 }`,
 			},
 			{
@@ -59,13 +61,15 @@ resource "cloudflare_d1_database" "db2" {
 }`,
 				Expected: `
 resource "cloudflare_d1_database" "db1" {
-  account_id = "f037e56e89293a057740de681ac9abbe"
-  name       = "database-one"
+  account_id       = "f037e56e89293a057740de681ac9abbe"
+  name             = "database-one"
+  read_replication = { mode = "disabled" }
 }
 
 resource "cloudflare_d1_database" "db2" {
-  account_id = "f037e56e89293a057740de681ac9abbe"
-  name       = "database-two"
+  account_id       = "f037e56e89293a057740de681ac9abbe"
+  name             = "database-two"
+  read_replication = { mode = "disabled" }
 }`,
 			},
 			{
@@ -77,8 +81,9 @@ resource "cloudflare_d1_database" "test" {
 }`,
 				Expected: `
 resource "cloudflare_d1_database" "test" {
-  account_id = var.account_id
-  name       = "${var.environment}-database"
+  account_id       = var.account_id
+  name             = "${var.environment}-database"
+  read_replication = { mode = "disabled" }
 }`,
 			},
 			{
@@ -94,12 +99,28 @@ resource "cloudflare_d1_database" "test" {
 }`,
 				Expected: `
 resource "cloudflare_d1_database" "test" {
-  account_id = "f037e56e89293a057740de681ac9abbe"
-  name       = "lifecycle-database"
+  account_id       = "f037e56e89293a057740de681ac9abbe"
+  name             = "lifecycle-database"
+  read_replication = { mode = "disabled" }
 
   lifecycle {
     prevent_destroy = true
   }
+}`,
+			},
+			{
+				Name: "d1 database with read_replication already set",
+				Input: `
+resource "cloudflare_d1_database" "test" {
+  account_id       = "f037e56e89293a057740de681ac9abbe"
+  name             = "my-database"
+  read_replication = { mode = "auto" }
+}`,
+				Expected: `
+resource "cloudflare_d1_database" "test" {
+  account_id       = "f037e56e89293a057740de681ac9abbe"
+  name             = "my-database"
+  read_replication = { mode = "auto" }
 }`,
 			},
 		}


### PR DESCRIPTION
## Summary

Add `read_replication = { mode = "disabled" }` to every `cloudflare_d1_database` resource block during v4→v5 migration.

## Problem

The E2E CI run ([#278](https://github.com/cloudflare/tf-migrate/actions/runs/29342744917/job/87118491274)) is failing because all `cloudflare_d1_database` resources get a `400 Bad Request` from the D1 API:

```
"Invalid property: read_replication => Expected object, received null"
```

**Root cause chain:**

1. v4 state has no `read_replication` field (it did not exist in v4)
2. tf-migrate runs — the d1_database migrator was a no-op, so no `read_replication` is added to the config
3. The v5.22.0 provider's new state upgrader (`UpgradeFromLegacyV0`) initializes `read_replication` as `nil` in state
4. Terraform sends `read_replication: null` in the PUT request
5. The D1 API rejects null — it expects `{"mode": "disabled"}`, not null

## Fix

`TransformConfig` now sets `read_replication = { mode = "disabled" }` on every d1_database block that does not already have it. This matches the API default and prevents the null-rejection error.

A corresponding provider-side fix (initializing `read_replication` to `{mode:"disabled"}` in the state upgrader) will be submitted separately to `terraform-provider-cloudflare`.

## Changes

- `internal/resources/d1_database/v4_to_v5.go` — set `read_replication` default in `TransformConfig`
- `internal/resources/d1_database/v4_to_v5_test.go` — updated 5 expected outputs + added idempotency test
- `integration/v4_to_v5/testdata/d1_database/expected/d1_database.tf` — all 8 resource blocks updated

## Testing

```
go test -v ./internal/resources/d1_database/...   # 6/6 pass
TEST_RESOURCE=d1_database go test -v -run TestSingleResource ./integration/...  # pass
```